### PR TITLE
Grails create scripts generate Spock Specs by default.

### DIFF
--- a/spock-grails/scripts/_Events.groovy
+++ b/spock-grails/scripts/_Events.groovy
@@ -42,3 +42,25 @@ eventAllTestsStart = {
 eventPackagePluginsEnd = {
   loadSpockTestTypes()
 }
+
+eventDefaultStart = {
+    createUnitTest = { Map args = [:] ->
+        def superClass
+        // map unit test superclass to Spock equivalent
+        switch(args["superClass"]) {
+            case "ControllerUnitTestCase":
+                superClass = "ControllerSpec"
+                break
+            case "TagLibUnitTestCase":
+                superClass = "TagLibSpec"
+                break
+            default:
+                superClass = "UnitSpec"
+        }
+        createArtifact name: args["name"], suffix: "${args['suffix']}Spec", type: "Spec", path: "test/unit", superClass: superClass
+    }
+
+    createIntegrationTest = { Map args = [:] ->
+        createArtifact name: args["name"], suffix: "${args['suffix']}Spec", type: "Spec", path: "test/integration", superClass: "IntegrationSpec"
+    }
+}

--- a/spock-grails/src/templates/artifacts/Spec.groovy
+++ b/spock-grails/src/templates/artifacts/Spec.groovy
@@ -1,0 +1,9 @@
+@artifact.package@import spock.lang.*
+import grails.plugin.spock.*
+
+class @artifact.name@ extends @artifact.superclass@ {
+
+    def "feature method"() {
+
+    }
+}


### PR DESCRIPTION
This is a simple patch to let the Spock Grails plugin generate Specs as opposed to TestCases.

I pushed this to the groovy-1.7 branch.

Cheers,
Marco.
