### PR TITLE
Fixes code style configuration

### DIFF
--- a/ideaCodeStyle.xml
+++ b/ideaCodeStyle.xml
@@ -1,28 +1,29 @@
-<component name="CodeStyleSettingsManager">
-  <option name="PER_PROJECT_SETTINGS">
+<?xml version="1.0" encoding="UTF-8"?>
+<code_scheme name="style.xml">
+  <option name="OTHER_INDENT_OPTIONS">
     <value>
-      <option name="USE_SAME_INDENTS" value="true"/>
-      <option name="RIGHT_MARGIN" value="200"/>
-      <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
-      <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
-      <option name="JD_P_AT_EMPTY_LINES" value="false"/>
-      <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
-      <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
-      <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
-      <option name="WRAP_COMMENTS" value="true"/>
-      <option name="IF_BRACE_FORCE" value="3"/>
-      <option name="DOWHILE_BRACE_FORCE" value="3"/>
-      <option name="WHILE_BRACE_FORCE" value="3"/>
-      <option name="FOR_BRACE_FORCE" value="3"/>
-      <option name="INDENT_SIZE" value="2"/>
-      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-      <option name="TAB_SIZE" value="2"/>
-      <option name="USE_TAB_CHARACTER" value="false"/>
-      <option name="SMART_TABS" value="false"/>
-      <option name="LABEL_INDENT_SIZE" value="0"/>
-      <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
-      <option name="USE_RELATIVE_INDENTS" value="false"/>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
     </value>
   </option>
-  <option name="USE_PER_PROJECT_SETTINGS" value="true"/>
-</component>
+  <XML>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
+  <codeStyleSettings language="Groovy">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>
+


### PR DESCRIPTION
All source code is indented by 2 characters, but the formatter says 4 characters. Using the new configuration results in more consistent code.
