### PR TITLE
Adding functionality to show the attachments as part of the html report for @See annotation at Spec level 

### DIFF
--- a/spock-report/src/main/resources/org/spockframework/report/report.html
+++ b/spock-report/src/main/resources/org/spockframework/report/report.html
@@ -186,6 +186,24 @@
             </ul>
             {{/if}}
           </div>
+		  {{#if attachments}}
+			<div>
+				<ul>
+					<li class="result element attachments">
+					  <h5 class="elementHeader">
+						<a class="elementName">Attachments</a>
+					  </h5>
+					  <ul class="elementBody">
+						{{#attachments}}
+						<li>
+						  <a href="{{url}}">{{name}}</a>
+						</li>
+						{{/attachments}}
+					  </ul>
+					</li>
+				</ul>
+			<div>
+			{{/if}}
         </li>
         {{/specs}}
       </ul>


### PR DESCRIPTION
Attachments tag was not shown in the spock report when @See annotation is used at spec level.
Fixing the same by modifying the report.html file to accommodate the same view as in the case of a feature.