### PR TITLE
SpockConfig can include/exclude by regex pattern string.

### DIFF
--- a/docs/new_and_noteworthy.rst
+++ b/docs/new_and_noteworthy.rst
@@ -1,6 +1,25 @@
 New and Noteworthy
 ==================
 
+1.0
+~~~
+
+Patterns in SpockConfig
+-----------------------
+
+``SpockConfig.groovy`` now supports regex patterns of simple names of annotations,
+spec classes, or features.  This is useful in Grails, where the project classes
+are not available to the config loader.  Here is an example using both classes and patterns:
+
+    import some.pkg.Fast
+    import some.pkg.IntegrationSpec
+
+    runner {
+      include Fast, 'Good', 'Browser.*Spec'
+      exclude some.pkg.Slow, IntegrationSpec
+    }
+
+
 0.7
 ~~~
 

--- a/spock-core/src/main/java/spock/config/IncludeExcludeCriteria.java
+++ b/spock-core/src/main/java/spock/config/IncludeExcludeCriteria.java
@@ -17,29 +17,42 @@ package spock.config;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Configuration indicating which specs and methods should be
  * included/excluded from a spec run. Specs can be included/excluded
  * based on their annotations and their (base) classes. Methods
- * can be included/excluded based on their annotations.
+ * can be included/excluded based on their annotations and names.
+ * Criteria can be annotations, spec classes, base classes,
+ * and regex pattern strings.  Patterns are matched against the
+ * simple names of annotations, spec (but not base) classes,
+ * and methods.
  *
  * @author Peter Niederwieser
  */
 public class IncludeExcludeCriteria {
   @SuppressWarnings("unchecked")
-  public IncludeExcludeCriteria(Class<?>... criteria) {
-    for (Class<?> criterium : criteria)
-      if (criterium.isAnnotation())
-        annotations.add((Class<? extends Annotation>)criterium);
-      else
-        baseClasses.add(criterium);
+  public IncludeExcludeCriteria(Object... criteria) {
+    for (Object criterium : criteria)
+      if (criterium instanceof Class) {
+        Class<?> classCriterium = (Class<?>) criterium;
+        if (classCriterium.isAnnotation())
+          annotations.add((Class<? extends Annotation>)classCriterium);
+        else
+          baseClasses.add(classCriterium);
+      } else if (criterium instanceof String) {
+        patterns.add(Pattern.compile((String) criterium));
+      } else {
+        throw new ConfigurationException("unsupported criterium, must be pattern string or class: %s", criterium.toString());
+      }
   }
   
   public List<Class<? extends Annotation>> annotations = new ArrayList<Class<? extends Annotation>>();
   public List<Class<?>> baseClasses = new ArrayList<Class<?>>();
+  public List<Pattern> patterns = new ArrayList<Pattern>();
 
   public boolean isEmpty() {
-    return annotations.isEmpty() && baseClasses.isEmpty();
+    return annotations.isEmpty() && baseClasses.isEmpty() && patterns.isEmpty();
   }
 }

--- a/spock-core/src/main/java/spock/config/RunnerConfiguration.java
+++ b/spock-core/src/main/java/spock/config/RunnerConfiguration.java
@@ -23,11 +23,8 @@ package spock.config;
  * import some.pkg.IntegrationSpec
  *
  * runner {
- *   include Fast // could be either an annotation or a (base) class
- *   exclude {
- *     annotation some.pkg.Slow
- *     baseClass IntegrationSpec
- *   }
+ *   include Fast, 'Good' // annotations, (base) classes, or regex patterns
+ *   exclude some.pkg.Slow, IntegrationSpec
  *   filterStackTrace true // this is the default
  * }
  * </pre>

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IncludeExcludeSpecs.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IncludeExcludeSpecs.groovy
@@ -45,10 +45,10 @@ class Spec3 extends Specification {
   """)
   }
 
-  def "include specs based on annotations"() {
+  def "include specs based on annotations or patterns"() {
     runner.configurationScript = {
       runner {
-        include(*annotationTypes)
+        include(*criteria)
       }
     }
 
@@ -61,14 +61,24 @@ class Spec3 extends Specification {
     result.ignoreCount == 3 - runCount // cannot prevent JUnit from running excluded specs, so they get ignored
 
     where:
-    annotationTypes << [[Slow], [Fast], [Slow, Fast]]
-    runCount        << [1,      1,      2           ]
+    criteria            || runCount
+    [Slow]              || 1
+    [Fast]              || 1
+    [Slow, Fast]        || 2
+
+    ['Slow']            || 1
+    ['Fast']            || 1
+    ['Slow', 'Fast']    || 2
+
+    ['Spec1']           || 1
+    ['Spec[12]']        || 2
+    ['Spec.']           || 3
   }
 
-  def "exclude specs based on annotations"() {
+  def "exclude specs based on annotations or patterns"() {
     runner.configurationScript = {
       runner {
-        exclude(*annotationTypes)
+        exclude(*criteria)
       }
     }
 
@@ -81,8 +91,18 @@ class Spec3 extends Specification {
     result.ignoreCount == 3 - runCount // cannot prevent JUnit from running excluded specs, so they get ignored
 
     where:
-    annotationTypes << [[Slow], [Fast], [Slow, Fast]]
-    runCount        << [2,      2,      1           ]
+    criteria            || runCount
+    [Slow]              || 2
+    [Fast]              || 2
+    [Slow, Fast]        || 1
+
+    ['Slow']            || 2
+    ['Fast']            || 2
+    ['Slow', 'Fast']    || 1
+
+    ['Spec1']           || 2
+    ['Spec[12]']        || 1
+    ['Spec.']           || 0
   }
 
   def "include and exclude specs based on annotations"() {
@@ -105,5 +125,34 @@ class Spec3 extends Specification {
     annTypes1   << [[Slow], [Slow], [Slow],       [Fast], [Fast], [Fast],       [Slow, Fast], [Slow, Fast], [Slow, Fast]]
     annTypes2   << [[Slow], [Fast], [Slow, Fast], [Slow], [Fast], [Slow, Fast], [Slow],       [Fast],       [Slow, Fast]]
     runCount    << [0,      1,      0,            1,      0,      0,            1,            1,            0           ]
+  }
+
+  def "include and exclude specs based on patterns"() {
+    runner.configurationScript = {
+      runner {
+        include(*includes)
+        exclude(*excludes)
+      }
+    }
+
+    when:
+    def result = runner.runClasses(specs)
+
+    then:
+    result.runCount == runCount
+    result.failureCount == 0
+    result.ignoreCount == 3 - runCount // cannot prevent JUnit from running excluded specs, so they get ignored
+
+    where:
+    includes            | excludes          || runCount
+    ['Slow']            | ['Slow']          || 0
+    ['Slow']            | ['Fast']          || 1
+    ['Slow']            | ['Slow', 'Fast']  || 0
+    ['Fast']            | ['Slow']          || 1
+    ['Fast']            | ['Fast']          || 0
+    ['Fast']            | ['Slow', 'Fast']  || 0
+    ['Slow', 'Fast']    | ['Slow']          || 1
+    ['Slow', 'Fast']    | ['Fast']          || 1
+    ['Slow', 'Fast']    | ['Slow', 'Fast']  || 0
   }
 }


### PR DESCRIPTION
Please consider adding this to Spock.  You [mentioned](https://groups.google.com/d/msg/spockframework/DQFTj9dXD2Y/HPJqTISBiocJ) that it would be good to do.

The regex pattern is matched against the simple name
of the annotation, spec, or feature.  This addresses
http://code.google.com/p/spock/issues/detail?id=184

Also added to new_and_noteworthy, and updated javadoc in 
IncludeExcludeExtension and RunnerConfiguration.  Removed an apparently 
obsolete part of the example from the latter, because it didn't work 
when I tried it, and there are no specs for it.

I would have liked to use GrailsTestTargetPattern with its AntPathMatcher,
but that seemed out of scope for Spock.
