### PR TITLE
Fix for issue 338

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/constraint/WildcardMethodNameConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/WildcardMethodNameConstraint.java
@@ -23,8 +23,12 @@ public class WildcardMethodNameConstraint implements IInvocationConstraint {
   public static final WildcardMethodNameConstraint INSTANCE = new WildcardMethodNameConstraint();
 
   private WildcardMethodNameConstraint() {}
-  
+
+  private boolean isFinalizeCall(IMockInvocation invocation) {
+    return invocation.getMethod().getName().equals("finalize") && invocation.getArguments().size() == 0;
+  }
+
   public boolean isSatisfiedBy(IMockInvocation invocation) {
-    return DefaultEqualsHashCodeToStringInteractions.INSTANCE.match(invocation) == null;
+    return DefaultEqualsHashCodeToStringInteractions.INSTANCE.match(invocation) == null && !isFinalizeCall(invocation);
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/WildcardUsages.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/WildcardUsages.groovy
@@ -100,30 +100,32 @@ class WildcardUsages extends Specification {
     3 * _
   }
 
-  def "wildcard method name doesn't match Object's equals(), hashCode(), and toString() methods"() {
-    def list = Mock(List)
+  def "wildcard method name doesn't match Object's equals(), hashCode(), toString() and finalize() methods"() {
+    def mocked = Mock(Object)
 
     when:
-    list.equals(new Object())
-    list.hashCode()
-    list.toString()
+    mocked.equals(new Object())
+    mocked.hashCode()
+    mocked.toString()
+    mocked.finalize()
 
     then:
-    0 * list._()
-    0 * list._
+    0 * mocked._()
+    0 * mocked._
     0 * _
   }
 
-  def "wildcard method name matches overloaded equals(), hashCode(), and toString() methods"() {
+  def "wildcard method name matches overloaded equals(), hashCode(), toString() and finalize() methods"() {
     def overloaded = Mock(Overloaded)
 
     when:
     overloaded.equals("me")
     overloaded.hashCode([])
     overloaded.toString(true)
+    overloaded.finalize(true)
 
     then:
-    3 * overloaded._
+    4 * overloaded._
   }
 
   def "usage in interaction doesn't interfere with usage in where-block"() {
@@ -148,4 +150,5 @@ interface Overloaded {
   boolean equals(String str)
   int hashCode(List list)
   String toString(boolean verbose)
+  void finalize(boolean bool)
 }


### PR DESCRIPTION
Calls to finalize() don't match to method name wildcard anymore.

One thing to note is that in the test I changed the mocked entity from interface (List) to a class (Object) as I couldn't reproduce the issue for interface mocks - I think that cglib's handling of finalize() adds to the mix.
