### PR TITLE
Adding tag support

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagsExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagsExtension.java
@@ -1,10 +1,10 @@
-package common.extension.spock.runtime;
+package org.spockframework.runtime.extension.builtin; 
 
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.ISkippable;
 import org.spockframework.runtime.model.SpecInfo;
-import common.extension.spock.lang.Tags;
+import spock.lang.Tags;
 
 /**
  * User: gcurrey

--- a/spock-core/src/main/java/spock/lang/Tags.java
+++ b/spock-core/src/main/java/spock/lang/Tags.java
@@ -1,6 +1,6 @@
-package common.extension.spock.lang;
+package spock.lang;
 
-import common.extension.spock.runtime.TagsExtension;
+import org.spockframework.runtime.extension.builtin.TagsExtension;
 import org.spockframework.runtime.extension.ExtensionAnnotation;
 
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
A new extension to bring the concept of cucumber tags into spock.  This extension allows you to do the following:

``` java
MyTest extends Specification{
    @Tags(["PROD"])
    def "some test"(){

    }

   def "another test"(){

   }
}
```

or

``` java
@Tags(["JIRA-1234"])
MyTest extends Specification{
    def "some test"(){

    }

   def "another test"(){

   }
}
```

You can then pass a vm arg when running junit to run just a subset of tests, if you so desire:

```
-Dtags=PROD
```

or

```
-Dtags=UAT,JIRA-1234
```

If you do not supply the vm arg, all tests will run.  If you supply the VM arg, only specifications or features that match the tags supplied in the VM arg will execute.
