### PR TITLE
[ISSUE-274] Closure used as data value in where-block can't be called with method syntax

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/runtime/condition/ClosureAsDataValueCallSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/condition/ClosureAsDataValueCallSpec.groovy
@@ -1,0 +1,24 @@
+package org.spockframework.runtime.condition
+import org.spockframework.EmbeddedSpecification
+import spock.lang.Issue
+
+class ClosureAsDataValueCallSpec extends EmbeddedSpecification {
+
+  @Issue("http://issues.spockframework.org/detail?id=274")
+  def "multi line expression failss"() {
+    when:
+    runner.runSpecBody("""
+    def "multi line expression failing"() {
+      expect:
+      1 == wibble()
+
+      where:
+      wibble = { 1 }
+    }
+    """)
+
+    then:
+    notThrown(Exception)
+  }
+}
+


### PR DESCRIPTION
Apply fix to AST in DeepBlockRewriter to detect whether a method in the expect would be expected to be using one of the implied params from where: and create that link.
