### PR TITLE
InjectMocks - Property, Setter, Constructor injection

### DIFF
--- a/spock-core/src/main/groovy/spock/util/injectmock/Collaborator.groovy
+++ b/spock-core/src/main/groovy/spock/util/injectmock/Collaborator.groovy
@@ -1,0 +1,12 @@
+package spock.util.injectmock
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@interface Collaborator {
+
+}

--- a/spock-core/src/main/groovy/spock/util/injectmock/InjectMockUtils.groovy
+++ b/spock-core/src/main/groovy/spock/util/injectmock/InjectMockUtils.groovy
@@ -1,0 +1,24 @@
+package spock.util.injectmock
+
+import org.spockframework.runtime.extension.IMethodInvocation
+import spock.lang.Specification
+
+import java.lang.reflect.Field
+
+@groovy.transform.PackageScope
+class InjectMockUtils {
+
+    public static Specification getSpec( IMethodInvocation invocation ) {
+        ( Specification ) invocation.target.with {
+            delegate instanceof Specification ? delegate : invocation.instance
+        }
+    }
+
+    public static Collection<Field> findAllDeclaredFieldsWithAnnotation(Object object, Class... annotatedClasses) {
+        return object.class.declaredFields.findAll { Field field ->
+            annotatedClasses.any { Class annotatedClass ->
+                return annotatedClass in field.declaredAnnotations*.annotationType()
+            }
+        }
+    }
+}

--- a/spock-core/src/main/groovy/spock/util/injectmock/InjectMocksExtension.groovy
+++ b/spock-core/src/main/groovy/spock/util/injectmock/InjectMocksExtension.groovy
@@ -1,0 +1,15 @@
+package spock.util.injectmock
+
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.model.FieldInfo
+
+class InjectMocksExtension extends AbstractAnnotationDrivenExtension<Subject> {
+
+    @Override
+    @SuppressWarnings(['UnnecessaryGetter', 'GroovyGetterCallCanBePropertyAccess'])
+    void visitFieldAnnotation(Subject annotation, FieldInfo field) {
+        InjectMocksInterceptor interceptor = new InjectMocksInterceptor(field)
+        field.parent.topSpec.addSetupInterceptor(interceptor)
+    }
+
+}

--- a/spock-core/src/main/groovy/spock/util/injectmock/InjectMocksInterceptor.groovy
+++ b/spock-core/src/main/groovy/spock/util/injectmock/InjectMocksInterceptor.groovy
@@ -1,0 +1,203 @@
+package spock.util.injectmock
+
+import org.codehaus.groovy.reflection.ClassInfo
+import org.spockframework.runtime.extension.AbstractMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FieldInfo
+import spock.lang.Specification
+
+import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Type
+
+import static spock.util.injectmock.InjectMockUtils.getSpec
+
+class InjectMocksInterceptor extends AbstractMethodInterceptor {
+
+    private static Comparator<Constructor> CONSTRUCTOR_COMPARATOR = [compare: {
+        Constructor a, Constructor b ->
+            return a.parameterTypes.size().compareTo(b.parameterTypes.size())
+    }] as Comparator<Constructor>
+
+    private static final List<String> SETTERS_TO_IGNORE = ["setMetaClass"]
+
+    // TODO: There has to be a better way to get ridd of those kind of dynamic methods
+    private static final List<String> TYPE_REGEXP_IN_PROP_INJECTION_TO_IGNORE = ["\$class\$", "\$callSiteArray","_\$stMC", "metaClass", "this\$0"]
+
+    private final FieldInfo fieldInfo
+
+    InjectMocksInterceptor(FieldInfo fieldInfo) {
+        this.fieldInfo = fieldInfo
+    }
+
+    @Override
+    void interceptSetupMethod(IMethodInvocation invocation) {
+        Specification specInstance = getSpec(invocation)
+        Collection<Field> injectionCandidates = getInjectionCandidates(specInstance)
+        // either by constructor injection, setter injection, or property injection
+        tryToInjectCandidatesIntoSubject(injectionCandidates, specInstance)
+        invocation.proceed()
+    }
+
+    private void tryToInjectCandidatesIntoSubject(Collection<Field> injectionCandidates, Specification specInstance) {
+        boolean injectionSuccess = tryToInjectViaConstructor(injectionCandidates, specInstance)
+        if (!injectionSuccess) {
+            injectionSuccess = tryToInjectViaSetters(injectionCandidates, specInstance)
+        }
+        if (!injectionSuccess) {
+            tryToInjectViaProperties(injectionCandidates, specInstance)
+        }
+    }
+
+    private boolean tryToInjectViaConstructor(Collection<Field> injectionCandidates, Specification specInstance) {
+        try {
+            Constructor constructorWithMaxParams = findConstructorWithMaxParams()
+            if (!atLeastOneInjectionCandidateClassExistsAsConstructorParameter(constructorWithMaxParams, injectionCandidates)) {
+                return false
+            }
+            Object[] parameters = collectAllParametersFromCandidatesSetNullIfMissing(constructorWithMaxParams, injectionCandidates, specInstance)
+            Object instantiatedSubject = constructorWithMaxParams.newInstance(parameters)
+            fieldInfo.writeValue(specInstance, instantiatedSubject)
+            return true
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Constructor findConstructorWithMaxParams() {
+        Constructor constructor = fieldInfo.type.constructors.max(CONSTRUCTOR_COMPARATOR)
+        constructor.accessible = true
+        return constructor
+    }
+
+    private Object[] collectAllParametersFromCandidatesSetNullIfMissing(Constructor constructorWithMaxParams, Collection<Field> injectionCandidates, Specification specInstance) {
+        Collection parameters = []
+        constructorWithMaxParams.genericParameterTypes.each {
+            Field field = getMatchingInjectionCandidateIfOneExists(injectionCandidates, it)
+            parameters << (field == null ? field : specInstance[field.name])
+        }
+        return parameters.toArray()
+    }
+
+    private boolean atLeastOneInjectionCandidateClassExistsAsConstructorParameter(Constructor constructorWithMaxParams, Collection<Field> injectionCandidates) {
+        constructorWithMaxParams.genericParameterTypes.any {
+            return getMatchingInjectionCandidateIfOneExists(injectionCandidates, it)
+        }
+    }
+
+    private Field getMatchingInjectionCandidateIfOneExists(Collection<Field> injectionCandidates, Type parameterType) {
+        return injectionCandidates.find {
+            return it.genericType == parameterType
+        }
+    }
+
+    private boolean tryToInjectViaSetters(Collection<Field> injectionCandidates, Specification specInstance) {
+        // Property setter injection; mocks will first be resolved by type, then, if there is several property of the same type
+        try {
+            Object subject = instantiateSubjectAndSetOnSpecification(specInstance)
+            List<Method> setters = getAllSettersFromSubject()
+            Map matchingSetters = getMatchingSettersBasingOnTypeAndPropertyName(injectionCandidates, setters)
+            if (matchingSetters.isEmpty()) {
+                return false
+            }
+            matchingSetters.each { Method method, Field injectionCandidate ->
+                method.invoke(subject, specInstance[injectionCandidate.name])
+            }
+            return true
+        } catch (Exception e) {
+            return false
+        }
+    }
+
+    private Map getMatchingSettersBasingOnTypeAndPropertyName(Collection<Field> injectionCandidates, List<Method> setters) {
+        Map matchingSetters = [:]
+        injectionCandidates.each { Field injectionCandidate ->
+            setters.each {
+                if (it.genericParameterTypes.size() == 1 && it.genericParameterTypes[0] == injectionCandidate.type) {
+                    // if there is several property of the same type by the match of the property name and the mock name.
+                    if (matchingSetters[it] && it.name.substring(3).equalsIgnoreCase(injectionCandidate.name)) {
+                        matchingSetters[it] = injectionCandidate
+                    } else if (!matchingSetters[it]) {
+                        matchingSetters[it] = injectionCandidate
+                    }
+                }
+            }
+        }
+        return matchingSetters
+    }
+
+    private List<Method> getAllSettersFromSubject() {
+        return fieldInfo.type.methods.findAll {
+            return it.name.startsWith("set") && !SETTERS_TO_IGNORE.contains(it.name)
+        }
+    }
+
+    private Object instantiateSubjectAndSetOnSpecification(Specification specInstance) {
+        final Object subject
+        Constructor constructorWithMinArgs = fieldInfo.type.constructors.min(CONSTRUCTOR_COMPARATOR)
+        if (constructorWithMinArgs.parameterTypes.size() == 0) {
+            subject = fieldInfo.type.newInstance()
+        } else {
+            // must be inner class or some nonmatching constructor
+            subject = fieldInfo.type.newInstance(null)
+        }
+        specInstance[fieldInfo.name] = subject
+        return subject
+    }
+
+    private boolean tryToInjectViaProperties(Collection<Field> injectionCandidates, Specification specInstance) {
+        // Field injection; mocks will first be resolved by type, then, if there is several property of the same type, by the match of the field name and the mock name.
+        // Note 1: If you have fields with the same type (or same erasure), it's better to name all @Mock annotated fields with the matching fields, otherwise Mockito might get confused and injection won't happen.
+        Object subject = instantiateSubjectAndSetOnSpecification(specInstance)
+        List<Field> fields = getAllFieldsFromSubject()
+        Map matchingFields = getMatchingFieldsBasingOnTypeAndPropertyName(injectionCandidates, fields)
+        matchingFields.each { Field field, Field injectionCandidate ->
+            subject[injectionCandidate.name] = specInstance[injectionCandidate.name]
+        }
+   }
+
+    private List<Field> getAllFieldsFromSubject() {
+        List<Field> fields = []
+        fieldInfo.type.declaredFields.each { Field field ->
+            if( TYPE_REGEXP_IN_PROP_INJECTION_TO_IGNORE.every { return !field.name.contains(it) }
+                && field.type != ClassInfo) {
+                fields << field
+            }
+        }
+        return fields
+    }
+
+    private Map getMatchingFieldsBasingOnTypeAndPropertyName(Collection<Field> injectionCandidates, List<Field> allFields) {
+        Map matchingFields = [:]
+        injectionCandidates.each { Field injectionCandidate ->
+            allFields.each {
+                if (it.type == injectionCandidate.type) {
+                    // if there is several property of the same type by the match of the property name and the mock name.
+                    if (matchingFields[it] && it.name.equalsIgnoreCase(injectionCandidate.name)) {
+                        matchingFields[it] = injectionCandidate
+                    } else if (!matchingFields[it]) {
+                        matchingFields[it] = injectionCandidate
+                    }
+                }
+            }
+        }
+        return matchingFields
+    }
+
+    private Collection<Field> getInjectionCandidates(Specification specInstance) {
+        Collection<Field> collaborators = InjectMockUtils.findAllDeclaredFieldsWithAnnotation(specInstance, Collaborator)
+        // check if there are any collaborators
+        if (collaborators.empty) {
+            // if there are none pick all non subject annotated fields for injection into the collaborator
+            return specInstance.class.declaredFields.findAll {
+                return !it.declaredAnnotations.contains(Subject)
+            }
+        } else {
+            // if there are collaborators pick only them
+            return collaborators
+        }
+    }
+
+}

--- a/spock-core/src/main/groovy/spock/util/injectmock/Subject.groovy
+++ b/spock-core/src/main/groovy/spock/util/injectmock/Subject.groovy
@@ -1,0 +1,12 @@
+package spock.util.injectmock
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@ExtensionAnnotation(InjectMocksExtension)
+@interface Subject {}

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorNoCollaboratorsSeveralSubjectsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorNoCollaboratorsSeveralSubjectsSpec.groovy
@@ -1,0 +1,56 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksConstructorNoCollaboratorsSeveralSubjectsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeClass someClass = Mock()
+
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+	@Subject
+	SomeClass objectUnderTest2
+
+    def "should inject first acceptable object into each subject"() {
+        given:
+        someOtherClassToBeInjected.someMethod() >> TEST_METHOD_1
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+        String secondResult = objectUnderTest2.someOtherClass.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClassToBeInjected
+
+        and:
+        secondResult == TEST_METHOD_1
+        objectUnderTest2.someOtherClass == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+
+        SomeClass(SomeOtherClass someOtherClass) {
+            this.someOtherClass = someOtherClass
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorNoCollaboratorsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorNoCollaboratorsSpec.groovy
@@ -1,0 +1,48 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksConstructorNoCollaboratorsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeClass someClass = Mock()
+
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject first acceptable object into subject"() {
+        given:
+        someOtherClassToBeInjected.someMethod() >> TEST_METHOD_1
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+
+        SomeClass(SomeOtherClass someOtherClass) {
+            this.someOtherClass = someOtherClass
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorNoCollaboratorsWithGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorNoCollaboratorsWithGenericsSpec.groovy
@@ -1,0 +1,40 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksConstructorNoCollaboratorsWithGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    List<SomeClass> listThatShouldNotBeInjected = []
+
+    List<SomeOtherClass> someOtherClassList = [new SomeOtherClass()]
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject list of some other classes into subject"() {
+        expect:
+            objectUnderTest.someOtherClassList == someOtherClassList
+    }
+
+
+    class SomeClass {
+        List<SomeOtherClass> someOtherClassList
+
+        SomeClass(List<SomeOtherClass> someOtherClassList) {
+            this.someOtherClassList = someOtherClassList
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorSeveralSubjectsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorSeveralSubjectsSpec.groovy
@@ -1,0 +1,54 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksConstructorSeveralSubjectsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    @Subject
+	SomeClass objectUnderTest2
+
+    def "should inject collaborator into each subject"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+        String secondResult = objectUnderTest2.someOtherClass.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        secondResult == TEST_METHOD_1
+        objectUnderTest2.someOtherClass == someOtherClass
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+
+        SomeClass(SomeOtherClass someOtherClass) {
+            this.someOtherClass = someOtherClass
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorSpec.groovy
@@ -1,0 +1,46 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksConstructorSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator into subject"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+
+        SomeClass(SomeOtherClass someOtherClass) {
+            this.someOtherClass = someOtherClass
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorWithGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorWithGenericsSpec.groovy
@@ -1,0 +1,42 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksConstructorWithGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    List<Integer> listNotToBeInjected = []
+
+    @Collaborator
+    List<SomeOtherClass> someOtherClassList = [new SomeOtherClass()]
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator list into subject"() {
+        expect:
+            objectUnderTest.someOtherClassList == someOtherClassList
+    }
+
+
+    class SomeClass {
+        List<SomeOtherClass> someOtherClassList
+
+        SomeClass(List<SomeOtherClass> someOtherClassList) {
+            this.someOtherClassList = someOtherClassList
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorWithSeveralGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksConstructorWithSeveralGenericsSpec.groovy
@@ -1,0 +1,42 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksConstructorWithSeveralGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    Map<String, Integer> mapNotToBeInjected = [:]
+
+    @Collaborator
+    Map<Integer, String> someOtherClassMap = [:]
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator list into subject"() {
+        expect:
+            objectUnderTest.someOtherClassMap == someOtherClassMap
+    }
+
+
+    class SomeClass {
+        Map<Integer, String> someOtherClassMap
+
+        SomeClass(Map<Integer, String> someOtherClassMap) {
+            this.someOtherClassMap = someOtherClassMap
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesNoCollaboratorsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesNoCollaboratorsSpec.groovy
@@ -1,0 +1,50 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksPropertiesNoCollaboratorsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject fields into subject via properties with no collaborators"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+        someOtherClassToBeInjected.someMethod() >> TEST_METHOD_2
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+        String secondResult = objectUnderTest.someOtherClassToBeInjected.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        secondResult == TEST_METHOD_2
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        private SomeOtherClass someOtherClass
+        private SomeOtherClass someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesNoCollaboratorsWithGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesNoCollaboratorsWithGenericsSpec.groovy
@@ -1,0 +1,42 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksPropertiesNoCollaboratorsWithGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    List<SomeOtherClass> listNotToBeInjected = []
+
+    List<SomeOtherClass> someOtherClassToBeInjected = []
+
+    List<SomeOtherClass> someOtherClass = []
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject fields into subject via properties with no collaborators"() {
+        expect:
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        private List<SomeOtherClass> someOtherClass
+        private List<SomeOtherClass> someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesNoMatchingSetterAndConstructorSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesNoMatchingSetterAndConstructorSpec.groovy
@@ -1,0 +1,64 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksPropertiesNoMatchingSetterAndConstructorSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    @Collaborator
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    @Collaborator
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator into subject via properties"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+        someOtherClassToBeInjected.someMethod() >> TEST_METHOD_2
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+        String secondResult = objectUnderTest.someOtherClassToBeInjected.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        secondResult == TEST_METHOD_2
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        private SomeOtherClass someOtherClass
+        private SomeOtherClass someOtherClassToBeInjected
+
+        SomeClass() {
+
+        }
+
+        SomeClass(Integer integer) {
+
+        }
+
+        public void setBigDecimal(BigDecimal bigDecimal) {
+
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesNoMatchingSetterAndConstructorWithoutCollaboratorsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesNoMatchingSetterAndConstructorWithoutCollaboratorsSpec.groovy
@@ -1,0 +1,62 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksPropertiesNoMatchingSetterAndConstructorWithoutCollaboratorsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator into subject via properties without collaborators"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+        someOtherClassToBeInjected.someMethod() >> TEST_METHOD_2
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+        String secondResult = objectUnderTest.someOtherClassToBeInjected.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        secondResult == TEST_METHOD_2
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        private SomeOtherClass someOtherClass
+        private SomeOtherClass someOtherClassToBeInjected
+
+        SomeClass() {
+
+        }
+
+        SomeClass(Integer integer) {
+
+        }
+
+        public void setBigDecimal(BigDecimal bigDecimal) {
+
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesSpec.groovy
@@ -1,0 +1,52 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksPropertiesSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    @Collaborator
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    @Collaborator
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator into subject via properties"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+        someOtherClassToBeInjected.someMethod() >> TEST_METHOD_2
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+        String secondResult = objectUnderTest.someOtherClassToBeInjected.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        secondResult == TEST_METHOD_2
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        private SomeOtherClass someOtherClass
+        private SomeOtherClass someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesWithGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesWithGenericsSpec.groovy
@@ -1,0 +1,47 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksPropertiesWithGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    List<SomeOtherClass> someOtherClassNonCollaboratorNotToBeInjected
+
+    @Collaborator
+    List<Integer> listNotToBeInjected = Mock()
+
+    @Collaborator
+    List<SomeOtherClass> someOtherClassToBeInjected = Mock()
+
+    @Collaborator
+    List<SomeOtherClass> someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator into subject via properties"() {
+        expect:
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        private List<SomeOtherClass> someOtherClass
+        private List<SomeOtherClass> someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesWithSeveralGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksPropertiesWithSeveralGenericsSpec.groovy
@@ -1,0 +1,38 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksPropertiesWithSeveralGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    Map<String, Integer> mapNotToBeInjected = [:]
+
+    @Collaborator
+    Map<Integer, String> someOtherClassMap = [:]
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator list into subject"() {
+        expect:
+            objectUnderTest.someOtherClassMap == someOtherClassMap
+    }
+
+
+    class SomeClass {
+        private Map<Integer, String> someOtherClassMap
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersNoCollaboratorsWithGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersNoCollaboratorsWithGenericsSpec.groovy
@@ -1,0 +1,44 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSettersNoCollaboratorsWithGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    List<Integer> listNotToBeInjected = Mock()
+
+    List<SomeOtherClass> someOtherClassNotToBeInjected = Mock()
+
+    List<SomeOtherClass> someOtherClassToBeInjected = Mock()
+
+    List<SomeOtherClass> someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject parameters into subject via setters"() {
+        expect:
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        List<SomeOtherClass> someOtherClass
+        List<SomeOtherClass> someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersSpec.groovy
@@ -1,0 +1,52 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSettersSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    @Collaborator
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    @Collaborator
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator into subject via setters"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+        someOtherClassToBeInjected.someMethod() >> TEST_METHOD_2
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+        String secondResult = objectUnderTest.someOtherClassToBeInjected.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        secondResult == TEST_METHOD_2
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+        SomeOtherClass someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithCollaboratorsAndNonMatchingConstructorSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithCollaboratorsAndNonMatchingConstructorSpec.groovy
@@ -1,0 +1,51 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSettersWithCollaboratorsAndNonMatchingConstructorSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    @Collaborator
+    SomeOtherClass someOtherClass = Mock()
+
+    @Subject
+    SomeClass objectUnderTest
+
+    def "should inject collaborator into subject via setters ignoring nonmatching constructor"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+        SomeOtherClass someOtherClassToBeInjected
+
+        SomeClass() {
+
+        }
+
+        SomeClass(Integer integer) {
+
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithGenericsNoCollaboratorsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithGenericsNoCollaboratorsSpec.groovy
@@ -1,0 +1,44 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSettersWithGenericsNoCollaboratorsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    List<Integer> listNotToBeInjected = Mock()
+
+    List<SomeOtherClass> someOtherClassNotToBeInjected = Mock()
+
+    List<SomeOtherClass> someOtherClassToBeInjected = Mock()
+
+    List<SomeOtherClass> someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject properties into subject via setters"() {
+        expect:
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        List<SomeOtherClass> someOtherClass
+        List<SomeOtherClass> someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithGenericsSpec.groovy
@@ -1,0 +1,48 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSettersWithGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    @Collaborator
+    List<Integer> listNotToBeInjected = Mock()
+
+    @Collaborator
+    List<SomeOtherClass> someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    List<SomeOtherClass> someOtherClassToBeInjected = Mock()
+
+    @Collaborator
+    List<SomeOtherClass> someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator into subject via setters"() {
+        expect:
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        List<SomeOtherClass> someOtherClass
+        List<SomeOtherClass> someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithNoCollaboratorsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithNoCollaboratorsSpec.groovy
@@ -1,0 +1,50 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSettersWithNoCollaboratorsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    public static final String TEST_METHOD_2 = "Test method 2"
+
+    SomeOtherClass someOtherClassToBeInjected = Mock()
+
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject objects into subject via setters"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+        someOtherClassToBeInjected.someMethod() >> TEST_METHOD_2
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+        String secondResult = objectUnderTest.someOtherClassToBeInjected.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+
+        and:
+        secondResult == TEST_METHOD_2
+        objectUnderTest.someOtherClassToBeInjected == someOtherClassToBeInjected
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+        SomeOtherClass someOtherClassToBeInjected
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithSeveralGenericsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSettersWithSeveralGenericsSpec.groovy
@@ -1,0 +1,38 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSettersWithSeveralGenericsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    Map<String, Integer> mapNotToBeInjected = [:]
+
+    @Collaborator
+    Map<Integer, String> someOtherClassMap = [:]
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator list into subject"() {
+        expect:
+            objectUnderTest.someOtherClassMap == someOtherClassMap
+    }
+
+
+    class SomeClass {
+        Map<Integer, String> someOtherClassMap
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSeveralConstructorsNoCollaboratorsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSeveralConstructorsNoCollaboratorsSpec.groovy
@@ -1,0 +1,64 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSeveralConstructorsNoCollaboratorsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    String string = "string"
+
+    Integer integer = 10
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject all fields into subject"() {
+        given:
+        someOtherClassNotToBeInjected.someMethod() >> TEST_METHOD_1
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClassNotToBeInjected
+        objectUnderTest.string == TEST_METHOD_1
+        objectUnderTest.integer == integer
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+        String string
+        Integer integer
+
+        SomeClass(SomeOtherClass someOtherClass) {
+            this.someOtherClass = someOtherClass
+        }
+
+        SomeClass(SomeOtherClass someOtherClass, String string) {
+            this.string = string
+            this.someOtherClass = someOtherClass
+        }
+
+        SomeClass(SomeOtherClass someOtherClass, String string, Integer integer) {
+            this.integer = integer
+            this.string = string
+            this.someOtherClass = someOtherClass
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSeveralConstructorsOneCollaboratorSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSeveralConstructorsOneCollaboratorSpec.groovy
@@ -1,0 +1,68 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSeveralConstructorsOneCollaboratorSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    String string = "string"
+
+    Integer integer = 10
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborator into subject"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+        objectUnderTest.string == null
+        objectUnderTest.integer == null
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+        String string
+        Integer integer
+
+        SomeClass(SomeOtherClass someOtherClass) {
+            this.integer = integer
+            this.string = string
+            this.someOtherClass = someOtherClass
+        }
+
+        SomeClass(SomeOtherClass someOtherClass, String string) {
+            this.integer = integer
+            this.string = string
+            this.someOtherClass = someOtherClass
+        }
+
+        SomeClass(SomeOtherClass someOtherClass, String string, Integer integer) {
+            this.integer = integer
+            this.string = string
+            this.someOtherClass = someOtherClass
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+

--- a/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSeveralConstructorsSeveralCollaboratorsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/injectmock/InjectMocksSeveralConstructorsSeveralCollaboratorsSpec.groovy
@@ -1,0 +1,70 @@
+package spock.util.injectmock
+
+import spock.lang.Specification
+
+class InjectMocksSeveralConstructorsSeveralCollaboratorsSpec extends Specification {
+
+    public static final String TEST_METHOD_1 = "Test method 1"
+
+    @Collaborator
+    String string = "string"
+
+    @Collaborator
+    Integer integer = 10
+
+    SomeOtherClass someOtherClassNotToBeInjected = Mock()
+
+    @Collaborator
+    SomeOtherClass someOtherClass = Mock()
+
+	@Subject
+	SomeClass objectUnderTest
+
+    def "should inject collaborators into subject"() {
+        given:
+        someOtherClass.someMethod() >> TEST_METHOD_1
+
+        when:
+        String firstResult = objectUnderTest.someOtherClass.someMethod()
+
+        then:
+        firstResult == TEST_METHOD_1
+        objectUnderTest.someOtherClass == someOtherClass
+        objectUnderTest.string == string
+        objectUnderTest.integer == integer
+    }
+
+
+    class SomeClass {
+        SomeOtherClass someOtherClass
+        String string
+        Integer integer
+
+        SomeClass(SomeOtherClass someOtherClass) {
+            this.integer = integer
+            this.string = string
+            this.someOtherClass = someOtherClass
+        }
+
+        SomeClass(SomeOtherClass someOtherClass, String string) {
+            this.integer = integer
+            this.string = string
+            this.someOtherClass = someOtherClass
+        }
+
+        SomeClass(SomeOtherClass someOtherClass, String string, Integer integer) {
+            this.integer = integer
+            this.string = string
+            this.someOtherClass = someOtherClass
+        }
+    }
+
+    class SomeOtherClass {
+        String someMethod() {
+            "Some other class"
+        }
+    }
+
+}
+
+


### PR DESCRIPTION
1) We stick to creating mocks in the standard Spock way 
2) The objects (not only mocks) that should be injected will be annotated with @Collaborator
3) The object that should have the dependencies injected into will be called @Subject
4) The injection takes place as in Mockito (http://docs.mockito.googlecode.com/hg/latest/org/mockito/InjectMocks.html)

> Mockito will try to inject mocks only either by constructor injection, setter injection, or property injection in order and as described below. If any of the following strategy fail, then Mockito won't report failure; i.e. you will have to provide dependencies yourself.
> 
> Constructor injection; the biggest constructor is chosen, then arguments are resolved with mocks declared in the test only.
> Note: If arguments can not be found, then null is passed. If non-mockable types are wanted, then constructor injection won't happen. In these cases, you will have to satisfy dependencies yourself.
> 
> Property setter injection; mocks will first be resolved by type, then, if there is several property of the same type, by the match of the property name and the mock name.
> Note 1: If you have properties with the same type (or same erasure), it's better to name all @Mock annotated fields with the matching properties, otherwise Mockito might get confused and injection won't happen.
> 
> Note 2: If @InjectMocks instance wasn't initialized before and have a no-arg constructor, then it will be initialized with this constructor.
> 
> Field injection; mocks will first be resolved by type, then, if there is several property of the same type, by the match of the field name and the mock name.
> Note 1: If you have fields with the same type (or same erasure), it's better to name all @Mock annotated fields with the matching fields, otherwise Mockito might get confused and injection won't happen.
> 
> Note 2: If @InjectMocks instance wasn't initialized before and have a no-arg constructor, then it will be initialized with this constructor.

5) At least one element is annotated with Collaborator - we inject only those elements
6) There is no element annotated with Collaborator - all properties are considered for injections
