### PR TITLE
Allow Build on Windows

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/report/log/ReportLogConfigurationSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/report/log/ReportLogConfigurationSpec.groovy
@@ -17,6 +17,7 @@
 package org.spockframework.report.log
 
 import spock.lang.Specification
+import java.util.regex.Matcher
 
 class ReportLogConfigurationSpec extends Specification {
   def configuration = new ReportLogConfiguration()
@@ -44,6 +45,6 @@ class ReportLogConfigurationSpec extends Specification {
     configuration.logFileSuffix = "at-#timestamp"
 
     expect:
-    configuration.logFile ==~ "/foo/bar/baz-at-2\\d\\d\\d-.+\\.log"
+    (configuration.logFile as String).replaceAll(Matcher.quoteReplacement(System.getProperty("file.separator")), "/") ==~ "/foo/bar/baz-at-2\\d\\d\\d-.+\\.log"
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
@@ -249,6 +249,6 @@ loadLogFile([{
   }
 
   private String normalize(String str) {
-    str.trim().replaceAll("\\d", "X")
+    str.trim().replaceAll("\\d", "X").replaceAll("(\\\\r\\\\n|\\\\n)", "\\n")
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/util/ExceptionUtilSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/ExceptionUtilSpec.groovy
@@ -20,9 +20,10 @@ class ExceptionUtilSpec extends Specification {
   def "print stack trace to string"() {
     def exception = new IOException("ouch")
     def elem = new StackTraceElement("DeclaringClass", "methodName", "filename", 42)
+    def lineSeparator = System.getProperty("line.separator")
     exception.stackTrace = [elem]
 
     expect:
-    ExceptionUtil.printStackTrace(exception) == "java.io.IOException: ouch\n\tat DeclaringClass.methodName(filename:42)\n"
+    ExceptionUtil.printStackTrace(exception) == "java.io.IOException: ouch${lineSeparator}\tat DeclaringClass.methodName(filename:42)${lineSeparator}"
   }
 }


### PR DESCRIPTION
Builds on windows were failing due to specs relying on *Nix line endings
/ file separators.
