### PR TITLE
added manifest to core.gradle to allow spock core to work in OSGi land

### DIFF
--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -17,3 +17,14 @@ dependencies {
   compile libs.objenesis, optional
 }
 
+apply plugin: 'osgi'
+jar {
+  manifest {
+    name = 'spock-core'
+    instruction 'Export-Package', 'org.spockframework.*', 'spock.*'
+    instruction 'Embed-Dependency', 'groovy;inline=false', 'junit;inline=false'
+    instruction 'Import-Package', 'org.objenesis;version="[1,2)";resolution:=optional', 'org.apache.tools.ant;version="[1,2)";resolution:=optional', 'org.apache.tools.ant.types;version="[1,2)";resolution:=optional',
+                                  'net.sf.cglib.proxy;version="[2.2,3)";resolution:=optional', 'org.apache.tools.ant.types.selectors;version="[1.7,2)";resolution:=optional',
+								  'groovy.lang;version="[1.8,3)"', 'org.codehaus.groovy.*;version="[1.8,3)"', 'org.junit.runner;version="[4,5)"'
+  }
+}


### PR DESCRIPTION
This adds a manifest to the spock-core jar so the jar can be deployed as a bundle to an OSGi container.
