### PR TITLE
[Test case] Broken shared field initialization in trait

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/smoke/traits/BasicTraitUsage.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/traits/BasicTraitUsage.groovy
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.spockframework.smoke.trait
+package org.spockframework.smoke.traits
 
 import spock.lang.*
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/traits/MySharedTrait.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/traits/MySharedTrait.groovy
@@ -1,0 +1,39 @@
+/*
+* Copyright 2014 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.spockframework.smoke.traits
+
+import spock.lang.Shared
+
+trait MySharedTrait {
+
+  @Shared
+  String sharedValue = "sharedValueInitializedInline"
+  @Shared
+  String notInitializedSharedValue
+
+  String instanceValue = "instanceValueInitializedInline"
+  String notInitializedInstanceValue
+
+  def setupSpec() {
+    sharedValue = "sharedValueInitializedInSetupSpec"
+    notInitializedSharedValue = "notInitializedSharedValueInitializedInSetupSpec"
+  }
+
+  def setup() {
+    instanceValue = "instanceValueInitializedInSetup"
+    notInitializedInstanceValue = "notInitializedInstanceValueInitializedInSetup"
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/traits/MyTrait.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/traits/MyTrait.groovy
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.spockframework.smoke.trait
+package org.spockframework.smoke.traits
 
 import org.junit.After
 import org.junit.Before

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/traits/SharedTraitUsage.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/traits/SharedTraitUsage.groovy
@@ -1,0 +1,47 @@
+/*
+* Copyright 2014 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.spockframework.smoke.traits
+
+import spock.lang.Ignore
+import spock.lang.Issue
+import spock.lang.Specification
+
+class SharedTraitUsage extends Specification implements MySharedTrait {
+
+  @Ignore
+  @Issue("https://code.google.com/p/spock/issues/detail?id=370")
+  def "should not restore inline assigned value on shared field defined in trait before every test"() {
+    expect:
+      sharedValue == "sharedValueInitializedInSetupSpec"
+  }
+
+  @Ignore
+  @Issue("https://code.google.com/p/spock/issues/detail?id=370")
+  def "should not restore not initialized shared field defined in trait before every test"() {
+    expect:
+      notInitializedSharedValue == "notInitializedSharedValueInitializedInSetupSpec"
+  }
+
+  def "should not restore inline assigned value on instance field defined in trait before every test"() {
+    expect:
+      instanceValue == "instanceValueInitializedInSetup"
+  }
+
+  def "should not restore not initialized instance field defined in trait before every test"() {
+    expect:
+      notInitializedInstanceValue == "notInitializedInstanceValueInitializedInSetup"
+  }
+}


### PR DESCRIPTION
I've been playing with Spock and traits mix and I spotted an issue with `@Shared` field declared in a trait as reported in [issue 370](https://code.google.com/p/spock/issues/detail?id=370).

After some debugging AST transformations using `EmbeddedSpecification` it seems Spock doesn't see fields from trait and cannot do rename/initialization transformation for shared fields. I tried to modify the behavior, but traits are in general visible as interfaces and abstract methods (with setter/getter for fields). It is possible to get the field from a field and its annotation(s) with something like that:

```
Traits.findHelpers(clazz.interfaces[0]).fieldHelper.getFields().get(0).getAnnotations()
```

but "usual" modifications for shared fields (rename/change initialization place) would be risky to perform in a trait. I hope you will have some better idea what to do with that issue.

Btw, as Idea 14 doesn't allow to create (and use) classes/traits in a package named "trait" I renamed it to "traits".
