### PR TITLE
Errors in feature setup should be logged on the feature instead of the spec

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/BaseSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/BaseSpecRunner.java
@@ -396,6 +396,7 @@ public class BaseSpecRunner {
     runSetup(spec.getSuperSpec());
     for (MethodInfo method : spec.getSetupMethods()) {
       if (runStatus != OK) return;
+      method.setFeature(currentFeature);
       invoke(currentInstance, method);
     }
   }


### PR DESCRIPTION
Currently errors occuring inside the setup method are logged as errors of the specification. 
This way a single error can not be related to the test feature it occured on.
Additionally the feature itself is not marked as failed.

This update links each execution of the setup method to its corresponding test feature method.
