### PR TITLE
Combine stdout and stderr into one log stream

### DIFF
--- a/spock-core/src/main/java/org/spockframework/report/log/ReportLogEmitter.java
+++ b/spock-core/src/main/java/org/spockframework/report/log/ReportLogEmitter.java
@@ -48,7 +48,7 @@ class ReportLogEmitter implements IRunListener, IStandardStreamsListener {
   }
 
   public void standardErr(String message) {
-    standardStream(message, "errorOutput");
+    standardStream(message, "output");
   }
 
   private void standardStream(String message, String key) {

--- a/spock-specs/src/test/groovy/org/spockframework/report/log/ReportLogEmitterSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/report/log/ReportLogEmitterSpec.groovy
@@ -250,7 +250,7 @@ class ReportLogEmitterSpec extends Specification {
         name: "SampleSpec",
         features: [[
             name: "sample feature",
-            errorOutput: ["foo\nbar"]
+            output: ["foo\nbar"]
         ]]
     ]
   }
@@ -277,7 +277,7 @@ class ReportLogEmitterSpec extends Specification {
     log == [
         package: "foo.bar",
         name: "SampleSpec",
-        errorOutput: ["foo\nbar"]
+        output: ["foo\nbar"]
     ]
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
@@ -77,10 +77,8 @@ loadLogFile([{
             "narrative": "Given foo\\nWhen bar\\nThen baz\\nAnd bazbaz",
             "output": [
                 "out1\\n",
-                "out2\\n"
-            ],
-            "errorOutput": [
                 "err1\\n",
+                "out2\\n",
                 "err2\\n"
             ],
             "end": 1360051647586,
@@ -159,10 +157,8 @@ loadLogFile([{
             "narrative": "Given foo\\nWhen bar\\nThen baz\\nAnd bazbaz",
             "output": [
                 "out1\\n",
+                "err1\\n",
                 "out2\\n"
-            ],
-            "errorOutput": [
-                "err1\\n"
             ],
             "exceptions": [
                 "java.io.IOException: ouch\\n\\tat DeclaringClass.methodName(filename:42)\\n"


### PR DESCRIPTION
For each test feature method the stdout and stderr outputs are logged independently.
This way the order of multiple alternating outputs its lost.

This update combines both streams.
