### PR TITLE
allow one column data-table to be passed as parameter

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -238,6 +238,9 @@ public class WhereBlockRewriter {
     if (varExpr == null)
       throw new InvalidSpecCompileException(column.get(0),
           "Header of data table may only contain variable names");
+    if (AstUtil.isWildcardRef(varExpr)){
+      return; // ignore wildcards - _ can be used as placeholder for pseudo-second-column in one-column data
+    }
 
     ListExpression listExpr = new ListExpression(column.subList(1, column.size()));
     BinaryExpression binExpr = new BinaryExpression(varExpr, Token.newSymbol(Types.LEFT_SHIFT, -1, -1), listExpr);

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -138,6 +138,15 @@ a | a
     3 | "wow"
   }
 
+  def "allow one column to be passed as parameter"(a) {
+    expect:
+    a == 3
+
+    where:
+    a | _
+    3 | _
+  }
+
   def "tables can be mixed with other parameterizations"() {
     expect:
     [a, b, c, d] == [1, 2, 3, 4]


### PR DESCRIPTION
This pull-request allows values from one-column data-table to be passed as parameter. For example:

``` groovy
def "allow one column to be passed as parameter"(a) {
    expect:
    a == 3

    where:
    a | _
    3 | _
  }

```
