### PR TITLE
render exceptions in conditions as condition failure

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -43,6 +43,9 @@ public class AstNodeCache {
   public final MethodNode SpockRuntime_VerifyCondition =
       SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.VERIFY_CONDITION).get(0);
 
+  public final MethodNode SpockRuntime_ConditionFailedWithException =
+      SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.CONDITION_FAILED_WITH_EXCEPTION).get(0);
+
   public final MethodNode SpockRuntime_VerifyMethodCondition =
       SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.VERIFY_METHOD_CONDITION).get(0);
 
@@ -51,6 +54,9 @@ public class AstNodeCache {
 
   public final MethodNode ValueRecorder_Record =
       ValueRecorder.getDeclaredMethods(org.spockframework.runtime.ValueRecorder.RECORD).get(0);
+
+  public final MethodNode ValueRecorder_StartRecordingValue =
+      ValueRecorder.getDeclaredMethods(org.spockframework.runtime.ValueRecorder.START_RECORDING_VALUE).get(0);
 
   public final MethodNode ValueRecorder_RealizeNas =
       ValueRecorder.getDeclaredMethods(org.spockframework.runtime.ValueRecorder.REALIZE_NAS).get(0);

--- a/spock-core/src/main/java/org/spockframework/runtime/Condition.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/Condition.java
@@ -16,6 +16,7 @@
 
 package org.spockframework.runtime;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.spockframework.runtime.model.ExpressionInfo;
@@ -30,24 +31,28 @@ import org.spockframework.util.Nullable;
 public class Condition {
   private static final Pattern pattern = Pattern.compile("\\s*\n\\s*");
 
-  private final Iterable<Object> values;
+  private final List<Object> values;
   private final String text;
   private final TextPosition position;
   private final String message;
+  private final Integer notRecordedVarNumberBecauseOfException;
+  private final Throwable exception;
 
   private volatile ExpressionInfo expression;
   private volatile String rendering;
 
-  public Condition(@Nullable Iterable<Object> values, @Nullable String text, TextPosition position,
-      @Nullable String message) {
+  public Condition(@Nullable List<Object> values, @Nullable String text, TextPosition position,
+      @Nullable String message, @Nullable Integer notRecordedVarNumberBecauseOfException, @Nullable Throwable exception) {
     this.text = text;
     this.position = position;
     this.values = values;
     this.message = message;
+    this.notRecordedVarNumberBecauseOfException = notRecordedVarNumberBecauseOfException;
+    this.exception = exception;
   }
 
   @Nullable
-  public Iterable<Object> getValues() {
+  public List<Object> getValues() {
     return values;
   }
 
@@ -84,7 +89,7 @@ public class Condition {
 
   private void createExpression() {
     if (text == null || values == null) return;
-    expression = new ExpressionInfoBuilder(flatten(text), TextPosition.create(1, 1), values).build();
+    expression = new ExpressionInfoBuilder(flatten(text), TextPosition.create(1, 1), values, notRecordedVarNumberBecauseOfException, exception).build();
   }
 
   private void createRendering() {

--- a/spock-core/src/main/java/org/spockframework/runtime/ConditionNotSatisfiedError.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ConditionNotSatisfiedError.java
@@ -26,6 +26,11 @@ public class ConditionNotSatisfiedError extends SpockAssertionError {
     this.condition = condition;
   }
 
+  public ConditionNotSatisfiedError(Condition condition, Throwable cause) {
+    super(cause);
+    this.condition = condition;
+  }
+
   public Condition getCondition() {
     return condition;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/ExpressionInfoBuilder.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ExpressionInfoBuilder.java
@@ -17,6 +17,7 @@
 package org.spockframework.runtime;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.stmt.*;
@@ -24,6 +25,7 @@ import org.codehaus.groovy.control.SourceUnit;
 
 import org.spockframework.runtime.model.*;
 import org.spockframework.util.Assert;
+import org.spockframework.util.Nullable;
 import org.spockframework.util.TextUtil;
 
 /**
@@ -34,13 +36,17 @@ public class ExpressionInfoBuilder {
   private final String text;
   private final String adjustedText;
   private final TextPosition startPos;
-  private final Iterable<Object> values;
+  private final List<Object> values;
+  private final Integer notRecordedVarNumberBecauseOfException;
+  private final Throwable exception;
   private final String[] lines;
 
-  public ExpressionInfoBuilder(String text, TextPosition startPos, Iterable<Object> values) {
+  public ExpressionInfoBuilder(String text, TextPosition startPos, List<Object> values, @Nullable Integer notRecordedVarNumberBecauseOfException, @Nullable Throwable exception) {
     this.text = text;
     this.startPos = startPos;
     this.values = values;
+    this.notRecordedVarNumberBecauseOfException = notRecordedVarNumberBecauseOfException;
+    this.exception = exception;
     adjustedText = TextUtil.repeatChar(' ', startPos.getColumnIndex()) + text;
     lines = adjustedText.split("\n");
   }
@@ -61,12 +67,17 @@ public class ExpressionInfoBuilder {
 
     // IDEA: rest of this method could be moved to ExpressionInfoConverter (but: might make EIC less testable)
     // IDEA: could make ExpressionInfo immutable
-    Iterator<?> iter = values.iterator();
-    for (ExpressionInfo info : exprInfo.inPostfixOrder(false)) {
+    List<ExpressionInfo> inPostfixOrder = exprInfo.inPostfixOrder(false);
+    for (int variableNumber = 0; variableNumber < inPostfixOrder.size(); variableNumber++) {
+      ExpressionInfo info = inPostfixOrder.get(variableNumber);
       info.setText(findText(info.getRegion()));
-      if (!iter.hasNext())
-        Assert.fail("Missing value for expression '%s' in condition '%s'", info.getText(), text);
-      info.setValue(iter.next());
+      if (notRecordedVarNumberBecauseOfException!=null && variableNumber == notRecordedVarNumberBecauseOfException) {
+        info.setValue(exception);
+      } else if (values.size() > variableNumber) { //we have this value
+        info.setValue(values.get(variableNumber));
+      }else {
+        info.setValue(ExpressionInfo.VALUE_NOT_AVAILABLE);
+      }
       if (startPos.getLineIndex() > 0)
         info.shiftVertically(startPos.getLineIndex());
     }

--- a/spock-core/src/main/java/org/spockframework/runtime/InvalidSpecException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/InvalidSpecException.java
@@ -22,7 +22,7 @@ package org.spockframework.runtime;
  *
  * @author Peter Niederwieser
  */
-public class InvalidSpecException extends RuntimeException {
+public class InvalidSpecException extends SpockException {
   private String msg;
 
   public InvalidSpecException(String msg) {

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockException.java
@@ -1,0 +1,23 @@
+package org.spockframework.runtime;
+
+public class SpockException extends RuntimeException {
+  public SpockException() {
+    super();
+  }
+
+  public SpockException(String message) {
+    super(message);
+  }
+
+  public SpockException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public SpockException(Throwable cause) {
+    super(cause);
+  }
+
+  protected SpockException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionException.java
@@ -21,7 +21,7 @@ package org.spockframework.runtime;
  *
  * @author Peter Niederwieser
  */
-public class SpockExecutionException extends RuntimeException {
+public class SpockExecutionException extends SpockException {
   private volatile String msg;
 
   public SpockExecutionException(String msg) {

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockRuntime.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockRuntime.java
@@ -62,13 +62,16 @@ public abstract class SpockRuntime {
 
   // method calls with spread-dot operator are not rewritten, hence this method doesn't have to care about spread-dot
   public static void verifyMethodCondition(@Nullable ValueRecorder recorder, @Nullable String text, int line, int column,
-      @Nullable Object message, Object target, String method, Object[] args, boolean safe, boolean explicit) {
+      @Nullable Object message, Object target, String method, Object[] args, boolean safe, boolean explicit, int lastVariableNum) {
     MatcherCondition matcherCondition = MatcherCondition.parse(target, method, args, safe);
     if (matcherCondition != null) {
       matcherCondition.verify(getValues(recorder), text, line, column, messageToString(message));
       return;
     }
 
+    if (recorder != null) {
+      recorder.startRecordingValue(lastVariableNum);
+    }
     Object result = safe ? GroovyRuntimeUtil.invokeMethodNullSafe(target, method, args) :
         GroovyRuntimeUtil.invokeMethod(target, method, args);
 

--- a/spock-core/src/main/java/org/spockframework/runtime/ValueRecorder.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ValueRecorder.java
@@ -27,6 +27,7 @@ import org.spockframework.runtime.model.ExpressionInfo;
  */
 public class ValueRecorder {
   private final ArrayList<Object> values = new ArrayList<Object>();
+  private final Stack<Integer> startedRecordings = new Stack<Integer>();
 
   public static final String RESET = "reset";
 
@@ -44,7 +45,27 @@ public class ValueRecorder {
   public Object record(int index, Object value) {
     realizeNas(index, null);
     values.add(value);
+
+    boolean foundThisCallOnStack = false;
+    while (!startedRecordings.empty()){
+      final Integer indexFromStack = startedRecordings.pop();
+      if (indexFromStack==index){
+        foundThisCallOnStack = true;
+        break;
+      }
+    }
+    if (!foundThisCallOnStack){
+      throw new IllegalStateException("can not found call #"+index+" on stack. Invalid call of record method?");
+    }
+
     return value;
+  }
+
+  public static final String START_RECORDING_VALUE = "startRecordingValue";
+
+  public int startRecordingValue(int index){
+    startedRecordings.push(index);
+    return index;
   }
 
   public static final String REALIZE_NAS = "realizeNas";
@@ -60,5 +81,13 @@ public class ValueRecorder {
 
   public List<Object> getValues() {
     return new ArrayList<Object>(values);
+  }
+
+  public Integer getCurrentRecordingVarNum() {
+    if (startedRecordings.isEmpty()) {
+      return null;
+    } else {
+      return startedRecordings.peek();
+    }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/ExtensionException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/ExtensionException.java
@@ -16,7 +16,9 @@
 
 package org.spockframework.runtime.extension;
 
-public class ExtensionException extends RuntimeException {
+import org.spockframework.runtime.SpockException;
+
+public class ExtensionException extends SpockException {
   private String message;
 
   public ExtensionException(String message) {

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ExpressionInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ExpressionInfo.java
@@ -141,14 +141,10 @@ public class ExpressionInfo implements Iterable<ExpressionInfo> {
     };
   }
 
-  public Iterable<ExpressionInfo> inPostfixOrder(final boolean skipIrrelevant) {
-    return new Iterable<ExpressionInfo>() {
-      public Iterator<ExpressionInfo> iterator() {
-        List<ExpressionInfo> list = new ArrayList<ExpressionInfo>();
-        collectPostfix(list, skipIrrelevant);
-        return list.iterator();
-      }
-    };
+  public List<ExpressionInfo> inPostfixOrder(final boolean skipIrrelevant) {
+    List<ExpressionInfo> list = new ArrayList<ExpressionInfo>();
+    collectPostfix(list, skipIrrelevant);
+    return list;
   }
 
   public Iterable<ExpressionInfo> inCustomOrder(boolean skipIrrelevant, Comparator<ExpressionInfo> comparator) {

--- a/spock-core/src/main/java/org/spockframework/util/IncompatibleGroovyVersionException.java
+++ b/spock-core/src/main/java/org/spockframework/util/IncompatibleGroovyVersionException.java
@@ -14,7 +14,9 @@
 
 package org.spockframework.util;
 
-public class IncompatibleGroovyVersionException extends RuntimeException {
+import org.spockframework.runtime.SpockException;
+
+public class IncompatibleGroovyVersionException extends SpockException {
   public IncompatibleGroovyVersionException(String message) {
     super(message);
   }

--- a/spock-core/src/main/java/org/spockframework/util/WrappedException.java
+++ b/spock-core/src/main/java/org/spockframework/util/WrappedException.java
@@ -14,13 +14,15 @@
 
 package org.spockframework.util;
 
+import org.spockframework.runtime.SpockException;
+
 /**
  * Wraps a checked exception s.t. it can be thrown from a method that doesn't
  * declare to throw it.
  *
  * @author Peter Niederwieser
  */
-public class WrappedException extends RuntimeException {
+public class WrappedException extends SpockException {
   public WrappedException(Throwable cause) {
     super(cause);
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionsInConditions.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionsInConditions.groovy
@@ -1,0 +1,82 @@
+package org.spockframework.smoke.condition
+
+import junit.framework.Assert
+import org.spockframework.runtime.ConditionNotSatisfiedError
+import org.spockframework.runtime.SpockException
+import spock.lang.FailsWith
+import spock.lang.Specification
+
+
+class ExceptionsInConditions extends ConditionRenderingSpec {
+  def "null pointer exception in condition"() {
+    expect:
+    isRendered("""\
+            map.get("key").length() == 0
+            |   |          |
+            [:] null       java.lang.NullPointerException: Cannot invoke method length() on null object
+        """.stripIndent(),
+        {
+          def map = new HashMap<String, String>()
+          assert map.get("key").length() == 0
+        }
+    )
+  }
+
+
+  def "exception while invoking methods condition"() {
+    expect:
+    isRendered("""\
+            getKey(map, "key").length() == 0
+            |      |
+            |      [:]
+            java.lang.IllegalArgumentException: key does not exists
+        """.stripIndent(),
+        {
+          def getKey = { map, key ->
+            def result = map.get(key)
+            if (result == null) {
+              throw new IllegalArgumentException("key does not exists")
+            }
+            return result;
+          }
+          def map = new HashMap<String, String>()
+          assert getKey(map, "key").length() == 0
+        }
+    )
+  }
+
+  def "spock assertion errors should be processed as is"() {
+    expect:
+    isRendered("""\
+            result != null
+            |      |
+            null   false
+        """.stripIndent(),
+        {
+          def getKey = { map, key ->
+            def result = map.get(key)
+            assert result != null
+            return result;
+          }
+          def map = new HashMap<String, String>()
+          assert getKey(map, "key").length() == 0
+        }
+    )
+  }
+
+  @FailsWith(SpockException)
+  def "spock exceptions should be processed as is"() {
+    def getKey = { map, key ->
+      def result = map.get(key)
+      if (result == null) {
+        throw new SpockException("key does not exists")
+      }
+      return result;
+    }
+    def map = new HashMap<String, String>()
+
+    expect:
+    getKey(map, "key").length() == 0
+
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/MatcherConditions.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/MatcherConditions.groovy
@@ -130,7 +130,7 @@ class MatcherConditions extends EmbeddedSpecification {
     42 equalTo(x)
   }
 
-  @FailsWith(MissingMethodException)
+  @FailsWith(ConditionNotSatisfiedError)
   def "cannot have a string literal as actual (because matcher expression gets parsed as a method call)"() {
     def x = "fred"
 
@@ -150,7 +150,7 @@ class MatcherConditions extends EmbeddedSpecification {
     String property = "property"
   }
 
-  @FailsWith(MissingMethodException)
+  @FailsWith(ConditionNotSatisfiedError)
   def "cannot have a method expression as actual in Groovy 1.8 (because matcher expression gets parsed as a chained method call)"() {
     def foo = new Foo()
 
@@ -165,7 +165,7 @@ class MatcherConditions extends EmbeddedSpecification {
     that foo.method(), equalTo("method")
   }
 
-  @FailsWith(MissingMethodException)
+  @FailsWith(ConditionNotSatisfiedError)
   def "cannot have a property expression as actual (because matcher expression gets parsed as a method call)"() {
     def foo = new Foo()
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
@@ -165,7 +165,7 @@ loadLogFile([{
                 "err1\\n"
             ],
             "exceptions": [
-                "java.io.IOException: ouch\\n\\tat DeclaringClass.methodName(filename:42)\\n"
+                "Condition not satisfied:nnthrowException()n|njava.io.IOException: ouchnn\\tat apackage.MySpec.some feature(scriptXXXXXXXXXXXXXXXXXXXXXXX.groovy:XX)nCaused by: java.io.IOException: ouchn\\tat DeclaringClass.methodName(filename:XX)n"
             ],
             "end": 1360051647586,
             "result": "failed",


### PR DESCRIPTION
## Idea

Spock has the best exception rendering I have ever see. For example, lets take a spec:
```groovy
    def "responce code should starts with 200"(){
        when:
        def map = new HashMap<String, String>()
        map.put("responceCode", "404 NOT FOUND")
        then:
        map.get("responceCode").startsWith("200")
    }
```

It fails and has good rendering:

```
Condition not satisfied:

map.get("responceCode").startsWith("200")
|   |                   |
|   404 NOT FOUND       false
[responceCode:404 NOT FOUND]

	at org.spockframework.guice.JavaStubs.responce code should starts with 200(JavaStubs.groovy:98)
```

But how it will be rendered if map miss value for key "responceCode"? For example in this spec:
```groovy
    def "responce code should starts with 200"(){
        when:
        def map = new HashMap<String, String>()
        map.put("ResponceCode", "404 NOT FOUND")
        then:
        map.get("responceCode").startsWith("200")
    }
```

just an exception:
```
java.lang.NullPointerException: Cannot invoke method startsWith() on null object
	at Test.responce code should starts with 200(Test.groovy:8)
```

we can understand that map does not contains entry for "responceCode" but we can not inspect what map really contains. 

With my modifications it will become more friendly:
```
Condition not satisfied:

map.get("responceCode").startsWith("200")
|   |                   |
|   null                java.lang.NullPointerException: Cannot invoke method startsWith() on null object
[ResponceCode:404 NOT FOUND]

	at org.spockframework.guice.Test.responce code should starts with 200(Test.groovy:11)
Caused by: java.lang.NullPointerException: Cannot invoke method startsWith() on null object
	... 1 more
```

So exceptions that occured during evaluating condition become part of rendering.

## Implementation
Lets take for example this condition:
```
map.get("key") == "abc"
```

Before my changes it will be transformed to (I omit unnecessary parts)
```
SpockRuntime.verifyCondition(
                valueRecorder.reset(),
                "map.get(\"key\") == \"abc\"",
                8,
                9,
                null,
                valueRecorder.record(
                        6,
                        Boolean.valueOf(
                                ScriptBytecodeAdapter.compareEqual(
                                        valueRecorder.record(4,
                                                ScriptBytecodeAdapter.invokeMethodN(
                                                        Test.class,
                                                        valueRecorder.record(0, map),
                                                        (String)valueRecorder.record(1, "get"),
                                                        [valueRecorder.record(2, "key") ]
                                                )
                                        ),
                                        valueRecorder.record(5, "abc")
                                )
                        )
                )
        );
```

We need to:
1) handle exception, so surround this expression with try-catch.
2) to understand number of value that was not recorded because of exception, so lets remember value number before recording value (and before evaluating expression for this value).
```groovy
try {
    SpockRuntime.verifyCondition(
            $spock_valueRecorder.reset(), 
            "map.get(\"key\") == \"abc\"", 
            14,
            7,
            null,
            $spock_valueRecorder.record(
                    $spock_valueRecorder.startRecordingValue(6),
                    Boolean.valueOf(
                            ScriptBytecodeAdapter.compareEqual(
                                    $spock_valueRecorder.record(
                                            $spock_valueRecorder.startRecordingValue(4),
                                            ScriptBytecodeAdapter.invokeMethodN(
                                                    ExceptionsInConditionsSpec.class,
                                                    $spock_valueRecorder.record(
                                                            $spock_valueRecorder.startRecordingValue(0),
                                                            map
                                                    ),
                                                    (String) ShortTypeHandling.castToString(
                                                            $spock_valueRecorder.record(
                                                                    $spock_valueRecorder.startRecordingValue(1),
                                                                    "get")
                                                    ),
                                                    [$spock_valueRecorder.record(
                                                            $spock_valueRecorder.startRecordingValue(2),
                                                            "key"
                                                    )]
                                            )
                                    ),
                                    $spock_valueRecorder.record(
                                            $spock_valueRecorder.startRecordingValue(5),
                                            "abc")
                            )
                    )
            )
    );
}
catch (Throwable throwable) {
    SpockRuntime.conditionFailedWithException($spock_valueRecorder, "map.get(\"key\") == \"abc\"", 14, 7, null, throwable);
}
```

ValueRecorder,startRecording method:
```groovy
  private final Stack<Integer> startedRecordings = new Stack<Integer>();

  public int startRecordingValue(int index){
    startedRecordings.push(index);
    return index;
  }

```

So we add value number to stack before evaluating expression for this value. And remove value number from top of stack when value is written to ValueRecording. And when exception is thrown we can learn where exception is thrown by peeking value from top of stack.
