### PR TITLE
Single page documentation Issue #65

### DIFF
--- a/docs/all_in_one.adoc
+++ b/docs/all_in_one.adoc
@@ -1,0 +1,23 @@
+= Spock Framework Reference Documentation
+:toc: left
+:toclevels: 3
+:author: Peter Niederwieser
+:revnumber: 1.0
+
+include::introduction.adoc[]
+
+include::getting_started.adoc[]
+
+include::spock_primer.adoc[]
+
+include::data_driven_testing.adoc[]
+
+include::interaction_based_testing.adoc[]
+
+include::extensions.adoc[]
+
+include::modules.adoc[]
+
+include::release_notes.adoc[]
+
+include::migration_guide.adoc[]

--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -1,9 +1,9 @@
-= Data Driven Testing
+== Data Driven Testing
 
 Oftentimes, it is useful to exercise the same test code multiple times, with varying inputs and expected results.
 Spock's data driven testing support makes this a first class feature.
 
-== Introduction
+=== Introduction
 
 Suppose we want to specify the behavior of the +Math.max+ method:
 
@@ -48,7 +48,7 @@ We have finished the test logic, but still need to supply the data values to be 
 which always comes at the end of the method. In the simplest (and most common) case, the +where:+ block holds a _data table_.
 
 [[data-tables]]
-== Data Tables
+=== Data Tables
 
 Data tables are a convenient way to exercise a feature method with a fixed set of data values:
 
@@ -84,13 +84,13 @@ a | _
 0 | _
 ----
 
-== Isolated Execution of Iterations
+=== Isolated Execution of Iterations
 
 Iterations are isolated from each other in the same way as separate feature methods. Each iteration gets its own instance
 of the specification class, and the `setup` and `cleanup` methods will be called before and after each iteration,
 respectively.
 
-== Sharing of Objects between Iterations
+=== Sharing of Objects between Iterations
 
 In order to share an object between iterations, it has to be kept in a `@Shared` or static field.
 
@@ -100,7 +100,7 @@ Note that such objects will also be shared with other methods. There is currentl
 just between iterations of the same method. If you consider this a problem, consider putting each method into a separate
 spec, all of which can be kept in the same file. This achieves better isolation at the cost of some boilerplate code.
 
-== Syntactic Variations
+=== Syntactic Variations
 
 The previous code can be tweaked in a few ways. First, since the `where:` block already declares all data variables, the
 method parameters can be omitted.footnote:[The idea behind allowing method parameters is to enable better IDE support.
@@ -125,7 +125,7 @@ class DataDriven extends Specification {
 }
 ----
 
-== Reporting of Failures
+=== Reporting of Failures
 
 Let's assume that our implementation of the `max` method has a flaw, and one of the iterations fails:
 
@@ -147,7 +147,7 @@ footnote:[For example, a feature method could use data variables in its `setup:`
 In any case, it would be nice if Spock made it loud and clear which iteration failed, rather than just reporting the
 failure. This is the purpose of the `@Unroll` annotation.
 
-== Method Unrolling
+=== Method Unrolling
 
 A method annotated with `@Unroll` will have its iterations reported independently:
 
@@ -208,7 +208,7 @@ for further details on this topic.
 The `@Unroll` annotation can also be placed on a spec. This has the same effect as placing it on each data-driven
 feature method of the spec.
 
-== Data Pipes
+=== Data Pipes
 
 Data tables aren't the only way to supply values to data variables. In fact, a data table is just syntactic sugar for
 one or more _data pipes_:
@@ -229,7 +229,7 @@ used as a data provider. This includes objects of type `Collection`, `String`, `
 they can fetch data from external sources like text files, databases and spreadsheets, or generate data randomly.
 Data providers are queried for their next value only when needed (before the next iteration).
 
-== Multi-Variable Data Pipes
+=== Multi-Variable Data Pipes
 
 If a data provider returns multiple values per iteration (as an object that Groovy knows how to iterate over),
 it can be connected to multiple data variables simultaneously. The syntax is somewhat similar to Groovy multi-assignment
@@ -255,7 +255,7 @@ where:
 [a, b, _, c] << sql.rows("select * from maxdata")
 ----
 
-== Data Variable Assignment
+=== Data Variable Assignment
 
 A data variable can be directly assigned a value:
 
@@ -282,7 +282,7 @@ b = row.b
 c = row.c
 ----
 
-== Combining Data Tables, Data Pipes, and Variable Assignments
+=== Combining Data Tables, Data Pipes, and Variable Assignments
 
 Data tables, data pipes, and variable assignments can be combined as needed:
 
@@ -300,19 +300,19 @@ b << [5, 0, 0]
 c = a > b ? a : b
 ----
 
-== Number of Iterations
+=== Number of Iterations
 
 The number of iterations depends on how much data is available. Successive executions of the same method can
 yield different numbers of iterations. If a data provider runs out of values sooner than its peers, an exception will occur.
 Variable assignments don't affect the number of iterations. A `where:` block that only contains assignments yields
 exactly one iteration.
 
-== Closing of Data Providers
+=== Closing of Data Providers
 
 After all iterations have completed, the zero-argument `close` method is called on all data providers that have
 such a method.
 
-== More on Unrolled Method Names
+=== More on Unrolled Method Names
 
 An unrolled method name is similar to a Groovy `GString`, except for the following differences:
 

--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -1,16 +1,16 @@
-= Extensions
+== Extensions
 
 Spock comes with a powerful extension mechanism, which allows to hook into a spec's lifecycle to enrich or alter its
 behavior. In this chapter, we will first learn about Spock's built-in extensions, and then dive into writing custom
 extensions.
 
-== Built-In Extensions
+=== Built-In Extensions
 
 Most of Spock's built-in extensions are _annotation-driven_. In other words, they are triggered by annotating a
 spec class or method with a certain annotation. You can tell such an annotation by its +@ExtensionAnnotation+
 meta-annotation.
 
-=== Ignore
+==== Ignore
 
 To temporarily prevent a feature method from getting executed, annotate it with +spock.lang.Ignore+:
 
@@ -38,7 +38,7 @@ class MySpec extends Specification { ... }
 
 In most execution environments, ignored feature methods and specs will be reported as "skipped".
 
-=== IgnoreRest
+==== IgnoreRest
 
 To ignore all but a (typically) small subset of methods, annotate the latter with +spock.lang.IgnoreRest+:
 
@@ -54,7 +54,7 @@ def "I'll also be ignored"() { ... }
 
 +@IgnoreRest+ is especially handy in execution environments that don't provide an (easy) way to run a subset of methods.
 
-=== IgnoreIf
+==== IgnoreIf
 
 To ignore a feature method under certain conditions, annotate it with +spock.lang.IgnoreIf+,
 followed by a predicate:
@@ -80,7 +80,7 @@ Using the `os` property, the previous example can be rewritten as:
 def "I'll run everywhere but on Windows"() { ... }
 ----
 
-=== Requires
+==== Requires
 
 To execute a feature method under certain conditions, annotate it with `spock.lang.Requires`,
 followed by a predicate:
@@ -95,7 +95,7 @@ def "I'll only run on Windows"() { ... }
 to state the conditions under which a method gets executed, rather than the conditions under which it gets ignored.
 
 
-=== Stepwise
+==== Stepwise
 
 To execute features in the order that they are declared, annotate a spec class with `spock.lang.Stepwise`:
 
@@ -112,7 +112,7 @@ class RunInOrderSpec extends Specification {
 failure are skipped.
 
 
-=== Timeout
+==== Timeout
 
 To fail a feature method, fixture, or class that exceeds a given execution duration, use `spock.lang.Timeout`,
 followed by a duration, and optionally a time unit. The default time unit is seconds.
@@ -148,7 +148,7 @@ When applied to a fixture method, the timeout is per execution of the fixture me
 When a timeout is reported to the user, the stack trace shown reflects the execution stack of the test framework when
 the timeout was exceeded.
 
-=== Use
+==== Use
 
 To activate one or more Groovy categories within the scope of a feature method or spec, use `spock.util.mop.Use`:
 
@@ -172,7 +172,7 @@ It has no effect when applied to a helper method. However, when applied to a spe
 methods.
 
 
-=== ConfineMetaClassChanges
+==== ConfineMetaClassChanges
 
 To confine meta class changes to the scope of a feature method or spec class, use `spock.util.mop.ConfineMetaClassChanges`:
 
@@ -205,7 +205,7 @@ after `cleanupSpec` is executed.
 When applied to a feature method, the meta classes are restored to as they were after `setup` was executed,
 before `cleanup` is executed.
 
-=== AutoCleanup
+==== AutoCleanup
 
 Automatically clean up a field or property at the end of its lifetime by using `spock.lang.AutoCleanup`.
 
@@ -231,7 +231,7 @@ annotated object. To prevent cleanup exceptions from being reported, override th
 def ignoreMyExceptions
 ----
 
-=== Title and Narrative
+==== Title and Narrative
 
 To attach a natural-language name to a spec, use `spock.lang.Title`:
 
@@ -255,7 +255,7 @@ So that bar
 class GiveTheUserFooSpec() { ... }
 ----
 
-=== Issue
+==== Issue
 
 To indicate that a feature or spec relates to one or more issues in an external tracking system, use `spock.lang.Issue`:
 
@@ -271,7 +271,7 @@ class MySpec {
 }
 ----
 
-=== Subject
+==== Subject
 
 To indicate one or more subjects of a spec, use `spock.lang.Subject`:
 
@@ -292,7 +292,7 @@ Foo myFoo
 
 TODO More to follow.
 
-== Writing Custom Extensions
+=== Writing Custom Extensions
 
 TODO
 

--- a/docs/getting_started.adoc
+++ b/docs/getting_started.adoc
@@ -1,14 +1,14 @@
-= Getting Started
+== Getting Started
 
 It's really easy to get started with Spock. This section shows you how.
 
-== Spock Web Console
+=== Spock Web Console
 
 http://webconsole.spockframework.org[Spock Web Console] is a website that allows you to instantly view, edit, run, and
 even publish Spock specifications. It is the perfect place to toy around with Spock without making any commitments.
 So why not run http://webconsole.spockframework.org/edit/9001[Hello, Spock!] right away?
 
-== Spock Example Project
+=== Spock Example Project
 
 To try Spock in your local environment, clone or download/unzip the https://github.com/spockframework/spock-example
 [Spock Example Project]. It comes with fully working Ant, Gradle, and Maven builds that require no further setup.

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -11,3 +11,5 @@ Version 1.0
 . <<modules.adoc#,Modules>>
 . <<release_notes.adoc#,Release Notes>>
 . <<migration_guide.adoc#,Migration Guide>>
+
+<<all_in_one.adoc#,Single Page Documentation>>

--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -1,4 +1,4 @@
-= Interaction Based Testing
+== Interaction Based Testing
 
 Interaction-based testing is a design and testing technique that emerged in the Extreme Programming
 (XP) community in the early 2000's. Focusing on the behavior of objects rather than their state, it explores how
@@ -50,7 +50,7 @@ We hope that by the end of this chapter, you will agree that we have achieved th
 
 Except where indicated, all features of Spock's mocking framework work both for testing Java and Groovy code.
 
-== Creating Mock Objects
+=== Creating Mock Objects
 
 Mock objects are created with the +MockingApi.Mock()+ method.footnote:[For additional ways to create mock objects,
 see <<OtherKindsOfMockObjects>> and <<ALaCarteMocks>>.]
@@ -79,7 +79,7 @@ Mock objects literally implement (or, in the case of a class, extend) the type t
 words, in our example +subscriber+ _is-a_ +Subscriber+. Hence it can be passed to statically typed (Java)
 code that expects this type.
 
-== Default Behavior of Mock Objects
+=== Default Behavior of Mock Objects
 
 .Lenient vs. Strict Mocking Frameworks
 ****
@@ -97,7 +97,7 @@ the default value for the method's return type (+false+, +0+, or +null+). An exc
 equal to itself, has a unique hash code, and a string representation that includes the name of the type it represents.
 This default behavior is overridable by stubbing the methods, which we will learn about in the <<Stubbing>> section.
 
-== Injecting Mock Objects into Code Under Specification
+=== Injecting Mock Objects into Code Under Specification
 
 After creating the publisher and its subscribers, we need to make the latter known to the former:
 
@@ -117,7 +117,7 @@ class PublisherSpec extends Specification {
 
 We are now ready to describe the expected interactions between the two parties.
 
-== Mocking
+=== Mocking
 
 Mocking is the act of describing (mandatory) interactions between the object under specification and its collaborators.
 Here is an example:
@@ -141,7 +141,7 @@ When this feature method gets run, all invocations on mock objects that occur wh
 satisfied, a (subclass of) +InteractionNotSatisfiedError+ will be thrown. This verification happens automatically
 and does not require any additional code.
 
-=== Interactions
+==== Interactions
 
 .Is an Interaction Just a Regular Method Invocation?
 ****
@@ -163,7 +163,7 @@ parts: a _cardinality_, a _target constraint_, a _method constraint_, and an _ar
 cardinality
 ----
 
-=== Cardinality
+==== Cardinality
 
 The cardinality of an interaction describes how often a method call is expected. It can either be a fixed number or
 a range:
@@ -179,7 +179,7 @@ _ * subscriber.receive("hello")      // any number of calls, including zero
                                      // (rarely needed; see 'Strict Mocking')
 ----
 
-=== Target Constraint
+==== Target Constraint
 
 The target constraint of an interaction describes which mock object is expected to receive the method call:
 
@@ -189,7 +189,7 @@ The target constraint of an interaction describes which mock object is expected 
 1 * _.receive("hello")          // a call to any mock object
 ----
 
-=== Method Constraint
+==== Method Constraint
 
 The method constraint of an interaction describes which method is expected to be called:
 
@@ -214,7 +214,7 @@ When expecting a call to a setter method, only method syntax can be used:
 1 * subscriber.setStatus("ok") // NOT: 1 * subscriber.status = "ok"
 ----
 
-=== Argument Constraints
+==== Argument Constraints
 
 The argument constraints of an interaction describe which method arguments are expected:
 
@@ -257,7 +257,7 @@ Groovy allows any method whose last parameter has an array type to be called in 
 vararg syntax can also be used in interactions matching such methods.
 ****
 
-=== Matching Any Method Call
+==== Matching Any Method Call
 
 Sometimes it can be useful to match "anything", in some sense of the word:
 
@@ -273,7 +273,7 @@ Sometimes it can be useful to match "anything", in some sense of the word:
 NOTE: Although `(_.._) * _._(*_) >> _` is a valid interaction declaration,
 it is neither good style nor particularly useful.
 
-=== Strict Mocking
+==== Strict Mocking
 
 Now, when would matching any method call be useful? A good example is _strict mocking_,
 a style of mocking where no interactions other than those explicitly declared are allowed:
@@ -296,7 +296,7 @@ NOTE: `_ *` is only meaningful in the context of strict mocking. In particular, 
 when <<Stubbing>> an invocation. For example, `_ * auditing.record(_) >> "ok"`
 can (and should!) be simplified to `auditing.record(_) >> "ok"`.
 
-=== Where to Declare Interactions
+==== Where to Declare Interactions
 
 So far, we declared all our interactions in a `then:` block. This often results in a spec that reads naturally.
 However, it is also permissible to put interactions anywhere _before_ the `when:` block that is supposed to satisfy
@@ -321,7 +321,7 @@ a cardinality (when mocking) or a response generator (when stubbing). Either of 
 ****
 
 [[declaring-interactions-at-creation-time]]
-=== Declaring Interactions at Mock Creation Time (New in 0.7)
+==== Declaring Interactions at Mock Creation Time (New in 0.7)
 
 If a mock has a set of "base" interactions that don't vary, they can be declared right at mock creation time:
 
@@ -350,7 +350,7 @@ class MySpec extends Specification {
 }
 ----
 
-=== Grouping Interactions with Same Target (New in 0.7)
+==== Grouping Interactions with Same Target (New in 0.7)
 
 Interactions sharing the same target can be grouped in a `Specification.with` block. Similar to
 <<declaring-interactions-at-creation-time,Declaring Interactions at Mock Creation Time>>, this makes it unnecessary
@@ -366,7 +366,7 @@ with(subscriber) {
 
 A `with` block can also be used for grouping conditions with the same target.
 
-=== Mixing Interactions and Conditions
+==== Mixing Interactions and Conditions
 
 A `then:` block may contain both interactions and conditions. Although not strictly required, it is customary
 to declare interactions before conditions:
@@ -384,7 +384,7 @@ publisher.messageCount == 1
 Read out aloud: "When the publisher sends a 'hello' message, then the subscriber should receive the message exactly
 once, and the publisher's message count should be one."
 
-=== Explicit Interaction Blocks
+==== Explicit Interaction Blocks
 
 Internally, Spock must have full information about expected interactions _before_ they take place.
 So how is it possible for interactions to be declared in a `then:` block?
@@ -426,7 +426,7 @@ interaction {
 
 Since an `MockingApi.interaction` block is always moved in its entirety, the code now works as intended.
 
-=== Scope of Interactions
+==== Scope of Interactions
 
 Interactions declared in a `then:` block are scoped to the preceding `when:` block:
 
@@ -455,7 +455,7 @@ Interactions are always scoped to a particular feature method. Hence they cannot
 `setupSpec` method, or `cleanupSpec` method. Likewise, mock objects should not be stored in static or `@Shared`
 fields.
 
-=== Verification of Interactions
+==== Verification of Interactions
 
 There a two main ways in which a mock-based test can fail: An interaction can match more invocations than
 allowed, or it can match fewer invocations than required. The former case is detected right when the invocation
@@ -508,7 +508,7 @@ Unmatched invocations (ordered by similarity):
 1 * subscriber2.receive("hello")
 ----
 
-=== Invocation Order
+==== Invocation Order
 
 Often, the exact method invocation order isn't relevant and may change over time. To avoid over-specification,
 Spock defaults to allowing any invocation order, provided that the specified interactions are eventually satisfied:
@@ -541,7 +541,7 @@ In other words, invocation order is enforced _between_ but not _within_ `then:` 
 NOTE: Splitting up a `then:` block with `and:` does not impose any ordering, as `and:`
 is only meant for documentation purposes and doesn't carry any semantics.
 
-=== Mocking Classes
+==== Mocking Classes
 
 Besides interfaces, Spock also supports mocking of classes. Mocking classes works
 just like mocking interfaces; the only additional requirement is to put `cglib-nodep-2.2` or higher
@@ -552,7 +552,7 @@ NOTE: Java 8 is only supported from CGLIB 3.2 onwards, which has not been releas
 2015-03-02. As a temporary workaround, you can pull a prerelease version (e.g.
 `com.github.cglib:cglib.cglib-nodep:e10bc3dda2`) from Maven repository `https://jitpack.io`.
 
-== Stubbing
+=== Stubbing
 
 Stubbing is the act of making collaborators respond to method calls in a certain way. When stubbing
 a method, you don't care if and how many times the method is going to be called; you just want it to
@@ -594,7 +594,7 @@ A stubbed interaction can be declared in the usual places: either inside a `then
 it's common to declare interactions <<declaring-interactions-at-creation-time,at mock creation time>> or in a
 `setup:` block.
 
-=== Returning Fixed Values
+==== Returning Fixed Values
 
 We have already seen the use of the right-shift (`>>`) operator to return a fixed value:
 
@@ -615,7 +615,7 @@ This will return `"ok"` whenever `"message1"` is received, and `"fail"` whenever
 `"message2"` is received. There is no limit as to which values can be returned, provided they are
 compatible with the method's declared return type.
 
-=== Returning Sequences of Values
+==== Returning Sequences of Values
 
 To return different values on successive invocations, use the triple-right-shift (`>>>`) operator:
 
@@ -628,7 +628,7 @@ This will return `"ok"` for the first invocation, `"error"` for the second and t
 and `"ok"` for all remaining invocations. The right-hand side must be a value that Groovy knows how to iterate over;
 in this example, we've used a plain list.
 
-=== Computing Return Values
+==== Computing Return Values
 
 To compute a return value based on the method's argument, use the the right-shift (`>>`) operator together with a closure.
 If the closure declares a single untyped parameter, it gets passed the method's argument list:
@@ -655,7 +655,7 @@ If you find yourself in need of more information about a method invocation than 
 `org.spockframework.mock.IMockInvocation`. All methods declared in this interface are available inside the closure,
 without a need to prefix them. (In Groovy terminology, the closure _delegates_ to an instance of `IMockInvocation`.)
 
-=== Performing Side Effects
+==== Performing Side Effects
 
 Sometimes you may want to do more than just computing a return value. A typical example is
 throwing an exception. Again, closures come to the rescue:
@@ -668,7 +668,7 @@ subscriber.receive(_) >> { throw new InternalError("ouch") }
 Of course, the closure can contain more code, for example a `println` statement. It
 will get executed every time an incoming invocation matches the interaction.
 
-=== Chaining Method Responses
+==== Chaining Method Responses
 
 Method responses can be chained:
 
@@ -680,7 +680,7 @@ subscriber.receive(_) >>> ["ok", "fail", "ok"] >> { throw new InternalError() } 
 This will return `"ok", "fail", "ok"` for the first three invocations, throw `InternalError`
 for the fourth invocations, and return `ok` for any further invocation.
 
-== Combining Mocking and Stubbing
+=== Combining Mocking and Stubbing
 
 Mocking and stubbing go hand-in-hand:
 
@@ -715,14 +715,14 @@ get a chance to match.
 NOTE: Mocking and stubbing of the same method call has to happen in the same interaction.
 
 [[OtherKindsOfMockObjects]]
-== Other Kinds of Mock Objects (New in 0.7)
+=== Other Kinds of Mock Objects (New in 0.7)
 
 So far, we have created mock objects with the `MockingApi.Mock` method. Aside from
 this method, the `MockingApi` class provides a couple of other factory methods for creating
 more specialized kinds of mock objects.
 
 [[Stubs]]
-=== Stubs
+==== Stubs
 
 A _stub_ is created with the `MockingApi.Stub` factory method:
 
@@ -756,7 +756,7 @@ def subscriber = Stub(Subscriber) {
 ----
 
 [[Spies]]
-=== Spies
+==== Spies
 
 (Think twice before using this feature. It might be better to change the design of the code under specification.)
 
@@ -806,7 +806,7 @@ returns the real invocation's result, but in this example we opted to return our
 If we had wanted to pass a different message to the real method, we could have used `callRealMethodWithArgs("changed message")`.
 
 [[PartialMocks]]
-=== Partial Mocks
+==== Partial Mocks
 
 (Think twice before using this feature. It might be better to change the design of the code under specification.)
 
@@ -829,7 +829,7 @@ then:
 ----
 
 [[GroovyMocks]]
-== Groovy Mocks (New in 0.7)
+=== Groovy Mocks (New in 0.7)
 
 So far, all the mocking features we have seen work the same no matter if the calling code is written in Java or Groovy.
 By leveraging Groovy's dynamic capabilities, Groovy mocks offer some additional features specifically for testing Groovy code.
@@ -841,7 +841,7 @@ mock features are needed. When called from Java code, Groovy mocks will behave l
 isn't necessary to use a Groovy mock merely because the code under specification and/or mocked type is written
 in Groovy. Unless you have a concrete reason to use a Groovy mock, prefer a regular mock.
 
-=== Mocking Dynamic Methods
+==== Mocking Dynamic Methods
 
 All Groovy mocks implement the `GroovyObject` interface. They support the mocking and stubbing of
 dynamic methods as if they were physically declared methods:
@@ -854,7 +854,7 @@ def subscriber = GroovyMock(Subscriber)
 ----
 
 [[MockingAllInstancesOfAType]]
-=== Mocking All Instances of a Type
+==== Mocking All Instances of a Type
 
 (Think twice before using this feature. It might be better to change the design of the code under specification.)
 
@@ -900,7 +900,7 @@ Since a global Groovy mock is still based on a CGLIB proxy, it will retain its g
 ****
 
 [[MockingConstructors]]
-=== Mocking Constructors
+==== Mocking Constructors
 
 (Think twice before using this feature. It might be better to change the design of the code under specification.)
 
@@ -925,7 +925,7 @@ Now, whenever some code tries to construct a subscriber named Fred, we'll constr
 a subscriber named Barney instead.
 
 [MockingStaticMethods]
-=== Mocking Static Methods
+==== Mocking Static Methods
 
 (Think twice before using this feature. It might be better to change the design of the code under specification.)
 
@@ -948,12 +948,12 @@ the mock's instance isn't really needed. In such a case one can just write:
 GroovySpy(RealSubscriber, global: true)
 ----
 
-== Advanced Features (New in 0.7)
+=== Advanced Features (New in 0.7)
 
 Most of the time you shouldn't need these features. But if you do, you'll be glad to have them.
 
 [[ALaCarteMocks]]
-=== A la Carte Mocks
+==== A la Carte Mocks
 
 At the end of the day, the `Mock()`, `Stub()`, and `Spy()` factory methods are just canned ways to
 create mock objects with a certain configuration. If you want more fine-grained control over a mock's configuration,
@@ -971,7 +971,7 @@ verified (as for a `Stub()`). Instead of passing `ZeroOrNullResponse`, we could 
 `org.spockframework.mock.IDefaultResponse` for responding to unexpected method invocations.
 
 [[DetectingMockObjects]]
-=== Detecting Mock Objects
+==== Detecting Mock Objects
 
 To find out whether a particular object is a Spock mock object, use a `org.spockframework.mock.MockDetector`:
 
@@ -998,7 +998,7 @@ mock.type == List
 mock.nature == MockNature.MOCK
 ----
 
-== Further Reading
+=== Further Reading
 
 If you would like to dive deeper into interaction-based testing, we recommend the following resources:
 

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -1,5 +1,5 @@
 [[introduction]]
-= Introduction
+== Introduction
 
 Spock is a testing and specification framework for Java and Groovy applications. What makes it stand out from the crowd
 is its beautiful and highly expressive specification language. Thanks to its JUnit runner, Spock is compatible with most

--- a/docs/migration_guide.adoc
+++ b/docs/migration_guide.adoc
@@ -1,8 +1,8 @@
-= Migration Guide
+== Migration Guide
 
 This page explains incompatible changes between successive versions and provides suggestions on how to deal with them.
 
-== 1.0
+=== 1.0
 
 Specs, Spec base classes and third-party extensions may have be recompiled in order to work with Spock 1.0.
 
@@ -13,15 +13,15 @@ Make sure to pick the right binaries for your Groovy version of choice: `groovy-
 
 No known source incompatible changes.
 
-== 0.7
+=== 0.7
 
 Client code must be recompiled in order to work with Spock 0.7. This includes third-party Spock extensions and base classes.
 
 No known source incompatible changes.
 
-== 0.6
+=== 0.6
 
-=== Class initialization order
+==== Class initialization order
 
 NOTE: This only affects cases where one specification class inherits from another one.
 
@@ -66,7 +66,7 @@ class Derived extends Base {
 To overcome this problem, you can either use a field initializer for `base`, or move the assignment of `derived` into
 a setup method.
 
-=== `@Unroll` naming pattern syntax
+==== `@Unroll` naming pattern syntax
 
 NOTE: This is not a change from 0.5, but a change compared to 0.6-SNAPSHOT.
 
@@ -98,7 +98,7 @@ def "maximum of two numbers"() { ... }
 For various reasons, the new syntax didn't work out as we had hoped, and eventually we decided to go back to the string
 based syntax. See <<improved-unroll-0.6,Improved `@Unroll`>> for recent improvements to that syntax.
 
-=== Hamcrest matcher syntax
+==== Hamcrest matcher syntax
 
 NOTE: This only affects users moving from the Groovy 1.7 to the 1.8 or 2.0 variant.
 

--- a/docs/modules.adoc
+++ b/docs/modules.adoc
@@ -1,27 +1,27 @@
-= Modules
+== Modules
 
-== Guice Module
+=== Guice Module
 
 Integration with the http://code.google.com/p/google-guice/[Guice] IoC container. For examples see the specs in the
 https://github.com/spockframework/spock/tree/master/spock-guice/src/test/groovy/org/spockframework/guice[codebase].
 
-== Spring Module
+=== Spring Module
 
 Integration with the http://docs.spring.io/spring/docs/4.1.5.RELEASE/spring-framework-reference/html/testing.html#testcontext-framework[Spring TestContext Framework].
 For examples see the specs in the https://github.com/spockframework/spock/tree/master/spock-spring/src/test/groovy/org/spockframework/spring[codebase].
 
-== Tapestry Module
+=== Tapestry Module
 
 Integration with the http://tapestry.apache.org/tapestry5/[Tapestry5] IoC container. For examples see the specs in the
 https://github.com/spockframework/spock/tree/master/spock-tapestry/src/test/groovy/org/spockframework/tapestry[codebase].
 
 
-== Unitils Module
+=== Unitils Module
 
 Integration with the http://www.unitils.org/[Unitils] library. For examples see the specs in the
 https://github.com/spockframework/spock/tree/master/spock-unitils/src/test/groovy/org/spockframework/unitils/dbunit[codebase].
 
-== Grails Module
+=== Grails Module
 
 The Grails plugin has moved to its own https://github.com/spockframework/spock-grails[GitHub project].
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -1,6 +1,6 @@
-= Release Notes
+== Release Notes
 
-== 1.0 (released 2015-03-02)
+=== 1.0 (released 2015-03-02)
 
 1.0 has arrived! Finally (and some years late) the version number communicates what
 https://code.google.com/p/spock/wiki/WhoIsUsingSpock[Spock users] have known for ages - that Spock isn't only useful
@@ -12,7 +12,7 @@ Cédric Champeau, David Dawson, Rob Fletcher, Sean Gilligan, Ken Kousen, Guillau
 http://www.nofluffjuststuff.com/home/main[NFJS Tour], Graeme Rocher, Baruch Sadogursky, Odin Hole Standal,
 Howard M. Lewis Ship, Ken Sipe, Venkat Subramaniam, Russel Winder.
 
-=== What's New In This Release
+==== What's New In This Release
 
 * <<Contributors,17 contributors>>, <<Resolved Issues,21 resolved issues>>, <<Merged Pull Requests,18 merged pull requests>>,
   <<Ongoing Work,some ongoing work>>. No ground-breaking new features, but significant improvements and fixes across the board.
@@ -28,13 +28,13 @@ Howard M. Lewis Ship, Ken Sipe, Venkat Subramaniam, Russel Winder.
   http://builds.spockframework.org[Linux] CI builds, pull requests automatically tested, all development on `master`
   branch (bye-bye `groovy-x.y` branches!).
 
-=== Other News
+==== Other News
 
 * Follow our new http://twitter.spockframework.org[Twitter account]
 * Try these <<New Third Party Extensions,new third-party extensions>>
 * Check out the upcoming http://manning.com/kapelonis/[Java Testing with Spock] book from Manning
 
-=== What's Up Next?
+==== What's Up Next?
 
 With a revamped build/release process and a reforming core team, we hope to release much more frequently from now on.
 Another big focus will be to better involve the community and their valuable contributions. Last but not least, we are
@@ -46,7 +46,7 @@ The Spock Team
 
 '''
 
-=== Contributors
+==== Contributors
 
 17 awesome people contributed to this release:
 
@@ -68,7 +68,7 @@ The Spock Team
 * https://github.com/magdzikk[Magda Stożek]
 * https://github.com/rvarlikli[Ramazan VARLIKLI]
 
-=== Resolved Issues
+==== Resolved Issues
 
 21 burning issues were fixed:
 
@@ -94,7 +94,7 @@ The Spock Team
 * https://code.google.com/p/spock/issues/detail?id=392[Release binary variants for Groovy 2.3 and Groovy 2.4]
 * https://code.google.com/p/spock/issues/detail?id=393[Port reference documentation to Asciidoc]
 
-=== Merged Pull Requests
+==== Merged Pull Requests
 
 18 hand-crafted pull requests were merged or cherry-picked:
 
@@ -117,14 +117,14 @@ The Spock Team
 * https://github.com/spockframework/spock/pull/11[missing code]
 * https://github.com/spockframework/spock/pull/10[Support overriding Junit After*/Before* methods in the derived class](
 
-=== New Third Party Extensions
+==== New Third Party Extensions
 
 These awesome extensions have been published or updated:
 
 * https://github.com/marcingrzejszczak/spock-subjects-collaborators-extension[Spock Subjects-Collaborators Extension]
 * https://github.com/renatoathaydes/spock-reports[Spock Reports Extension]
 
-=== Ongoing Work
+==== Ongoing Work
 
 These great features didn't make it into this release (but hopefully the next!):
 
@@ -133,13 +133,13 @@ These great features didn't make it into this release (but hopefully the next!):
 * https://github.com/spockframework/spock/pull/50[Soft asserts: check all then throw all failures]
 * https://github.com/spockframework/spock/pull/17[Detached mocks]
 
-== 0.7 (released 2012-10-08)
+=== 0.7 (released 2012-10-08)
 
-=== Snapshot Repository Moved
+==== Snapshot Repository Moved
 
 Spock snapshots are now available from http://oss.sonatype.org/content/repositories/snapshots/.
 
-=== New Reference Documentation
+==== New Reference Documentation
 
 The new Spock reference documentation is available at http://docs.spockframework.org.
 It will gradually replace the documentation at http://wiki.spockframework.org.
@@ -148,7 +148,7 @@ Documentation for the latest Spock snapshot is at http://docs.spockframework.org
 As of Spock 0.7, the chapters on <<data_driven_testing.adoc#,Data Driven Testing>> and
 <<interaction_based_testing.adoc#,Interaction Based Testing>> are complete.
 
-=== Improved Mocking Failure Message for +TooManyInvocationsError+
+==== Improved Mocking Failure Message for +TooManyInvocationsError+
 
 The diagnostic message accompanying a +TooManyInvocationsError+ has been greatly improved.
 Here is an example:
@@ -167,7 +167,7 @@ Matching invocations (ordered by last occurrence):
 
 <<interaction_based_testing.adoc#ShowAllMatchingInvocations,Reference Documentation>>
 
-=== Improved Mocking Failure Message for `TooFewInvocationsError`
+==== Improved Mocking Failure Message for `TooFewInvocationsError`
 
 The diagnostic message accompanying a `TooFewInvocationsError` has been greatly improved.
 Here is an example:
@@ -186,7 +186,7 @@ Unmatched invocations (ordered by similarity):
 
 <<interaction_based_testing.adoc#ShowUnmatchedInvocations,Reference Documentation>>
 
-=== Stubs
+==== Stubs
 
 Besides mocks, Spock now has explicit support for stubs:
 
@@ -201,7 +201,7 @@ Using a stub over a mock is an effective way to communicate its role to readers 
 
 <<interaction_based_testing.adoc#Stubs,Reference Documentation>>
 
-=== Spies
+==== Spies
 
 Besides mocks, Spock now has support for spies:
 
@@ -217,7 +217,7 @@ change the behavior of the real object. Furthermore, spies can be used as partia
 <<interaction_based_testing.adoc#Spies,Reference Documentation>>
 
 
-=== Declaring Interactions at Mock Creation Time
+==== Declaring Interactions at Mock Creation Time
 
 Interactions can now be declared at mock creation time:
 
@@ -233,7 +233,7 @@ This feature is particularly attractive for <<Stubs>>.
 
 <<interaction_based_testing.adoc#declaring-interactions-at-creation-time,Reference Documentation>>
 
-=== Groovy Mocks
+==== Groovy Mocks
 
 Spock now offers specialized mock objects for spec'ing Groovy code:
 
@@ -250,7 +250,7 @@ rather than Groovy code, it behaves like a regular mock.
 
 <<interaction_based_testing.adoc#GroovyMocks,Reference Documentation>>
 
-=== Global Mocks
+==== Global Mocks
 
 A Groovy mock can be made _global_:
 
@@ -265,7 +265,7 @@ Furthermore, a global mock allows mocking of the type's constructors and static 
 
 <<interaction_based_testing.adoc#MockingAllInstancesOfAType,Reference Documentation>>
 
-=== Grouping Conditions with Same Target Object
+==== Grouping Conditions with Same Target Object
 
 Inspired from Groovy's `Object.with` method, the `Specification.with` method allows to group conditions
 involving the same target object:
@@ -282,7 +282,7 @@ with(person) {
 }
 ----
 
-=== Grouping Interactions with Same Target Object
+==== Grouping Interactions with Same Target Object
 
 The `with` method can also be used for grouping interactions:
 
@@ -304,7 +304,7 @@ with(service) {
 
 <<interaction_based_testing.adoc#GroupingInteractionsWithSameTarget,Reference Documentation>>
 
-=== Polling Conditions
+==== Polling Conditions
 
 `spock.util.concurrent.PollingConditions` joins `AsyncConditions` and `BlockingVariable(s)` as another utility for
 testing asynchronous code:
@@ -332,7 +332,7 @@ conditions.eventually {
 }
 ----
 
-=== Experimental DSL Support for Eclipse
+==== Experimental DSL Support for Eclipse
 
 Spock now ships with a DSL descriptor that lets Groovy Eclipse better
 understand certain parts of Spock's DSL. The descriptor is automatically
@@ -363,7 +363,7 @@ def person = Stub(Person) {
 DSL support is activated for Groovy Eclipse 2.7.1 and higher. If necessary,
 it can be deactivated in the Groovy Eclipse preferences.
 
-=== Experimental DSL Support for IntelliJ IDEA
+==== Experimental DSL Support for IntelliJ IDEA
 
 Spock now ships with a DSL descriptor that lets Intellij IDEA better
 understand certain parts of Spock's DSL. The descriptor is automatically
@@ -392,13 +392,13 @@ def person = Stub(Person) {
 
 DSL support is activated for IntelliJ IDEA 11.1 and higher.
 
-=== Splitting up Class Specification
+==== Splitting up Class Specification
 
 Parts of class `spock.lang.Specification` were pulled up into two new super classes: `spock.lang.MockingApi`
 now contains all mocking-related methods, and `org.spockframework.lang.SpecInternals` contains internal methods
 which aren't meant to be used directly.
 
-=== Improved Failure Messages for `notThrown` and `noExceptionThrown`
+==== Improved Failure Messages for `notThrown` and `noExceptionThrown`
 
 Instead of just passing through exceptions, `Specification.notThrown` and `Specification.noExceptionThrown`
 now fail with messages like:
@@ -409,7 +409,7 @@ Expected no exception to be thrown, but got 'java.io.FileNotFoundException'
 Caused by: java.io.FileNotFoundException: ...
 ----
 
-=== `HamcrestSupport.expect`
+==== `HamcrestSupport.expect`
 
 Class `spock.util.matcher.HamcrestSupport` has a new `expect` method that makes
 http://code.google.com/p/hamcrest/[Hamcrest] assertions read better in then-blocks:
@@ -423,19 +423,19 @@ then:
 expect x, closeTo(42, 0.01)
 ----
 
-=== @Beta
+==== @Beta
 
 Recently introduced classes and methods may be annotated with `@Beta`, as a sign that they may still undergo incompatible
 changes. This gives us a chance to incorporate valuable feedback from our users. (Yes, we need your feedback!) Typically,
 a `@Beta` annotation is removed within one or two releases.
 
-=== Fixed Issues
+==== Fixed Issues
 
 See the https://code.google.com/p/spock/issues/list?can=1&q=label%3AMilestone-0.7[issue tracker] for a list of fixed issues.
 
-== 0.6 (released 2012-05-02)
+=== 0.6 (released 2012-05-02)
 
-=== Mocking Improvements
+==== Mocking Improvements
 
 The mocking framework now provides better diagnostic messages in some cases.
 
@@ -460,7 +460,7 @@ import static spock.util.matcher.HamcrestMatchers.closeTo
 1 * foo.bar(closeTo(42, 0.001))
 ----
 
-=== Extended JUnit Rules Support
+==== Extended JUnit Rules Support
 
 In addition to rules implementing `org.junit.rules.MethodRule` (which has been deprecated in JUnit 4.9), Spock now also
 supports rules implementing the new `org.junit.rules.TestRule` interface. Also supported is the new `@ClassRule`
@@ -470,7 +470,7 @@ honor the `@Unroll` annotation and any defined naming pattern.
  
 See https://code.google.com/p/spock/issues/detail?id=240[Issue 240] for a known limitation with Spock's TestRule support.
 
-=== Condition Rendering Improvements
+==== Condition Rendering Improvements
 
 When two objects are compared with the `==` operator, they are unequal, but their string representations are the same,
 Spock will now print the objects' types:
@@ -482,27 +482,27 @@ enteredNumber == 42
 42 (java.lang.String)
 ----
 
-=== JUnit Fixture Annotations
+==== JUnit Fixture Annotations
 
 Fixture methods can now be declared with JUnit's `@Before`, `@After`, `@BeforeClass`, and `@AfterClass` annotations,
 as an addition or alternative to Spock's own fixture methods. This was particularly needed for Grails 2.0 support.
 
-=== Tapestry 5.3 Support
+==== Tapestry 5.3 Support
 
 Thanks to a contribution from http://howardlewisship.com/[Howard Lewis Ship], the Tapestry module is now compatible
 with Tapestry 5.3. Older 5.x versions are still supported.
 
-=== IBM JDK Support
+==== IBM JDK Support
 
 Spock now runs fine on IBM JDKs, working around a bug in the IBM JDK's verifier.
 
-=== Improved JUnit Compatibility
+==== Improved JUnit Compatibility
 
 `org.junit.internal.AssumptionViolatedException` is now recognized and handled as known from JUnit. `@Unrolled` methods
 no longer cause "yellow" nodes in IDEs.
 
 [[improved-unroll-0.6]]
-=== Improved `@Unroll`
+==== Improved `@Unroll`
 
 The `@Unroll` naming pattern can now be provided in the method name, instead of as an argument to the annotation:
 
@@ -530,7 +530,7 @@ def "#person.name.toUpperCase() is #person.age years old"() { ... }
 The `@Unroll` annotation can now be applied to a spec class. In this case, all data-driven feature methods in the class
 will be unrolled.
 
-=== Improved `@Timeout`
+==== Improved `@Timeout`
 
 The `@Timeout` annotation can now be applied to a spec class. In this case, the timeout applies to all feature methods
 (individually) that aren't already annotated with `@Timeout`. Timed methods are now executed on the regular test
@@ -540,7 +540,7 @@ Also the interruption behavior has been improved, to increase the chance that a 
 The failure exception that is thrown when a timeout occurs now contains the stacktrace of test execution, allowing you
 to see where the test was “stuck” or how far it got in the allocated time.
 
-=== Improved Data Table Syntax
+==== Improved Data Table Syntax
 
 Table cells can now be separated with double pipes. This can be used to visually set apart expected outputs from
 provided inputs:
@@ -554,14 +554,14 @@ a | b || sum
 3 | 1 || 4
 ----
 
-=== Groovy 1.8/2.0 Support
+==== Groovy 1.8/2.0 Support
 
 Spock 0.6 ships in three variants for Groovy 1.7, 1.8, and 2.0. Make sure to pick the right version - for example,
 for Groovy 1.8 you need to use spock-core-0.6-groovy-1.8 (likewise for all other modules). The Groovy 2.0 variant
 is based on Groovy 2.0-beta-3-SNAPSHOT and only available from http://m2repo.spockframework.org. The Groovy 1.7 and
 1.8 variants are also available from Maven Central. The next version of Spock will no longer support Groovy 1.7.
 
-=== Grails 2.0 Support
+==== Grails 2.0 Support
 
 Spock's Grails plugin was split off into a separate project and now lives at http://github.spockframework.org/spock-grails.
 The plugin supports both Grails 1.3 and 2.0.
@@ -569,13 +569,13 @@ The plugin supports both Grails 1.3 and 2.0.
 The Spock Grails plugin supports all of the new Grails 2.0 test mixins, effectively deprecating the existing unit
 testing classes (e.g. UnitSpec). For integration testing, IntegrationSpec must still be used.
 
-=== IntelliJ IDEA Integration
+==== IntelliJ IDEA Integration
 
 The folks from http://www.jetbrains.com[JetBrains] have added a few handy features around data tables. Data tables
 will now be layed out automatically when reformatting code. Data variables are no longer shown as "unknown" and have
 their types inferred from the values in the table (!).
 
-=== GitHub Repository
+==== GitHub Repository
 
 All source code has moved to http://github.spockframework.org/. The http://github.spockframework.org/spock-grails[Grails Spock plugin],
 http://github.spockframework.org/spock-example[Spock Example] project, and
@@ -583,13 +583,13 @@ http://github.spockframework.org/spockwebconsole[Spock Web Console] now have the
 Also available are slides and code for various Spock presentations (such as
 http://github.spockframework.org/smarter-testing-with-spock[this one]).
 
-=== Gradle Build
+==== Gradle Build
 
 Spock is now exclusively built with Gradle. Building Spock yourself is as easy as cloning the
 http://github.spockframework.org/spock[Github repo] and executing `gradlew build`. No build tool installation is
 required; the only prerequisite for building Spock is a JDK installation (1.5 or higher).
 
-=== Fixed Issues
+==== Fixed Issues
 
 See the https://code.google.com/p/spock/issues/list?can=1&q=label%3AMilestone-0.6[issue tracker] for a list of fixed issues.
 

--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -1,4 +1,4 @@
-= Spock Primer
+== Spock Primer
 
 This chapter assumes that you have a basic knowledge of Groovy and unit testing. If you are a Java developer but haven't
 heard about Groovy, don't worry - Groovy will feel very familiar to you! In fact, one of Groovy's main design goals is to
@@ -12,7 +12,7 @@ To learn more about Groovy, go to http://groovy-lang.org/.
 
 To learn more about unit testing, go to http://en.wikipedia.org/wiki/Unit_testing.
 
-== Terminology
+=== Terminology
 
 Let's start with a few definitions: Spock lets you write _specifications_ that describe expected _features_ (properties,
 aspects) exhibited by a system of interest. The system of interest could be anything between a single class and a whole
@@ -22,7 +22,7 @@ snapshot of the SUS and its collaborators; this snapshot is called the feature's
 The following sections walk you through all building blocks of which a Spock specification may be composed. A typical
 specification uses only a subset of them.
 
-== Imports
+=== Imports
 
 [source,groovy]
 ----
@@ -31,7 +31,7 @@ import spock.lang.*
 
 Package `spock.lang` contains the most important types for writing specifications.
 
-== Specification
+=== Specification
 
 [source,groovy]
 ----
@@ -51,7 +51,7 @@ Class `Specification` contains a number of useful methods for writing specificat
 run specification with `Sputnik`, Spock's JUnit runner. Thanks to Sputnik, Spock specifications can be run by most modern
 Java IDEs and build tools.
 
-== Fields
+=== Fields
 
 [source,groovy]
 ----
@@ -83,7 +83,7 @@ static final PI = 3.141592654
 Static fields should only be used for constants. Otherwise shared fields are preferable, because their semantics with
 respect to sharing are more well-defined.
 
-== Fixture Methods
+=== Fixture Methods
 
 [source,groovy]
 ----
@@ -100,7 +100,7 @@ fields together with the `setupSpec()` and `cleanupSpec()` methods. All fixture 
 
 Note: The `setupSpec()` and `cleanupSpec()` methods may not reference instance fields.
 
-== Feature Methods
+=== Feature Methods
 
 [source,groovy]
 ----
@@ -123,7 +123,7 @@ Conceptually, a feature method consists of four phases:
 Whereas the first and last phases are optional, the stimulus and response phases are always present (except in
 interacting feature methods), and may occur more than once.
 
-=== Blocks
+==== Blocks
 
 Spock has built-in support for implementing each of the conceptual phases of a feature method. To this end, feature
 methods are structured into so-called _blocks_. Blocks start with a label, and extend to the beginning of the next block,
@@ -141,7 +141,7 @@ The picture on the right shows how blocks map to the conceptual phases of a feat
 special role, which will be revealed shortly. But first, let's have a closer look at the other blocks.
 --
 
-==== Setup Blocks
+===== Setup Blocks
 
 [source,groovy]
 ----
@@ -155,7 +155,7 @@ other blocks, and may not be repeated. A `setup` block doesn't have any special 
 optional and may be omitted, resulting in an _implicit_ `setup` block. The `given:` label is an alias for `setup:`,
 and sometimes leads to a more readable feature method description (see <<specs-as-doc,Specifications as Documentation>>).
 
-==== When and Then Blocks
+===== When and Then Blocks
 
 [source,groovy]
 ----
@@ -167,7 +167,7 @@ The `when` and `then` blocks always occur together. They describe a stimulus and
 blocks may contain arbitrary code, `then` blocks are restricted to _conditions_, _exception conditions_, _interactions_,
 and variable definitions. A feature method may contain multiple pairs of `when-then` blocks.
 
-===== Conditions
+====== Conditions
 
 Conditions describe an expected state, much like JUnit's assertions. However, conditions are written as plain boolean
 expressions, eliminating the need for an assertion API. (More precisely, a condition may also produce a non-boolean
@@ -205,7 +205,7 @@ stack.size() == 2
 As you can see, Spock captures all values produced during the evaluation of a condition, and presents them in an easily
 digestible form. Nice, isn't it?
 
-===== Implicit and explicit conditions
+====== Implicit and explicit conditions
 
 Conditions are an essential ingredient of `then` blocks and `expect` blocks. Except for calls to `void` methods and
 expressions classified as interactions, all top-level expressions in these blocks are implicitly treated as conditions.
@@ -221,7 +221,7 @@ def setup() {
 
 If an explicit condition is violated, it will produce the same nice diagnostic message as an implicit condition.
 
-===== Exception Conditions
+====== Exception Conditions
 
 Exception conditions are used to describe that a `when` block should throw an exception. They are defined using the
 `thrown()` method, passing along the expected exception type. For example, to describe that popping from an empty stack
@@ -300,7 +300,7 @@ By using `notThrown()`, we make it clear that in particular a `NullPointerExcept
 contract of `Map.put()`, this would be the right thing to do for a map that doesn't support `null` keys.) However,
 the method will also fail if any other exception is thrown.
 
-===== Interactions
+====== Interactions
 
 Whereas conditions describe an object's state, interactions describe how objects communicate with each other.
 Interactions are devoted a whole <<interaction_based_testing.adoc#,chapter>>, and so we only give a quick example here.
@@ -324,7 +324,7 @@ def "events are published to all subscribers"() {
 }
 ----
 
-==== Expect Blocks
+===== Expect Blocks
 
 An `expect` block is more limited than a `then` block in that it may only contain conditions and variable definitions.
 It is useful in situations where it is more natural to describe stimulus and expected response in a single expression.
@@ -351,7 +351,7 @@ to describe methods with side effects, and `expect` to describe purely functiona
 TIP: Leverage http://docs.groovy-lang.org/docs/latest/html/groovy-jdk/[Groovy JDK] methods like `any()` and `every()`
 to create more expressive and succinct conditions.
 
-==== Cleanup Blocks
+===== Cleanup Blocks
 
 [source,groovy]
 ----
@@ -380,7 +380,7 @@ block to clean up the file system, close a database connection, or shut down a n
 TIP: If a specification is designed in such a way that all its feature methods require the same resources, use a
 `cleanup()` method; otherwise, prefer `cleanup` blocks. The same trade-off applies to `setup()` methods and `setup` blocks.
 
-==== Where Blocks
+===== Where Blocks
 
 A `where` block always comes last in a method, and may not be repeated. It is used to write data-driven feature methods.
 To give you an idea how this is done, have a look at the following example:
@@ -405,7 +405,7 @@ Although it is declared last the `where` block is evaluated before feature metho
 
 The `where` block will be further explained in the <<data_driven_testing.adoc#,Data Driven Testing>> chapter.
 
-== Helper Methods
+=== Helper Methods
 
 Sometimes feature methods grow large and/or contain lots of duplicated code. In such cases it can make sense to introduce
 one or more helper methods. Two good candidates for helper methods are setup/cleanup logic and complex conditions.
@@ -491,7 +491,7 @@ and helper methods can increase the coupling between feature methods. If you reu
 end up with specifications that are fragile and hard to evolve.
 
 [[specs-as-doc]]
-== Specifications as Documentation
+=== Specifications as Documentation
 
 Well-written specifications are a valuable source of information. Especially for higher-level specifications targeting
 a wider audience than just developers (architects, domain experts, customers, etc.), it makes sense to provide more
@@ -541,7 +541,7 @@ As noted before, `given:` is just an alias for `setup:`.
 Block descriptions are not only present in source code, but are also available to the Spock runtime. Planned usages of
 block descriptions are enhanced diagnostic messages, and textual reports that are equally understood by all stakeholders.
 
-== Extensions
+=== Extensions
 
 As we have seen, Spock offers lots of functionality for writing specifications. However, there always comes a time
 when something else is needed. Therefore, Spock provides an interception-based extension mechanism. Extensions are
@@ -560,7 +560,7 @@ used (like specifying the behavior of exception conditions). In all other cases,
 
 To learn how to implement your own directives and extensions, go to the <<extensions.adoc#,Extensions>> chapter.
 
-== Comparison to JUnit
+=== Comparison to JUnit
 
 Although Spock uses a different terminology, many of its concepts and features are inspired from JUnit. Here is a rough
 comparison:


### PR DESCRIPTION
Created all_in_one.adoc to create a single page documentation (Issue #65)
Moved all headings one level down to fix asciidoctor error: only docbook type can contain level 0 sections
