### PR TITLE
Updated fixture methods inheritance explanation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{java,groovy,gradle,xml}]
+indent_style = space
+indent_size = 2

--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -401,7 +401,7 @@ def "computing the maximum of two numbers"() {
 This `where` block effectively creates two "versions" of the feature method: One where `a` is 5, `b` is 1, and `c` is 5,
 and another one where `a` is 3, `b` is 9, and `c` is 9.
 
-The `where` block will be further explained in the <<data_driven_testing.adoc#,Data Driven Testing>> chapter.
+The `where` block is called before the `setup` block. The `where` block will be further explained in the <<data_driven_testing.adoc#,Data Driven Testing>> chapter.
 
 == Helper Methods
 

--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -98,7 +98,11 @@ Usually it's a good idea to use a fresh fixture for every feature method, which 
 methods are for. Occasionally it makes sense for feature methods to share a fixture, which is achieved by using shared
 fields together with the `setupSpec()` and `cleanupSpec()` methods. All fixture methods are optional.
 
-Note: The `setupSpec()` and `cleanupSpec()` methods may not reference instance fields. Fixture methods overridden in subclasses will be executed like class constructors.
+Note:
+
+. The `setupSpec()` and `cleanupSpec()` methods may not reference instance fields.
+. In case Specificiation inheritance is being done and fixture methods are overridden then `setup()` of super class will run before `setup()` of sub class. `cleanup()` works in reverse order i.e. `cleanup()` of sub class will execute before `cleanup()` of super class.  `setupSpec()` and `cleanupSpec()` will work on similar lines. 
+
 
 === Feature Methods
 

--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -401,7 +401,7 @@ def "computing the maximum of two numbers"() {
 This `where` block effectively creates two "versions" of the feature method: One where `a` is 5, `b` is 1, and `c` is 5,
 and another one where `a` is 3, `b` is 9, and `c` is 9.
 
-The `where` block is called before the `setup` block. The `where` block will be further explained in the <<data_driven_testing.adoc#,Data Driven Testing>> chapter.
+The `where` block will be further explained in the <<data_driven_testing.adoc#,Data Driven Testing>> chapter.
 
 == Helper Methods
 


### PR DESCRIPTION
Added that "Fixture methods overridden in subclasses will be executed like class constructors."