### PR TITLE
PolingCondition: IAE timeout value is negative

### DIFF
--- a/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
+++ b/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
@@ -163,7 +163,10 @@ public class PollingConditions {
           String msg = String.format("Condition not satisfied after %1.2f seconds and %d attempts", elapsedTime / 1000d, attempts);
           throw new SpockTimeoutError(seconds, msg, e);
         }
-        Thread.sleep(Math.min(currDelay, start + timeoutMillis - System.currentTimeMillis()));
+        final long timeout = Math.min(currDelay, start + timeoutMillis - System.currentTimeMillis());
+        if (timeout > 0) {
+          Thread.sleep(timeout);
+        }
         currDelay *= factor;
       }
     }

--- a/spock-specs/src/test/groovy/spock/util/concurrent/PollingConditionsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/concurrent/PollingConditionsSpec.groovy
@@ -118,5 +118,20 @@ class PollingConditionsSpec extends Specification {
     spans[0] < spans[1]
     spans[1] < spans[2]
   }
+
+  def "work normally for long-running conditions"() {
+    when:
+    def condition = new PollingConditions(timeout: 4)
+    boolean secondAttempt = false
+    then:
+    condition.eventually {
+      try {
+        sleep 5000;
+        assert secondAttempt;
+      } finally {
+        secondAttempt = true
+      }
+    }
+  }
 }
 

--- a/spock-specs/src/test/groovy/spock/util/concurrent/PollingConditionsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/concurrent/PollingConditionsSpec.groovy
@@ -119,7 +119,7 @@ class PollingConditionsSpec extends Specification {
     spans[1] < spans[2]
   }
 
-  def "work normally for long-running conditions"() {
+  def "correctly handles checks that take longer than given check interval"() {
     when:
     def condition = new PollingConditions(timeout: 4)
     boolean secondAttempt = false


### PR DESCRIPTION
Old topic:
https://groups.google.com/forum/#!topic/spockframework/FNPguVWDqWs

If executing condition closure takes longer that timeout, IAE will be produced.

```
java.lang.IllegalArgumentException: timeout value is negative
at spock.util.concurrent.PollingConditions.within(PollingConditions.java:166)
at spock.util.concurrent.PollingConditions.eventually(PollingConditions.java:134)
```

