### PR TITLE
Fix the normalize method in ReportLogExtensionSpec

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
@@ -18,6 +18,8 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.spockframework.EmbeddedSpecification
 
+import java.util.regex.Matcher
+
 class ReportLogExtensionSpec extends EmbeddedSpecification {
   @Rule TemporaryFolder tempDir
   def logFile
@@ -249,6 +251,6 @@ loadLogFile([{
   }
 
   private String normalize(String str) {
-    str.trim().replaceAll("\\d", "X").replaceAll("(\\\\r\\\\n|\\\\n)", "\\n")
+    str.trim().replaceAll("\\d", "X").replaceAll("(\\\\r\\\\n|\\\\n)", Matcher.quoteReplacement("\\n"))
   }
 }


### PR DESCRIPTION
Fix the normalize method using Matcher.quoteReplacement to avoid ambiguities between n and \n