### PR TITLE
Set groovy-all dependency to provided

### DIFF
--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -11,7 +11,7 @@ Thanks to its JUnit runner, Spock is compatible with most IDEs, build tools, and
 Spock is inspired from JUnit, jMock, RSpec, Groovy, Scala, Vulcans, and other fascinating life forms."
 
 dependencies {
-  compile libs.groovy // easiest way to add Groovy dependency to POM
+  compile libs.groovy, provided // easiest way to add Groovy dependency to POM
   compile libs.junit
 
   compile libs.ant, optional


### PR DESCRIPTION
Set groovy-all dependency to provided to allow easier usage of indy version of groovy

Fixes #71
