### PR TITLE
Partial mocks for interfaces with default methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,17 @@ subprojects {
     }
   }
 
+  sourceSets.all { ss ->
+    for (jv in javaVersions.findAll { it <= javaVersion } ) {
+      java {
+        srcDir "src/${ss.name}.java$jv/java"
+      }
+      groovy {
+        srcDir "src/${ss.name}.java$jv/groovy"
+      }
+    }
+  }
+
   repositories {
     mavenCentral()
     maven { url "https://oss.jfrog.org/oss-snapshot-local/" }

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -21,6 +21,17 @@ idea {
     outputFile = file(outputFile.path.replace(".ipr", "-${variant}.ipr"))
     configure(modules) { module ->
       def prj = module.project
+      if(prj.name == "spock-specs") {
+        module.iml {
+          withXml {
+            def node = it.asNode()
+            def comp = node.component.find{it.@name == 'NewModuleRootManager'}
+            if(comp) {
+              comp.@LANGUAGE_LEVEL = "JDK_$javaVersion".replace('.', '_')
+            }
+          }
+        }
+      }      
       excludeDirs = prj.files(allLevelDirs) as Set
       if (prj == prj.rootProject) {
         excludeDirs += allLevelDirs.collect { prj.file("buildSrc/$it") }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/DefaultMethodInvoker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/DefaultMethodInvoker.java
@@ -62,8 +62,8 @@ public class DefaultMethodInvoker implements IResponseGenerator {
 
       // Get the method MethodHandle.invokeWithArguments(Object...)
       invokeWithArgumentsMethod = boundHandle.getClass().getMethod("invokeWithArguments", Object[].class);
-    } catch (Throwable t) {
-      throw new CannotCreateMockException(target.getClass(), "Failed to invoke default method '" + method.getName() + "'", t);
+    } catch (Exception e) {
+      throw new CannotCreateMockException(target.getClass(), "Failed to invoke default method '" + method.getName() + "'", e);
     }
 
     // Call boundHandle.invokeWithArguments(arguments), sneaky throwing possible exceptions

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/DefaultMethodInvoker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/DefaultMethodInvoker.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.mock.runtime;
+
+import org.spockframework.mock.CannotCreateMockException;
+import org.spockframework.mock.IMockInvocation;
+import org.spockframework.mock.IResponseGenerator;
+import org.spockframework.util.ReflectionUtil;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class DefaultMethodInvoker implements IResponseGenerator {
+  private final Object target;
+  private final Method method;
+  private final Object[] arguments;
+
+  public DefaultMethodInvoker(Object target, Method method, Object[] arguments) {
+    this.target = target;
+    this.method = method;
+    this.arguments = arguments;
+  }
+
+  public Object respond(IMockInvocation invocation) {
+    // This implementation uses classes from the java.lang.invoke package in order to invoke a default method.
+    // Without exception handling, the implementation is analogous to the following code:
+    //      final Field field = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
+    //      field.setAccessible(true);
+    //      final MethodHandles.Lookup implLookup = (MethodHandles.Lookup) field.get(null);
+    //      return implLookup.unreflectSpecial(method, method.getDeclaringClass()).bindTo(target).invokeWithArguments((Object)arguments);
+    // The java.lang.invoke package is only available since Java 7. In order to preserve the compatibility of spock-core
+    // with older versions of Java, we rewrite the above code using reflection.
+
+    Object boundHandle = null;
+    Method invokeWithArgumentsMethod = null;
+    try {
+      // Get the private field Lookup.IMPL_LOOKUP, which is maximally privileged
+      Class<?> lookupClass = Class.forName("java.lang.invoke.MethodHandles$Lookup");
+      final Field field = lookupClass.getDeclaredField("IMPL_LOOKUP");
+      field.setAccessible(true);
+      Object implLookup = field.get(null);
+
+      // Get a method handle for the default method
+      Method unreflectSpecialMethod = lookupClass.getMethod("unreflectSpecial", Method.class, Class.class);
+      Object specialHandle = unreflectSpecialMethod.invoke(implLookup, method, method.getDeclaringClass());
+
+      // Get a bound handle that prepends the target to the original arguments
+      Method bindToMethod = specialHandle.getClass().getMethod("bindTo", Object.class);
+      boundHandle = bindToMethod.invoke(specialHandle, target);
+
+      // Get the method MethodHandle.invokeWithArguments(Object...)
+      invokeWithArgumentsMethod = boundHandle.getClass().getMethod("invokeWithArguments", Object[].class);
+    } catch (Throwable t) {
+      throw new CannotCreateMockException(target.getClass(), "Failed to invoke default method '" + method.getName() + "'", t);
+    }
+
+    // Call boundHandle.invokeWithArguments(arguments), sneaky throwing possible exceptions
+    Object result = ReflectionUtil.invokeMethod(boundHandle, invokeWithArgumentsMethod, (Object)arguments);
+    return result;
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/DynamicProxyMockInterceptorAdapter.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/DynamicProxyMockInterceptorAdapter.java
@@ -27,9 +27,7 @@ public class DynamicProxyMockInterceptorAdapter implements InvocationHandler {
   }
 
   public Object invoke(Object target, Method method, Object[] arguments) throws Throwable {
-    boolean isDefault = (method.getModifiers() & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) == Modifier.PUBLIC
-      && method.getDeclaringClass().isInterface();
-    if(isDefault) {
+    if(isDefault(method)) {
       // The commented out code below uses classes from the java.lang.invoke package, which is only available since Java 7.
       // In order to preserve the compatibility of spock-core with older versions of Java, we rewrite this code using reflection.
       // Since the current if-block is executed only when handling a default method, and since default methods have benn
@@ -58,4 +56,18 @@ public class DynamicProxyMockInterceptorAdapter implements InvocationHandler {
     return interceptor.intercept(target, method, arguments,
         new FailingRealMethodInvoker("Cannot invoke real method on interface based mock object"));
   }
+
+  /**
+   * Returns {@code true} if the argument {@code m} is a default method; returns {@code false} otherwise.
+   * <br/>This method is used instead of {@link Method#isDefault()} in order to preserve the compatibility with Java versions prior to java 8.
+   *
+   * @param m the method to be checked whether it is default or not
+   * @return true if and only if the argument {@code m} is a default method as defined by the Java Language Specification.
+   */
+  public static boolean isDefault(Method m) {
+    // Default methods are public non-abstract instance methods declared in an interface.
+    return ((m.getModifiers() & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) ==
+      Modifier.PUBLIC) && m.getDeclaringClass().isInterface();
+  }
+
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/DynamicProxyMockInterceptorAdapter.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/DynamicProxyMockInterceptorAdapter.java
@@ -30,7 +30,7 @@ public class DynamicProxyMockInterceptorAdapter implements InvocationHandler {
   public Object invoke(Object target, Method method, Object[] arguments) throws Throwable {
     IResponseGenerator realMethodInvoker = (ReflectionUtil.isDefault(method) || ReflectionUtil.isObjectMethod(method))
       ? new DefaultMethodInvoker(target, method, arguments)
-      : new FailingRealMethodInvoker("Cannot invoke real method on interface based mock object");
+      : new FailingRealMethodInvoker("Cannot invoke real method '" + method.getName() + "' on interface based mock object");
     return interceptor.intercept(target, method, arguments, realMethodInvoker);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/DynamicProxyMockInterceptorAdapter.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/DynamicProxyMockInterceptorAdapter.java
@@ -14,10 +14,11 @@
 
 package org.spockframework.mock.runtime;
 
-import java.lang.reflect.Field;
+import org.spockframework.mock.IResponseGenerator;
+import org.spockframework.util.ReflectionUtil;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 public class DynamicProxyMockInterceptorAdapter implements InvocationHandler {
   private final IProxyBasedMockInterceptor interceptor;
@@ -27,47 +28,9 @@ public class DynamicProxyMockInterceptorAdapter implements InvocationHandler {
   }
 
   public Object invoke(Object target, Method method, Object[] arguments) throws Throwable {
-    if(isDefault(method)) {
-      // The commented out code below uses classes from the java.lang.invoke package, which is only available since Java 7.
-      // In order to preserve the compatibility of spock-core with older versions of Java, we rewrite this code using reflection.
-      // Since the current if-block is executed only when handling a default method, and since default methods have benn
-      // introduced in Java 8, we can safely assume that the java.lang.invoke classes are available at run time.
-/*
-      final Field field = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
-      field.setAccessible(true);
-      final MethodHandles.Lookup lookup = (MethodHandles.Lookup) field.get(null);
-      final Object result = lookup
-        .unreflectSpecial(method, method.getDeclaringClass())
-        .bindTo(target)
-        .invokeWithArguments();
-*/
-      Class<?> lookupClass = Class.forName("java.lang.invoke.MethodHandles$Lookup");
-      final Field field = lookupClass.getDeclaredField("IMPL_LOOKUP");
-      field.setAccessible(true);
-      Object implLookup = field.get(null);
-      Method unreflectSpecialMethod = lookupClass.getMethod("unreflectSpecial", Method.class, Class.class);
-      Object specialHandle = unreflectSpecialMethod.invoke(implLookup, method, method.getDeclaringClass());
-      Method bindToMethod = specialHandle.getClass().getMethod("bindTo", Object.class);
-      Object bindHandle = bindToMethod.invoke(specialHandle, target);
-      Method invokeWithArgumentsMethod = bindHandle.getClass().getMethod("invokeWithArguments", Object[].class);
-      Object result = invokeWithArgumentsMethod.invoke(bindHandle, (Object)new Object[0]);
-      return result;
-    }
-    return interceptor.intercept(target, method, arguments,
-        new FailingRealMethodInvoker("Cannot invoke real method on interface based mock object"));
+    IResponseGenerator realMethodInvoker = (ReflectionUtil.isDefault(method) || ReflectionUtil.isObjectMethod(method))
+      ? new DefaultMethodInvoker(target, method, arguments)
+      : new FailingRealMethodInvoker("Cannot invoke real method on interface based mock object");
+    return interceptor.intercept(target, method, arguments, realMethodInvoker);
   }
-
-  /**
-   * Returns {@code true} if the argument {@code m} is a default method; returns {@code false} otherwise.
-   * <br/>This method is used instead of {@link Method#isDefault()} in order to preserve the compatibility with Java versions prior to java 8.
-   *
-   * @param m the method to be checked whether it is default or not
-   * @return true if and only if the argument {@code m} is a default method as defined by the Java Language Specification.
-   */
-  public static boolean isDefault(Method m) {
-    // Default methods are public non-abstract instance methods declared in an interface.
-    return ((m.getModifiers() & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) ==
-      Modifier.PUBLIC) && m.getDeclaringClass().isInterface();
-  }
-
 }

--- a/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
@@ -65,6 +65,26 @@ public abstract class ReflectionUtil {
   }
 
   /**
+   * Returns {@code true} if the argument {@code m} is a default method; returns {@code false} otherwise.
+   * <br/>This method is used instead of {@link Method#isDefault()} in order to preserve the compatibility with Java versions prior to Java 8.
+   *
+   * @param m the method to be checked whether it is default or not
+   * @return true if and only if the argument {@code m} is a default method as defined by the Java Language Specification.
+   */
+  public static boolean isDefault(Method m) {
+    // Default methods are public non-abstract instance methods declared in an interface.
+    return ((m.getModifiers() & (Modifier.ABSTRACT | Modifier.PUBLIC | Modifier.STATIC)) ==
+      Modifier.PUBLIC) && m.getDeclaringClass().isInterface();
+  }
+
+  /**
+   * Returns {@code true} if the argument {@code m} is a public method of java.lang.Object.
+   */
+  public static boolean isObjectMethod(Method m) {
+    return Arrays.asList(Object.class.getMethods()).contains(m);
+  }
+
+  /**
    * Finds a public method with the given name declared in the given
    * class/interface or one of its super classes/interfaces. If multiple such
    * methods exists, it is undefined which one is returned.
@@ -134,7 +154,7 @@ public abstract class ReflectionUtil {
   }
 
   public static boolean hasAnyOfTypes(Object value, Class<?>... types) {
-    for (Class<?> type : types) 
+    for (Class<?> type : types)
       if (type.isInstance(value)) return true;
 
     return false;

--- a/spock-specs/specs.gradle
+++ b/spock-specs/specs.gradle
@@ -22,7 +22,10 @@ dependencies {
   junit libs.junit
 }
 
-// necessary to make @NotYetImplemented transform work (transform that ships 
+sourceCompatibility = javaVersion
+targetCompatibility = javaVersion
+
+// necessary to make @NotYetImplemented transform work (transform that ships
 // with Groovy and statically references third-party class junit.framwork.AssertionFailedError)
 tasks.withType(GroovyCompile) {
 	groovyClasspath += configurations.junit

--- a/spock-specs/src/test.java1.8/groovy/org/spockframework/smoke/mock/PartialMockingInterfacesWithDefaultMethods.groovy
+++ b/spock-specs/src/test.java1.8/groovy/org/spockframework/smoke/mock/PartialMockingInterfacesWithDefaultMethods.groovy
@@ -1,0 +1,96 @@
+package org.spockframework.smoke.mock
+
+import spock.lang.Specification
+
+class PartialMockingInterfacesWithDefaultMethods extends Specification {
+  def "ISquare area should be computed using the stubbed length - test with when: and then: blocks"() {
+    given:
+    ISquare square = Spy() {
+      2 * getLength() >> 3
+    }
+
+    when:
+    def area = square.area
+
+    then:
+    area == 9
+  }
+
+  def "ISquare area should be computed using the stubbed length - test with when:, then: and where: blocks"() {
+    given:
+    ISquare square = Spy() {
+      2 * getLength() >> len
+    }
+
+    when:
+    def area = square.area
+
+    then:
+    area == ar
+
+    where:
+    len | ar
+      3 |  9
+      5 | 25
+      7 | 49
+  }
+
+  def "ISquare area should be computed using the stubbed length - test with when: and then: blocks and various stub values"() {
+    given:
+    ISquare square = Spy() {
+      2 * getLength() >> 3
+      2 * getLength() >> 5
+      2 * getLength() >> 7
+    }
+
+    when:
+    def area1 = square.area
+    def area2 = square.area
+    def area3 = square.area
+
+    then:
+    area1 == 9
+    area2 == 25
+    area3 == 49
+  }
+
+  def "ISquare area should be computed using the stubbed length - test with expect: block"() {
+    given:
+    ISquare square = Spy() {
+      2 * getLength() >> 3
+    }
+
+    expect:
+    square.area == 9
+  }
+
+  def "ISquare area should be computed using the stubbed length - test with expect: and where: blocks"() {
+    given:
+    ISquare square = Spy() {
+      2 * getLength() >> len
+    }
+
+    expect:
+    square.area == ar
+
+    where:
+    len | ar
+      3 |  9
+      5 | 25
+      7 | 49
+  }
+
+  def "ISquare area should be computed using the stubbed length - test with expect: block and various stub values"() {
+    given:
+    ISquare square = Spy() {
+      2 * getLength() >> 3
+      2 * getLength() >> 5
+      2 * getLength() >> 7
+    }
+
+    expect:
+    square.area == 9
+    square.area == 25
+    square.area == 49
+  }
+}

--- a/spock-specs/src/test.java1.8/groovy/org/spockframework/smoke/mock/PartialMockingInterfacesWithDefaultMethods.groovy
+++ b/spock-specs/src/test.java1.8/groovy/org/spockframework/smoke/mock/PartialMockingInterfacesWithDefaultMethods.groovy
@@ -1,6 +1,23 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.spockframework.smoke.mock
 
 import spock.lang.Specification
+import static spock.util.matcher.HamcrestMatchers.closeTo
 
 class PartialMockingInterfacesWithDefaultMethods extends Specification {
   def "ISquare area should be computed using the stubbed length - test with when: and then: blocks"() {
@@ -93,4 +110,57 @@ class PartialMockingInterfacesWithDefaultMethods extends Specification {
     square.area == 25
     square.area == 49
   }
+
+
+  def "IQuarterlyCompoundedDeposit: compound interest should be computed using the stubbed annual nominal interest rate"() {
+    given:
+    IQuarterlyCompoundedDeposit deposit = Spy() {
+      1 * getAnnualNominalInterestRate() >> 0.043
+    }
+
+    when:
+    def compoundInterest = deposit.getCompoundInterest(1500, 6)
+
+    then:
+    compoundInterest closeTo(438.84, 0.01)
+  }
+
+  def "IQuarterlyCompoundedDeposit: compound interest should be computed using the stubbed annual nominal interest rate and the stubbed compounding periods per year"() {
+    given:
+    IQuarterlyCompoundedDeposit deposit = Spy() {
+      1 * getAnnualNominalInterestRate() >> 0.129  // stubbing an abstract method
+      1 * getCompoundingPeriodsPerYear() >> 12     // stubbing a default method
+    }
+
+    expect:
+    (deposit.getCompoundInterest(1500, 2)) closeTo(438.84, 0.01)
+  }
+
+
+  def "IQuarterlyCompoundedDeposit: should throw unchecked exception for negative values of principalAmount"() {
+    given:
+    IQuarterlyCompoundedDeposit deposit = Spy() {
+      getAnnualNominalInterestRate() >> 0.043
+    }
+
+    when:
+    deposit.getCompoundInterest(-1500, 6)
+
+    then:
+    thrown(IllegalArgumentException)
+  }
+
+  def "IQuarterlyCompoundedDeposit: should throw checked exception for negative values of numberOfYears"() {
+    given:
+    IQuarterlyCompoundedDeposit deposit = Spy() {
+      getAnnualNominalInterestRate() >> 0.043
+    }
+
+    when:
+    deposit.getCompoundInterest(1500, -6)
+
+    then:
+    thrown(IDeposit.DepositException)
+  }
+
 }

--- a/spock-specs/src/test.java1.8/java/org/spockframework/smoke/mock/IDeposit.java
+++ b/spock-specs/src/test.java1.8/java/org/spockframework/smoke/mock/IDeposit.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.mock;
+
+/**
+ * A bank deposit with <a href="https://en.wikipedia.org/wiki/Compound_interest">compound interest</a>.
+ */
+public interface IDeposit {
+  public static class DepositException extends Exception {
+    public DepositException(String message) {
+      super(message);
+    }
+  }
+
+  double getAnnualNominalInterestRate();
+  double getCompoundingPeriodInMonths();
+
+  default double getCompoundingPeriodsPerYear() {
+    return 12 / getCompoundingPeriodInMonths();
+  }
+
+  default double getBalance(double principalAmount, double numberOfYears) throws DepositException {
+    if(principalAmount < 0) throw new IllegalArgumentException("Invalid principalAmount: " + principalAmount);
+    if(numberOfYears < 0) throw new DepositException("Invalid numberOfYears: " + numberOfYears);
+    double j = getAnnualNominalInterestRate();
+    double n = getCompoundingPeriodsPerYear();
+    return principalAmount * Math.pow(1 + j / n, n * numberOfYears);
+  }
+
+  default double getCompoundInterest(double principalAmount, double numberOfYears) throws DepositException {
+    return getBalance(principalAmount, numberOfYears) - principalAmount;
+  }
+}

--- a/spock-specs/src/test.java1.8/java/org/spockframework/smoke/mock/IQuarterlyCompoundedDeposit.java
+++ b/spock-specs/src/test.java1.8/java/org/spockframework/smoke/mock/IQuarterlyCompoundedDeposit.java
@@ -16,10 +16,8 @@
 
 package org.spockframework.smoke.mock;
 
-public interface ISquare {
-  int getLength();
-
-  default int getArea() {
-    return getLength() * getLength();
+public interface IQuarterlyCompoundedDeposit extends IDeposit {
+  default double getCompoundingPeriodInMonths() {
+    return 3;
   }
 }

--- a/spock-specs/src/test.java1.8/java/org/spockframework/smoke/mock/ISquare.java
+++ b/spock-specs/src/test.java1.8/java/org/spockframework/smoke/mock/ISquare.java
@@ -1,0 +1,9 @@
+package org.spockframework.smoke.mock;
+
+public interface ISquare {
+  int getLength();
+
+  default int getArea() {
+    return getLength() * getLength();
+  }
+}


### PR DESCRIPTION
Right now, the `Spy` method can be used to create a partial mock for an abstract class, as shown in the following gist: https://gist.github.com/siordache/2113afe4e381a005c4b8.

The current pull request adds the ability to create a partial mock for an interface with default methods, as shown in the following gist: https://gist.github.com/siordache/74c77618e4caceac94e9.

This pull request changes only the `DynamicProxyMockInterceptorAdapter` class. Although default methods are available only since Java 8, the code changes introduced by this pull request preserve the Java 6 compatibility.

The pull request does not contain Spock specifications for testing the new feature, because they would require Java 8. What is your opinion about requiring Java 8 for the `spock-specs` module and sticking with Java 6 for the other ones?
