### PR TITLE
Adding block listener support

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
@@ -91,7 +91,7 @@ public class SpecParser implements GroovyClassVisitor {
 
   public void visitMethod(MethodNode method) {
     if (isIgnoredMethod(method)) return;
-    
+
     if (isFixtureMethod(method))
       buildFixtureMethod(method);
     else if (isFeatureMethod(method))
@@ -111,7 +111,7 @@ public class SpecParser implements GroovyClassVisitor {
       if (!fmName.equalsIgnoreCase(name)) continue;
 
       // assertion: is (meant to be) a fixture method, so we'll return true in the end
-      
+
       if (method.isStatic())
         errorReporter.error(method, "Fixture methods must not be static");
       if (!fmName.equals(name))
@@ -172,7 +172,7 @@ public class SpecParser implements GroovyClassVisitor {
     spec.getMethods().add(feature);
   }
 
-  private void buildHelperMethod(MethodNode method) {  
+  private void buildHelperMethod(MethodNode method) {
     Method helper = new HelperMethod(spec, method);
     spec.getMethods().add(helper);
 
@@ -192,7 +192,7 @@ public class SpecParser implements GroovyClassVisitor {
       else
         currBlock = addBlock(method, stat);
     }
-    
+
     checkIsValidSuccessor(method, BlockParseInfo.METHOD_END,
         method.getAst().getLastLineNumber(), method.getAst().getLastColumnNumber());
 
@@ -212,8 +212,13 @@ public class SpecParser implements GroovyClassVisitor {
       String description = getDescription(stat);
       if (description == null)
         block.getAst().add(stat);
-      else
+      else {
+        if(block.getName().equalsIgnoreCase("when") || block.getName().equalsIgnoreCase("then")
+          || block.getName().equalsIgnoreCase("setup")) {
+          block.getAst().add(stat);
+        }
         block.getDescriptions().add(description);
+      }
 
       return block;
 		}

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -356,7 +356,10 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
   public void visitWhenBlock(WhenBlock block) throws Exception {
     updateNotify("when", block);
+  }
 
+  public void visitSetupBlock(SetupBlock block) throws Exception {
+    updateNotify("setup", block);
   }
 
   public void visitThenBlock(ThenBlock block) {
@@ -604,7 +607,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
     for (Expression elementExpr : tupleExpr.getExpressions()) {
       Variable variable = (Variable) elementExpr;
       listExpr.addExpression(new ConstantExpression(
-          ReflectionUtil.getDefaultValue(variable.getOriginType().getTypeClass())));
+        ReflectionUtil.getDefaultValue(variable.getOriginType().getTypeClass())));
     }
 
     return listExpr;

--- a/spock-core/src/main/java/org/spockframework/report/log/ReportLogEmitter.java
+++ b/spock-core/src/main/java/org/spockframework/report/log/ReportLogEmitter.java
@@ -77,10 +77,14 @@ class ReportLogEmitter implements IRunListener, IStandardStreamsListener {
     specFailed = false;
 
     emit(putAll(mapOf(
-        "package", spec.getPackage(),
-        "name", spec.getName(),
-        "start", getCurrentTime()
+      "package", spec.getPackage(),
+      "name", spec.getName(),
+      "start", getCurrentTime()
     ), renderNarrative(spec.getNarrative()), renderTags(spec.getTags())));
+  }
+
+  public void block(String type, String description) {
+//    System.out.println(type+description);
   }
 
   public void beforeFeature(FeatureInfo feature) {

--- a/spock-core/src/main/java/org/spockframework/runtime/AbstractRunListener.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/AbstractRunListener.java
@@ -26,4 +26,5 @@ public class AbstractRunListener implements IRunListener {
   public void error(ErrorInfo error) {}
   public void specSkipped(SpecInfo spec) {}
   public void featureSkipped(FeatureInfo feature) {}
+  public void block(String type, String description) {}
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/AsyncRunListener.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/AsyncRunListener.java
@@ -66,7 +66,11 @@ public class AsyncRunListener implements IRunListener, IStoppable {
       public void run() {
         delegate.beforeSpec(spec);
       }
-    });  
+    });
+  }
+
+  public void block(String type, String description) {
+    delegate.block(type, description);
   }
 
   public void beforeFeature(final FeatureInfo feature) {

--- a/spock-core/src/main/java/org/spockframework/runtime/AsyncRunListener.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/AsyncRunListener.java
@@ -68,9 +68,12 @@ public class AsyncRunListener implements IRunListener, IStoppable {
       }
     });
   }
-
-  public void block(String type, String description) {
-    delegate.block(type, description);
+  public void block(final String type, final String description) {
+    addEvent(new Runnable() {
+      public void run() {
+        delegate.block(type, description);
+      }
+    });
   }
 
   public void beforeFeature(final FeatureInfo feature) {

--- a/spock-core/src/main/java/org/spockframework/runtime/IRunListener.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IRunListener.java
@@ -31,6 +31,11 @@ public interface IRunListener {
   void beforeSpec(SpecInfo spec);
 
   /**
+   * Called when a block is reached.
+   */
+  void block(String type,String description);
+
+  /**
    * Called before each feature of a spec.
    */
   void beforeFeature(FeatureInfo feature);
@@ -71,7 +76,7 @@ public interface IRunListener {
   // IDEA: might be able to remove remaining two methods and
   // call before/after instead, since skip flag should be set on
   // SpecInfo/FeatureInfo anyway
-  
+
   /**
    * Called if a spec is skipped, for example because it is marked
    * with @Ignore.

--- a/spock-core/src/main/java/org/spockframework/runtime/MasterRunListener.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/MasterRunListener.java
@@ -29,6 +29,12 @@ public class MasterRunListener implements IRunListener {
     }
   }
 
+  public void block(String type, String description) {
+    for (IRunListener listener : spec.getListeners()) {
+      listener.block(type, description);
+    }
+  }
+
   public void beforeFeature(FeatureInfo feature) {
     for (IRunListener listener : spec.getListeners()) {
       listener.beforeFeature(feature);

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
@@ -58,6 +58,7 @@ So that bar
       then: "baz"
       println("out2")
 
+
       and: "bazbaz"
       System.err.println("err2")
     }
@@ -109,7 +110,6 @@ loadLogFile([{
 
   def "write execution log for spec with failing feature"() {
     runner.throwFailure = false
-
     when:
     runner.runWithImports(
         """


### PR DESCRIPTION
Hey,
  I've added a  pull request that adds when/then block notification support.
 I'm planning to use them internally for dynamic report generation (descriptions with variable expansion) by customizing the existing support.
 Is this something  that interests the community ? If yes, I can allocate some time to add implement any feedback that comes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/111)
<!-- Reviewable:end -->
