### PR TITLE
Spock table param order validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,14 +39,15 @@ ext {
   fullVersion = "$baseVersion-groovy-$variant" + (snapshotVersion ? "-SNAPSHOT" : "")
   variantLessVersion = baseVersion + (snapshotVersion ? "-SNAPSHOT" : "")
   libs = [
-    ant: "org.apache.ant:ant:1.9.4",
-    asm: "org.ow2.asm:asm:5.0.3",
-    cglib: "cglib:cglib-nodep:3.1",
-    groovy: "org.codehaus.groovy:groovy-all:$groovyVersion",
-    h2database: "com.h2database:h2:1.3.174",
-    junit: "junit:junit:4.12",
-    log4j: "log4j:log4j:1.2.17",
-    objenesis: "org.objenesis:objenesis:2.1"
+    ant        : "org.apache.ant:ant:1.9.4",
+    annotations: 'com.intellij:annotations:12.0',
+    asm        : "org.ow2.asm:asm:5.0.3",
+    cglib      : "cglib:cglib-nodep:3.1",
+    groovy     : "org.codehaus.groovy:groovy-all:$groovyVersion",
+    h2database : "com.h2database:h2:1.3.174",
+    junit      : "junit:junit:4.12",
+    log4j      : "log4j:log4j:1.2.17",
+    objenesis  : "org.objenesis:objenesis:2.1"
   ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ description = "Spock Framework"
 
 ext {
   variants = [2.0, 2.3, 2.4]
-  variant = System.getProperty("variant") as BigDecimal ?: variants.first()
+  variant = System.getProperty("variant") as BigDecimal ?: variants.last()
   if (variant == 2.0) {
     groovyVersion = "2.0.8"
     minGroovyVersion = "2.0.0"
@@ -26,7 +26,7 @@ ext {
     minGroovyVersion = "2.3.0"
     maxGroovyVersion = "2.3.99"
   } else if (variant == 2.4) {
-    groovyVersion = "2.4.1"
+    groovyVersion = "2.4.4"
     minGroovyVersion = "2.4.0"
     maxGroovyVersion = "2.9.99"
   } else {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-bin.zip

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -13,6 +13,7 @@ Spock is inspired from JUnit, jMock, RSpec, Groovy, Scala, Vulcans, and other fa
 dependencies {
   compile libs.groovy // easiest way to add Groovy dependency to POM
   compile libs.junit
+  compile libs.annotations
 
   compile libs.ant, optional
   compile libs.asm, optional
@@ -25,13 +26,13 @@ jar {
     name = 'spock-core'
     instruction 'Export-Package', 'org.spockframework.*', 'spock.*'
     instruction 'Embed-Dependency', 'groovy;inline=false', 'junit;inline=false'
-    instruction 'Import-Package', 
-        'org.objenesis;version="[1,2)";resolution:=optional', 
-        'org.apache.tools.ant;version="[1,2)";resolution:=optional', 
+    instruction 'Import-Package',
+        'org.objenesis;version="[1,2)";resolution:=optional',
+        'org.apache.tools.ant;version="[1,2)";resolution:=optional',
         'org.apache.tools.ant.types;version="[1,2)";resolution:=optional',
-        'net.sf.cglib.proxy;version="[2.2,2)";resolution:=optional', 
+        'net.sf.cglib.proxy;version="[2.2,2)";resolution:=optional',
         'org.apache.tools.ant.types.selectors;version="[1.7,2)";resolution:=optional',
-		'groovy.lang;version="[1.8,3)"', 'org.codehaus.groovy.*;version="[1.8,3)"', 
+		'groovy.lang;version="[1.8,3)"', 'org.codehaus.groovy.*;version="[1.8,3)"',
         'org.junit.runner;version="[4,7)"'
   }
 }

--- a/spock-core/src/main/groovy/spock/util/EmbeddedSpecCompiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/EmbeddedSpecCompiler.groovy
@@ -83,13 +83,13 @@ class EmbeddedSpecCompiler {
     doCompile "package apackage; $imports ${source.trim()}"
   }
 
-  Class compileSpecBody(@Language(value = 'Groovy', prefix = 'class ASpec extends spock.lang.Specification { ', suffix = '}')
+  Class compileSpecBody(@Language(value = 'Groovy', prefix = 'class ASpec extends spock.lang.Specification { ', suffix = '\n}')
                         String source) {
     // one-liner keeps line numbers intact; newline safeguards against source ending in a line comment
     compileWithImports("class ASpec extends Specification { ${source.trim() + '\n'} }")[0]
   }
 
-  Class compileFeatureBody(@Language(value = 'Groovy', prefix = "def 'a feature'() { ", suffix = '}')
+  Class compileFeatureBody(@Language(value = 'Groovy', prefix = "def 'a feature'() { ", suffix = '\n}')
                            String source) {
     // one-liner keeps line numbers intact; newline safeguards against source ending in a line comment
     compileSpecBody "def 'a feature'() { ${source.trim() + '\n'} }"

--- a/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
+++ b/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
@@ -99,12 +99,12 @@ class EmbeddedSpecRunner {
     runClasses(compiler.compileWithImports(source))
   }
 
-  Result runSpecBody(@Language(value = 'Groovy', prefix = 'class ASpec extends spock.lang.Specification { ', suffix = '}')
+  Result runSpecBody(@Language(value = 'Groovy', prefix = 'class ASpec extends spock.lang.Specification { ', suffix = '\n}')
                      String source) {
     runClass(compiler.compileSpecBody(source))
   }
 
-  Result runFeatureBody(@Language(value = 'Groovy', prefix = "def 'a feature'() { ", suffix = '}')
+  Result runFeatureBody(@Language(value = 'Groovy', prefix = "def 'a feature'() { ", suffix = '\n}')
                         String source) {
     runClass(compiler.compileFeatureBody(source))
   }

--- a/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
+++ b/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
@@ -16,13 +16,15 @@
 
 package spock.util
 
+import org.intellij.lang.annotations.Language
+import org.junit.runner.JUnitCore
+import org.junit.runner.Request
+import org.junit.runner.Result
 import org.junit.runner.notification.RunListener
-import org.junit.runner.*
-
-import org.spockframework.util.NotThreadSafe
-import org.spockframework.util.IThrowableFunction
-import org.spockframework.runtime.RunContext
 import org.spockframework.runtime.ConfigurationScriptLoader
+import org.spockframework.runtime.RunContext
+import org.spockframework.util.IThrowableFunction
+import org.spockframework.util.NotThreadSafe
 
 import java.lang.reflect.Modifier
 
@@ -39,7 +41,7 @@ class EmbeddedSpecRunner {
   boolean throwFailure = true
 
   List<RunListener> listeners = []
-  
+
   Closure configurationScript = null
   List<Class> extensionClasses = []
   boolean inheritParentExtensions = true
@@ -97,11 +99,13 @@ class EmbeddedSpecRunner {
     runClasses(compiler.compileWithImports(source))
   }
 
-  Result runSpecBody(String source) {
+  Result runSpecBody(@Language(value = 'Groovy', prefix = 'class ASpec extends spock.lang.Specification { ', suffix = '}')
+                     String source) {
     runClass(compiler.compileSpecBody(source))
   }
 
-  Result runFeatureBody(String source) {
+  Result runFeatureBody(@Language(value = 'Groovy', prefix = "def 'a feature'() { ", suffix = '}')
+                        String source) {
     runClass(compiler.compileFeatureBody(source))
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedSpecRunner.java
@@ -114,7 +114,14 @@ public class ParameterizedSpecRunner extends BaseSpecRunner {
     if (runStatus != OK) return;
 
     while (haveNext(iterators)) {
-      initializeAndRunIteration(nextArgs(iterators).toArray(), estimatedNumIterations);
+      List<Object> dataValues = new ArrayList<Object>(nextArgs(iterators));
+
+      /* TODO should we take default parameter values into consideration instead? */
+      for (int i = dataValues.size(); i < currentFeature.getDataVariables().size(); i++) {
+        dataValues.add(null);
+      }
+
+      initializeAndRunIteration(dataValues.toArray(), estimatedNumIterations);
 
       if (resetStatus(ITERATION) != OK) break;
       // no iterators => no data providers => only derived parameterizations => limit to one iteration

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -50,14 +50,10 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
     this.executionOrder = executionOrder;
   }
 
-  public List<String> getParameterNames() {
-    return parameterNames;
-  }
-
   public void addParameterName(String parameterName) {
     parameterNames.add(parameterName);
   }
-  
+
   public List<String> getDataVariables() {
     return parameterNames; // currently the same
   }
@@ -109,7 +105,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   public boolean isReportIterations() {
     return reportIterations;
   }
-  
+
   public void setReportIterations(boolean flag) {
     reportIterations = flag;
   }
@@ -118,7 +114,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   public NameProvider<IterationInfo> getIterationNameProvider() {
     return iterationNameProvider;
   }
-  
+
   public void setIterationNameProvider(NameProvider<IterationInfo> provider) {
     iterationNameProvider = provider;
   }

--- a/spock-core/src/main/java/org/spockframework/util/ObjectUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ObjectUtil.java
@@ -38,13 +38,22 @@ public abstract class ObjectUtil {
   public static Class<?> voidAwareGetClass(Object obj) {
     return obj == null ? void.class : obj.getClass();
   }
-  
+
   public static boolean eitherNull(Object... objs) {
     for (Object obj: objs) {
       if (obj == null) return true;
     }
     return false;
   }
+
+  public static <T> T firstNonNull(T... objs) {
+    for (T obj : objs) {
+      if (obj != null)
+        return obj;
+    }
+    throw new IllegalArgumentException("All elements were null!");
+  }
+
 
   @SuppressWarnings("unchecked")
   public static @Nullable <T> T asInstance(Object obj, Class<T> type) {

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/ClosingOfDataProviders.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/ClosingOfDataProviders.groovy
@@ -25,7 +25,7 @@ class ClosingOfDataProviders extends Specification {
     MyCloseable provider = Mock()
 
     when:
-    runner.closeDataProviders(provider)
+    runner.closeDataProviders([provider])
 
     then:
     1 * provider.close() >> { action() }
@@ -40,7 +40,7 @@ class ClosingOfDataProviders extends Specification {
     java.io.Closeable provider2 = Mock()
 
     when:
-    runner.closeDataProviders(provider1, provider2)
+    runner.closeDataProviders([provider1, provider2])
 
     then:
     1 * provider1.close() >> { action() }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/EstimatedNumberOfIterations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/EstimatedNumberOfIterations.groovy
@@ -23,26 +23,26 @@ class EstimatedNumberOfIterations extends Specification {
 
   def "w/o data provider"() {
     expect: "estimation is 1"
-      runner.estimateNumIterations(new Object[0]) == 1
+      runner.estimateNumIterations([]) == 1
   }
 
   def "w/ data provider that doesn't respond to size"() {
     expect: "estimation is 'unknown', represented as -1"
-      runner.estimateNumIterations([1] as Object[]) == -1
+      runner.estimateNumIterations([1]) == -1
   }
 
   def "w/ data provider that responds to size"() {
     expect: "estimation is size"
-      runner.estimateNumIterations([[1, 2, 3]] as Object[]) == 3
+      runner.estimateNumIterations([[1, 2, 3]]) == 3
   }
 
   def "w/ multiple data providers, all of which respond to size"() {
     expect: "estimation is minimum"
-      runner.estimateNumIterations([[1], [1, 2], [1, 2, 3]] as Object[]) == 1
+      runner.estimateNumIterations([[1], [1, 2], [1, 2, 3]]) == 1
   }
 
   def "w/ multiple data providers, one of which doesn't respond to size"() {
   expect: "estimation is minimum of others"
-    runner.estimateNumIterations([1, [1, 2], [1, 2, 3]] as Object[]) == 2
+    runner.estimateNumIterations([1, [1, 2], [1, 2, 3]]) == 2
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -15,12 +15,10 @@
 package org.spockframework.smoke.parameterization
 
 import org.junit.internal.runners.model.MultipleFailureException
-
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.compiler.InvalidSpecCompileException
 import org.spockframework.runtime.SpockExecutionException
-
-import spock.lang.*
+import spock.lang.Shared
 
 class DataTables extends EmbeddedSpecification {
   static staticField = 42
@@ -139,16 +137,19 @@ class DataTables extends EmbeddedSpecification {
   def 'parameters must have same order as the table header'() {
     when:
     compiler.compileSpecBody '''
-      def 'invalid parameter order'(b, a) {
-        expect: a != b
-        where:  a | b
-                1 | 2
+      def 'invalid parameter order'(b, a, c, d) {
+        expect: true
+        where:  a << [1]
+
+                b | c
+                2 | 3
+
+                d = c + 1
       }
     '''
 
     then:
-    MultipleFailureException e = thrown()
-    e.failures*.class == [InvalidSpecCompileException] * 3
+    thrown InvalidSpecCompileException
   }
 
   def 'pseudo-column can be omitted from parameter list'(a) {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -18,6 +18,7 @@ import org.junit.internal.runners.model.MultipleFailureException
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.compiler.InvalidSpecCompileException
 import org.spockframework.runtime.SpockExecutionException
+import spock.lang.Ignore
 import spock.lang.Shared
 
 class DataTables extends EmbeddedSpecification {
@@ -250,19 +251,14 @@ class DataTables extends EmbeddedSpecification {
     thrown MissingPropertyException
   }
 
-  def 'cells cannot reference other cells'() {
-    when:
-    runner.runFeatureBody '''
+  @Ignore /* @PendingFeature */
+  def 'cells can reference previous cells'() {
       expect:
-      true
+      column3 == 3
 
       where:
-      first   | second
-      'dummy' | first + ' value'
-    '''
-
-    then:
-    thrown MissingPropertyException
+      column1 | column2     | column3
+      1       | column1 + 1 | column1 + column2
   }
 
   def 'rows must have same number of elements as header'() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -69,15 +69,6 @@ class MethodParameters extends EmbeddedSpecification {
     y << [1, 2]
   }
 
-  def "parameters in different order"(y, x) {
-    expect:
-    x == y
-
-    where:
-    x << [1, 2]
-    y << [1, 2]
-  }
-
   def "fewer parameters than data variables"() {
     when:
     compiler.compileSpecBody """

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -69,78 +69,37 @@ class MethodParameters extends EmbeddedSpecification {
     y << [1, 2]
   }
 
-  def "fewer parameters than data variables"() {
+  def 'more parameters than data variables'(x, y, z) {
     when:
-    compiler.compileSpecBody """
-def foo(x) {
-  expect:
-  x == y
-
-  where:
-  x << [1, 2]
-  y << [1, 2]
-}
-    """
+    z = 1
 
     then:
-    thrown(InvalidSpecCompileException)
-  }
-
-
-  def "more parameters than data variables"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x, y, z) {
-  expect:
-  x == y
-
-  where:
-  x << [1, 2]
-  y << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-  }
-
-  def "parameter that is not a data variable"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x, a) {
-  expect:
-  x == x
-
-  where:
-  x << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-  }
-
-  def "data variable that is not a parameter"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x) {
-  expect:
-  x == y
-
-  where:
-  $parameterizations
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
+    x == z
+    y == z
 
     where:
-    parameterizations << [
-        "x << [1,2]; y << [1, 2]",
-        "[x, y] << [[1, 2], [1, 2]]",
-        "x << [1, 2]; y = x"
-    ]
+    x | y
+    1 | 1
+  }
+
+  def 'extra parameters are type safe'(x, y, TreeMap<BigInteger, BigDecimal> z, boolean primitive) {
+    when:
+    z = [(1): 3]
+    primitive = true
+
+    then:
+    z instanceof TreeMap
+    z == [(1): 3]
+
+    primitive instanceof Boolean
+    primitive == true
+
+    x == y
+
+    where:
+    x | y
+    1 | 1
+    2 | 2
   }
 
   def "data value type can be coerced to parameter type"(x, String y) {


### PR DESCRIPTION
Where blocks in Spock tests can contain tables with variable name headers.
To make them `@TypeChecked` or `@CompileStatic`, these params should be declared in the method parameter list also.

However, the Spock Where block rewriter (compiler) didn't check for the order of the params, causing hard to debug scenarios.

In this commit I added a check for parameter names' order, in case the where block only contained a table.

Example of an invalid test:

```Groovy
def 'invalid parameter order'(b, a) {
  expect: a != b
  where:  a | b
          1 | 2
}
```

which will give a compile error now!