### PR TITLE
Added @Language to String source code params

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ ext {
   fullVersion = "$baseVersion-groovy-$variant" + (snapshotVersion ? "-SNAPSHOT" : "")
   variantLessVersion = baseVersion + (snapshotVersion ? "-SNAPSHOT" : "")
   libs = [
+    jetbrainsAnnotations: "org.jetbrains:annotations:13.0",
     ant: "org.apache.ant:ant:1.9.4",
     asm: "org.ow2.asm:asm:5.0.3",
     cglib: "cglib:cglib-nodep:3.1",

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -5,15 +5,16 @@ apply from: script("publishMaven")
 
 displayName = "Spock Framework - Core Module"
 
-description = "Spock is a testing and specification framework for Java and Groovy applications. \
-What makes it stand out from the crowd is its beautiful and highly expressive specification language. \
-Thanks to its JUnit runner, Spock is compatible with most IDEs, build tools, and continuous integration servers. \
-Spock is inspired from JUnit, jMock, RSpec, Groovy, Scala, Vulcans, and other fascinating life forms."
+description = '''Spock is a testing and specification framework for Java and Groovy applications.
+What makes it stand out from the crowd is its beautiful and highly expressive specification language.
+Thanks to its JUnit runner, Spock is compatible with most IDEs, build tools, and continuous integration servers.
+Spock is inspired from JUnit, jMock, RSpec, Groovy, Scala, Vulcans, and other fascinating life forms.'''
 
 dependencies {
   compile libs.groovy // easiest way to add Groovy dependency to POM
   compile libs.junit
 
+  compile libs.jetbrainsAnnotations, optional
   compile libs.ant, optional
   compile libs.asm, optional
   compile libs.cglib, optional
@@ -31,7 +32,7 @@ jar {
         'org.apache.tools.ant.types;version="[1,2)";resolution:=optional',
         'net.sf.cglib.proxy;version="[2.2,2)";resolution:=optional', 
         'org.apache.tools.ant.types.selectors;version="[1.7,2)";resolution:=optional',
-		'groovy.lang;version="[1.8,3)"', 'org.codehaus.groovy.*;version="[1.8,3)"', 
+        'groovy.lang;version="[1.8,3)"', 'org.codehaus.groovy.*;version="[1.8,3)"', 
         'org.junit.runner;version="[4,7)"'
   }
 }

--- a/spock-core/src/main/groovy/spock/util/EmbeddedSpecCompiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/EmbeddedSpecCompiler.groovy
@@ -17,6 +17,7 @@
 package spock.util
 
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 import org.junit.internal.runners.model.MultipleFailureException
 import org.junit.runner.RunWith
@@ -72,27 +73,29 @@ class EmbeddedSpecCompiler {
    * Compiles the given source code, and returns all Spock specifications
    * contained therein (but not other classes).
    */
-  List<Class> compile(String source) {
+  List<Class> compile(@Language('Groovy') String source) {
     doCompile(imports + source)
   }
 
-  List<Class> compileWithImports(String source) {
+  List<Class> compileWithImports(@Language('Groovy') String source) {
     addPackageImport(Specification.package )
     // one-liner keeps line numbers intact
     doCompile "package apackage; $imports ${source.trim()}"
   }
 
-  Class compileSpecBody(String source) {
+  Class compileSpecBody(@Language(value = 'Groovy', prefix = 'class ASpec extends spock.lang.Specification { ', suffix = '\n }')
+                        String source) {
     // one-liner keeps line numbers intact; newline safeguards against source ending in a line comment
     compileWithImports("class ASpec extends Specification { ${source.trim() + '\n'} }")[0]
   }
 
-  Class compileFeatureBody(String source) {
+  Class compileFeatureBody(@Language(value = 'Groovy', prefix = "def 'a feature'() { ", suffix = '\n }')
+                           String source) {
     // one-liner keeps line numbers intact; newline safeguards against source ending in a line comment
     compileSpecBody "def 'a feature'() { ${source.trim() + '\n'} }"
   }
 
-  private List<Class> doCompile(String source) {
+  private List<Class> doCompile(@Language('Groovy') String source) {
     loader.clearCache()
 
     try {

--- a/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
+++ b/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
@@ -16,6 +16,7 @@
 
 package spock.util
 
+import org.intellij.lang.annotations.Language
 import org.junit.runner.notification.RunListener
 import org.junit.runner.*
 
@@ -89,19 +90,21 @@ class EmbeddedSpecRunner {
     }
   }
 
-  Result run(String source) {
+  Result run(@Language('Groovy') String source) {
     runClasses(compiler.compile(source))
   }
 
-  Result runWithImports(String source) {
+  Result runWithImports(@Language('Groovy') String source) {
     runClasses(compiler.compileWithImports(source))
   }
 
-  Result runSpecBody(String source) {
+  Result runSpecBody(@Language(value = 'Groovy', prefix = 'class ASpec extends spock.lang.Specification { ', suffix = '\n }')
+                     String source) {
     runClass(compiler.compileSpecBody(source))
   }
 
-  Result runFeatureBody(String source) {
+  Result runFeatureBody(@Language(value = 'Groovy', prefix = "def 'a feature'() { ", suffix = '\n }')
+                        String source) {
     runClass(compiler.compileFeatureBody(source))
   }
 

--- a/spock-core/src/main/java/org/spockframework/util/inspector/AstInspector.java
+++ b/spock-core/src/main/java/org/spockframework/util/inspector/AstInspector.java
@@ -26,6 +26,7 @@ import org.codehaus.groovy.ast.stmt.*;
 import org.codehaus.groovy.control.*;
 
 import groovy.lang.GroovyClassLoader;
+import org.intellij.lang.annotations.Language;
 import org.spockframework.compiler.AstUtil;
 
 /**
@@ -131,9 +132,9 @@ public class AstInspector {
    * phase and stores the resulting AST for subsequent inspection.
    *
    * @param sourceText the source text to compile
-   * @throws CompilationFailedException if an error occurrs during compilation
+   * @throws CompilationFailedException if an error occurs during compilation
    */
-  public void load(String sourceText) throws CompilationFailedException {
+  public void load(@Language("Groovy") String sourceText) throws CompilationFailedException {
     reset();
     
     try {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitFixtureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitFixtureMethods.groovy
@@ -14,6 +14,7 @@
 
 package org.spockframework.smoke.junit
 
+import org.intellij.lang.annotations.Language
 import org.spockframework.EmbeddedSpecification
 
 import spock.lang.*
@@ -191,7 +192,7 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
     """
   }
 
-  protected run(String source) {
+  protected run(@Language('Groovy') String source) {
     addImports()
     runner.runWithImports(source)
   }


### PR DESCRIPTION

![language](https://cloud.githubusercontent.com/assets/1841944/9776659/65579f8e-5763-11e5-9790-a09cadf9b35d.png)
By annotating parameters with @Language('Groovy') we will have IDE support
(e.g. syntax check and highlighting) for inlined languages (mostly used in tests)