### PR TITLE
Fix data driven testing example in documentation

### DIFF
--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -62,7 +62,7 @@ class Math extends Specification {
         where:
         a | b | c
         1 | 3 | 3
-        7 | 4 | 4
+        7 | 4 | 7
         0 | 0 | 0
     }
 }


### PR DESCRIPTION
`Math.max(7, 4)` should return `7`, not `4`. Fixing this example also makes it consistent with the previous `MathSpec` example it is improving upon.