### PR TITLE
Implemented partial parameter definitions

### DIFF
--- a/spock-core/src/main/java/org/spockframework/util/ObjectUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ObjectUtil.java
@@ -46,6 +46,14 @@ public abstract class ObjectUtil {
     return false;
   }
 
+  public static <T> T firstNonNull(T... objs) {
+    for (T obj : objs) {
+      if (obj != null)
+        return obj;
+    }
+    throw new IllegalArgumentException("All elements were null!");
+  }
+
   @SuppressWarnings("unchecked")
   public static @Nullable <T> T asInstance(Object obj, Class<T> type) {
     return type.isInstance(obj) ? (T) obj : null;

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -18,7 +18,6 @@ package org.spockframework.smoke.parameterization
 
 import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 import org.spockframework.EmbeddedSpecification
-import org.spockframework.compiler.InvalidSpecCompileException
 
 /**
  * @author Peter Niederwieser
@@ -68,80 +67,6 @@ class MethodParameters extends EmbeddedSpecification {
     x << [1, 2]
     y << [1, 2]
   }
-  
-  def "fewer parameters than data variables"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x) {
-  expect:
-  x == y
-
-  where:
-  x << [1, 2]
-  y << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-  }
-
-
-  def "more parameters than data variables"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x, y, z) {
-  expect:
-  x == y
-
-  where:
-  x << [1, 2]
-  y << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-  }
-
-  def "parameter that is not a data variable"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x, a) {
-  expect:
-  x == x
-
-  where:
-  x << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-  }
-
-  def "data variable that is not a parameter"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x) {
-  expect:
-  x == y
-
-  where:
-  $parameterizations
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-
-    where:
-    parameterizations << [
-        "x << [1,2]; y << [1, 2]",
-        "[x, y] << [[1, 2], [1, 2]]",
-        "x << [1, 2]; y = x"
-    ]
-  }
 
   def "data value type can be coerced to parameter type"(x, String y) {
     expect:
@@ -167,5 +92,25 @@ def foo(x, ClassLoader y) {
 
     then:
     thrown(GroovyCastException)
+  }
+
+  def 'extra parameters are type safe'(x, y, TreeMap<BigInteger, BigDecimal> z, boolean b) {
+    when:
+    z = [(1): 3]
+    b = true
+
+    then:
+    z instanceof TreeMap
+    z == [(1): 3]
+
+    b instanceof Boolean
+    b == true
+
+    x == y
+
+    where:
+    x | y
+    1 | 1
+    2 | 2
   }
 }


### PR DESCRIPTION
Until now the parameters either included all the data table header elements or none.

Their order wasn't enforced, but was replaced with a method call, based on the header,
causing parameter values to be mixed up.

This is changed now to variable number parameter definition, where only the order is enforced:
- first you can define the type of any variable from the data table, followed by arbitrary
  number of extra parameters (called with `null`, no default values supported yet)
  - the data table header order is compile-time checked
  - the extra parameters can serve as type-safety declarations outside the method body
  - provided default parameter values are compile-time rejected (not supported yet)
  - primitives are auto-wrapped to nullable types (they need default values)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/525)
<!-- Reviewable:end -->
