### PR TITLE
Data table cells can reference previous ones

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/AstUtil.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstUtil.java
@@ -21,6 +21,8 @@ import java.util.*;
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.ast.expr.*;
 import org.codehaus.groovy.ast.stmt.*;
+import org.codehaus.groovy.runtime.dgmimpl.arrays.*;
+
 import org.objectweb.asm.Opcodes;
 
 import org.spockframework.lang.Wildcard;
@@ -36,6 +38,8 @@ import spock.lang.Specification;
  * @author Peter Niederwieser
  */
 public abstract class AstUtil {
+  private static String GET_AT_METHOD_NAME = new IntegerArrayGetAtMetaMethod().getName();
+
   /**
    * Tells whether the given node has an annotation of the given type.
    *
@@ -310,6 +314,12 @@ public abstract class AstUtil {
 
   public static void fixUpLocalVariables(Variable[] localVariables, VariableScope scope, boolean isClosureScope) {
     fixUpLocalVariables(Arrays.asList(localVariables), scope, isClosureScope);
+  }
+
+  public static MethodCallExpression createGetAtMethod(Expression expression, int index) {
+    return new MethodCallExpression(expression,
+                                    GET_AT_METHOD_NAME,
+                                    new ConstantExpression(index));
   }
 
   /**

--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -30,6 +30,8 @@ import org.spockframework.compiler.model.WhereBlock;
 import org.spockframework.runtime.model.DataProviderMetadata;
 import org.spockframework.util.*;
 
+import static org.spockframework.compiler.AstUtil.createGetAtMethod;
+
 /**
  *
  * @author Peter Niederwieser
@@ -77,7 +79,6 @@ public class WhereBlockRewriter {
     if (binExpr == null || binExpr.getClass() != BinaryExpression.class) // don't allow subclasses like DeclarationExpression
       notAParameterization(stat);
 
-    @SuppressWarnings("ConstantConditions")
     int type = binExpr.getOperation().getType();
 
     if (type == Types.LEFT_SHIFT) {
@@ -86,25 +87,29 @@ public class WhereBlockRewriter {
         rewriteSimpleParameterization(binExpr, stat);
       else if (leftExpr instanceof ListExpression)
         rewriteMultiParameterization(binExpr, stat);
-      else notAParameterization(stat);
+      else 
+        notAParameterization(stat);
     } else if (type == Types.ASSIGN)
       rewriteDerivedParameterization(binExpr, stat);
     else if (getOrExpression(binExpr) != null) {
       stats.previous();
       rewriteTableLikeParameterization(stats);
     }
-    else notAParameterization(stat);
+    else 
+      notAParameterization(stat);
   }
 
   private void createDataProviderMethod(Expression dataProviderExpr, int nextDataVariableIndex) {
     instanceFieldAccessChecker.check(dataProviderExpr);
+
+    dataProviderExpr = dataProviderExpr.transformExpression(new DataTablePreviousVariableTransformer());
 
     MethodNode method =
         new MethodNode(
             InternalIdentifiers.getDataProviderName(whereBlock.getParent().getAst().getName(), dataProviderCount++),
             Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
             ClassHelper.OBJECT_TYPE,
-            Parameter.EMPTY_ARRAY,
+            getPreviousParameters(nextDataVariableIndex),
             ClassNode.EMPTY_ARRAY,
             new BlockStatement(
                 Arrays.<Statement> asList(
@@ -114,6 +119,14 @@ public class WhereBlockRewriter {
 
     method.addAnnotation(createDataProviderAnnotation(dataProviderExpr, nextDataVariableIndex));
     whereBlock.getParent().getParent().getAst().addMethod(method);
+  }
+
+  private Parameter[] getPreviousParameters(int nextDataVariableIndex) {
+    Parameter[] results = new Parameter[nextDataVariableIndex];
+    for (int i = 0; i < nextDataVariableIndex; i++)
+      results[i] = new Parameter(ClassHelper.DYNAMIC_TYPE,
+                                 dataProcessorVars.get(i).getName());
+    return results;
   }
 
   private AnnotationNode createDataProviderAnnotation(Expression dataProviderExpr, int nextDataVariableIndex) {
@@ -171,10 +184,7 @@ public class WhereBlockRewriter {
               new DeclarationExpression(
                   dataVar,
                   Token.newSymbol(Types.ASSIGN, -1, -1),
-                  new MethodCallExpression(
-                      new VariableExpression(dataProcessorParameter),
-                      "getAt",
-                      new ConstantExpression(i))));
+                  createGetAtMethod(new VariableExpression(dataProcessorParameter), i)));
       exprStat.setSourcePosition(enclosingStat);
       dataProcessorStats.add(exprStat);
     }
@@ -300,7 +310,7 @@ public class WhereBlockRewriter {
       return;
     }
 
-    if (getDataProcessorVariable(varExpr.getName()) != null) {
+    if (isDataProcessorVariable(varExpr.getName())) {
       resources.getErrorReporter().error(varExpr, "Duplicate declaration of data variable '%s'", varExpr.getName());
       return;
     }
@@ -312,11 +322,11 @@ public class WhereBlockRewriter {
     }
   }
 
-  private VariableExpression getDataProcessorVariable(String name) {
+  private boolean isDataProcessorVariable(String name) {
     for (VariableExpression var : dataProcessorVars)
-      if (var.getName().equals(name)) return var;
-
-    return null;
+      if (var.getName().equals(name))
+        return true;
+    return false;
   }
 
   private void handleFeatureParameters() {
@@ -329,7 +339,7 @@ public class WhereBlockRewriter {
 
   private void checkAllParametersAreDataVariables(Parameter[] parameters) {
     for (Parameter param : parameters)
-      if (getDataProcessorVariable(param.getName()) == null)
+      if (!isDataProcessorVariable(param.getName()))
         resources.getErrorReporter().error(param, "Parameter '%s' does not refer to a data variable", param.getName());
   }
 
@@ -384,6 +394,29 @@ public class WhereBlockRewriter {
     public void visitBlockStatement(BlockStatement stat) {
       super.visitBlockStatement(stat);
       AstUtil.fixUpLocalVariables(dataProcessorVars, stat.getVariableScope(), false);
+    }
+  }
+
+  private class DataTablePreviousVariableTransformer extends ClassCodeExpressionTransformer {
+    private int depth = 0, rowIndex = 0;
+
+    @Override
+    protected SourceUnit getSourceUnit() { return null; }
+
+    @Override
+    public Expression transform(Expression expression) {
+      if ((expression instanceof VariableExpression) && isDataProcessorVariable(expression.getText())) {
+        return AstUtil.createGetAtMethod(expression, rowIndex);
+      }
+
+      depth++;
+      Expression transform = super.transform(expression);
+      depth--;
+
+      if (depth == 0)
+        rowIndex++;
+
+      return transform;
     }
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -14,8 +14,8 @@
 
 package org.spockframework.smoke.parameterization
 
-import org.junit.internal.runners.model.MultipleFailureException
-
+import org.junit.runner.notification.RunListener
+import org.junit.runners.model.MultipleFailureException
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.compiler.InvalidSpecCompileException
 import org.spockframework.runtime.SpockExecutionException
@@ -28,7 +28,11 @@ class DataTables extends EmbeddedSpecification {
   @Shared
   def sharedField = 42
 
-  def instanceField = 42
+  RunListener listener = Mock()
+
+  def setup() {
+    runner.listeners << listener
+  }
 
   def "basic usage"() {
     expect:
@@ -226,19 +230,118 @@ local | 1
     thrown(MissingPropertyException)
   }
 
-  def "cells cannot reference other cells"() {
-    when:
-    runner.runFeatureBody """
-expect:
-true
+  def 'cells can reference previous cells'() {
+    expect:
+    [a, b, c] == [0, 1, 2]
 
-where:
-a | b
-1 | a
-    """
+    where:
+    a | b     | c
+    0 | a + 1 | b + 1
+  }
+
+  def 'cell references are pointing to the current row'() {
+    expect:
+    b == 1 + a * 2
+    c == 3 * b
+
+    where:
+    a | b         | c
+    0 | 1 + a * 2 | 3 * b
+    1 | 1 + a * 2 | 3 * b
+    2 | 1 + a * 2 | 3 * b
+  }
+
+  def "cell references are evaluated correctly in the method's name"() {
+    when:
+    runner.runSpecBody '''
+      @Unroll def 'a = #a, b = #b'() {
+        expect:
+        true
+        
+        where:
+        a | b
+        0 | a + 1
+      }
+    '''
 
     then:
-    thrown(MissingPropertyException)
+    1 * listener.testStarted { it.methodName == "a = 0, b = 1" }
+  }
+
+  def "cells can't reference next cells"() {
+    when:
+    runner.runFeatureBody '''
+      expect:
+      false
+      
+      where:
+      a | b
+      b | 1
+    '''
+
+    then:
+    thrown Exception
+  }
+
+  def "cells can't reference themselves"() {
+    when:
+    runner.runFeatureBody '''
+      expect:
+      false
+      
+      where:
+      a | b
+      1 | b + 1
+    '''
+
+    then:
+    thrown Exception
+  }
+
+  def 'cell references are working with simple parameterization also'() {
+    expect:
+    c == 2
+
+    where:
+    a << [1, 2]
+    b << [3, 4]
+    c << [b - a, b - a]
+  }
+
+  def 'data tables can be referenced from following variables'() {
+    expect:
+    c == 3
+
+    where:
+    a | b
+    1 | 2
+    1 | a + 1
+
+    c = b + 1
+  }
+
+  @Ignore
+  def 'data table elements can reference each other'() {
+    expect:
+    runner.runFeatureBody '''
+      expect:
+      g == 12
+  
+      where:
+      a = 1
+      b = a + 1
+      
+      c << [b + 1]
+      
+      d = c + 1
+      
+      e         | f
+      b + c + d | e + 1
+      
+      g << [f + 1]
+      
+      h = g + 1       
+    '''
   }
 
   def "rows must have same number of elements as header"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -68,16 +68,7 @@ class MethodParameters extends EmbeddedSpecification {
     x << [1, 2]
     y << [1, 2]
   }
-
-  def "parameters in different order"(y, x) {
-    expect:
-    x == y
-
-    where:
-    x << [1, 2]
-    y << [1, 2]
-  }
-
+  
   def "fewer parameters than data variables"() {
     when:
     compiler.compileSpecBody """

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/Parameterizations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/Parameterizations.groovy
@@ -16,9 +16,10 @@
 
 package org.spockframework.smoke.parameterization
 
+import org.spockframework.EmbeddedSpecification
 import spock.lang.*
 
-class Parameterizations extends Specification {
+class Parameterizations extends EmbeddedSpecification {
   def "multi-parameterization"() {
     expect: a == b
     where :
@@ -57,7 +58,6 @@ class Parameterizations extends Specification {
     where:
     [_, a] << [["foo", 3]]
     [b, _] << [[3, "bar"]]
-    [_, _] << [["baz", "baz"]]
   }
 
   def "derived parameterization"() {
@@ -76,13 +76,17 @@ class Parameterizations extends Specification {
       d = c / 2
   }
 
-  @Ignore("""argument computer fails with groovy.lang.MissingPropertyException,
-  which is expected but cannot be easily tested; should check for this at compile-time""")
-  def "arguments may not be used before they have been assigned"() {
-    expect: true
-    where:
-      b = a
-      a = 1
+  def 'arguments may not be used before they have been assigned'() {
+    when:
+    runner.runFeatureBody '''
+      expect: true
+      where:
+        b = a
+        a = 1
+    '''
+
+    then:
+    thrown Exception
   }
 
   def "simple, multi- and derived parameterizations used together"() {
@@ -91,17 +95,6 @@ class Parameterizations extends Specification {
       a << [1, 2, 3]
       [b, _, c] << [[1, 9, 1], [2, 9, 2], [3, 9, 3]]
       d = a + b + c
-  }
-
-  @Ignore("we should either support this or disallow it")
-  def "simple parameterization whose value is accessed from closure within other parameterization"() {
-    expect:
-    a == 1
-    b == 1
-
-    where:
-    a << 1
-    b << {a}()
   }
 
   @Issue("http://code.google.com/p/spock/issues/detail?id=149")
@@ -131,7 +124,7 @@ class Parameterizations extends Specification {
     a() == 1
     b(1, 2) == 3
     1.times { n ->
-      b(n, n) - n == n
+      assert b(n, n) - n == n
     }
 
     and:


### PR DESCRIPTION
For data driven tests it could be important for a parameter to depend
on a previously calculated value.

Until now this wasn't possible, because the whole where block was calculated,
before the test method was called (via its generated parameters).
Also, the data providers calculate the whole column,
before moving on to the next one, making the references seem unobvious.

The fix was to provide the data provider methods with the list of already
calculated columns.
And because a cell should only refer to cells in the same row,
the variable references were changed to array indexes (see the getAt part).

This commit should play well with [`partial parameter definitions`](https://github.com/spockframework/spock/pull/525).

Partially fixes: https://github.com/spockframework/spock/issues/509