### PR TITLE
Fix PollingConditionsSpec

### DIFF
--- a/spock-specs/src/test/groovy/spock/util/concurrent/PollingConditionsSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/concurrent/PollingConditionsSpec.groovy
@@ -99,7 +99,7 @@ class PollingConditionsSpec extends Specification {
   }
 
   def "provides fine-grained control over polling rhythm"() {
-    conditions.initialDelay = 0.1
+    conditions.initialDelay = 0.01
     conditions.delay = 0.2
     conditions.factor = 2
 
@@ -121,12 +121,12 @@ class PollingConditionsSpec extends Specification {
 
   def "correctly handles checks that take longer than given check interval"() {
     when:
-    def condition = new PollingConditions(timeout: 4)
+    def condition = new PollingConditions(timeout: 0.05)
     boolean secondAttempt = false
     then:
     condition.eventually {
       try {
-        sleep 5000;
+        sleep 200;
         assert secondAttempt;
       } finally {
         secondAttempt = true


### PR DESCRIPTION
The AppVeyor build is so slow that it causes the spec to fail, since the initial setup of the polling conditions eventually block takes to long. By decreasing the initialDelay, this should no longer be an issue. Furthermore, the timeouts for another test are reduced from seconds to milliseconds, as there is no reason to waste 5 seconds waiting.