### PR TITLE
Add 'but' and 'examples' blocks to make it easier to use Gherkin-based stories

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/AbstractSpecVisitor.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AbstractSpecVisitor.java
@@ -33,4 +33,5 @@ public class AbstractSpecVisitor implements ISpecVisitor {
   public void visitThenBlock(ThenBlock block) throws Exception {}
   public void visitCleanupBlock(CleanupBlock block) throws Exception {}
   public void visitWhereBlock(WhereBlock block) throws Exception {}
+  public void visitExamplesBlock(ExamplesBlock block) throws Exception {}
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/ExamplesBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ExamplesBlockRewriter.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler;
+
+import java.util.*;
+
+import org.codehaus.groovy.ast.*;
+import org.codehaus.groovy.ast.expr.*;
+import org.codehaus.groovy.ast.stmt.*;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Token;
+import org.codehaus.groovy.syntax.Types;
+import org.objectweb.asm.Opcodes;
+
+import org.spockframework.compiler.model.ExamplesBlock;
+import org.spockframework.runtime.model.DataProviderMetadata;
+import org.spockframework.util.*;
+
+/**
+ *
+ * @author Peter Niederwieser
+ */
+public class ExamplesBlockRewriter {
+  private final ExamplesBlock examplesBlock;
+  private final IRewriteResources resources;
+  private final InstanceFieldAccessChecker instanceFieldAccessChecker;
+
+  private int dataProviderCount = 0;
+  // parameters of the data processor method (one for each data provider)
+  private final List<Parameter> dataProcessorParams = new ArrayList<Parameter>();
+  // statements of the data processor method (one for each parameterization variable)
+  private final List<Statement> dataProcessorStats = new ArrayList<Statement>();
+  // parameterization variables of the data processor method
+  private final List<VariableExpression> dataProcessorVars = new ArrayList<VariableExpression>();
+
+  private ExamplesBlockRewriter(ExamplesBlock examplesBlock, IRewriteResources resources) {
+    this.examplesBlock = examplesBlock;
+    this.resources = resources;
+    instanceFieldAccessChecker = new InstanceFieldAccessChecker(resources);
+  }
+
+  public static void rewrite(ExamplesBlock block, IRewriteResources resources) {
+    new ExamplesBlockRewriter(block, resources).rewrite();
+  }
+
+  private void rewrite() {
+    ListIterator<Statement> stats = examplesBlock.getAst().listIterator();
+    while (stats.hasNext())
+      try {
+        rewriteExamplesStat(stats);
+      } catch (InvalidSpecCompileException e) {
+        resources.getErrorReporter().error(e);
+      }
+
+    examplesBlock.getAst().clear();
+    handleFeatureParameters();
+    createDataProcessorMethod();
+  }
+
+  private void rewriteExamplesStat(ListIterator<Statement> stats) throws InvalidSpecCompileException {
+    Statement stat = stats.next();
+    BinaryExpression binExpr = AstUtil.getExpression(stat, BinaryExpression.class);
+    if (binExpr == null || binExpr.getClass() != BinaryExpression.class) // don't allow subclasses like DeclarationExpression
+      notAParameterization(stat);
+
+    @SuppressWarnings("ConstantConditions")
+    int type = binExpr.getOperation().getType();
+
+    if (type == Types.LEFT_SHIFT) {
+      Expression leftExpr = binExpr.getLeftExpression();
+      if (leftExpr instanceof VariableExpression)
+        rewriteSimpleParameterization(binExpr, stat);
+      else if (leftExpr instanceof ListExpression)
+        rewriteMultiParameterization(binExpr, stat);
+      else notAParameterization(stat);
+    } else if (type == Types.ASSIGN)
+      rewriteDerivedParameterization(binExpr, stat);
+    else if (getOrExpression(binExpr) != null) {
+      stats.previous();
+      rewriteTableLikeParameterization(stats);
+    }
+    else notAParameterization(stat);
+  }
+
+  private void createDataProviderMethod(Expression dataProviderExpr, int nextDataVariableIndex) {
+    instanceFieldAccessChecker.check(dataProviderExpr);
+
+    MethodNode method =
+        new MethodNode(
+            InternalIdentifiers.getDataProviderName(examplesBlock.getParent().getAst().getName(), dataProviderCount++),
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
+            ClassHelper.OBJECT_TYPE,
+            Parameter.EMPTY_ARRAY,
+            ClassNode.EMPTY_ARRAY,
+            new BlockStatement(
+                Arrays.<Statement> asList(
+                    new ReturnStatement(
+                        new ExpressionStatement(dataProviderExpr))),
+                new VariableScope()));
+
+    method.addAnnotation(createDataProviderAnnotation(dataProviderExpr, nextDataVariableIndex));
+    examplesBlock.getParent().getParent().getAst().addMethod(method);
+  }
+
+  private AnnotationNode createDataProviderAnnotation(Expression dataProviderExpr, int nextDataVariableIndex) {
+    AnnotationNode ann = new AnnotationNode(resources.getAstNodeCache().DataProviderMetadata);
+    ann.addMember(DataProviderMetadata.LINE, new ConstantExpression(dataProviderExpr.getLineNumber()));
+    List<Expression> dataVariableNames = new ArrayList<Expression>();
+    for (int i = nextDataVariableIndex; i < dataProcessorVars.size(); i++)
+      dataVariableNames.add(new ConstantExpression(dataProcessorVars.get(i).getName()));
+    ann.addMember(DataProviderMetadata.DATA_VARIABLES, new ListExpression(dataVariableNames));
+    return ann;
+  }
+
+  private Parameter createDataProcessorParameter() {
+    Parameter p = new Parameter(ClassHelper.DYNAMIC_TYPE, "$spock_p" + dataProcessorParams.size());
+    dataProcessorParams.add(p);
+    return p;
+  }
+
+  // generates: arg = argMethodParam
+  private void rewriteSimpleParameterization(BinaryExpression binExpr, ASTNode sourcePos)
+      throws InvalidSpecCompileException {
+    int nextDataVariableIndex = dataProcessorVars.size();
+    Parameter dataProcessorParameter = createDataProcessorParameter();
+    VariableExpression arg = (VariableExpression) binExpr.getLeftExpression();
+
+    VariableExpression dataVar = createDataProcessorVariable(arg, sourcePos);
+    ExpressionStatement exprStat = new ExpressionStatement(
+        new DeclarationExpression(
+            dataVar,
+            Token.newSymbol(Types.ASSIGN, -1, -1),
+            new VariableExpression(dataProcessorParameter)));
+    exprStat.setSourcePosition(sourcePos);
+    dataProcessorStats.add(exprStat);
+
+    createDataProviderMethod(binExpr.getRightExpression(), nextDataVariableIndex);
+  }
+
+  // generates:
+  // arg0 = argMethodParam.getAt(0)
+  // arg1 = argMethodParam.getAt(1)
+  private void rewriteMultiParameterization(BinaryExpression binExpr, Statement enclosingStat)
+      throws InvalidSpecCompileException {
+    int nextDataVariableIndex = dataProcessorVars.size();
+    Parameter dataProcessorParameter = createDataProcessorParameter();
+    ListExpression list = (ListExpression) binExpr.getLeftExpression();
+
+    @SuppressWarnings("unchecked")
+    List<Expression> listElems = list.getExpressions();
+    for (int i = 0; i < listElems.size(); i++) {
+      Expression listElem = listElems.get(i);
+      if (AstUtil.isWildcardRef(listElem)) continue;
+      VariableExpression dataVar = createDataProcessorVariable(listElem, enclosingStat);
+      ExpressionStatement exprStat =
+          new ExpressionStatement(
+              new DeclarationExpression(
+                  dataVar,
+                  Token.newSymbol(Types.ASSIGN, -1, -1),
+                  new MethodCallExpression(
+                      new VariableExpression(dataProcessorParameter),
+                      "getAt",
+                      new ConstantExpression(i))));
+      exprStat.setSourcePosition(enclosingStat);
+      dataProcessorStats.add(exprStat);
+    }
+
+    createDataProviderMethod(binExpr.getRightExpression(), nextDataVariableIndex);
+  }
+
+  private void rewriteDerivedParameterization(BinaryExpression parameterization, Statement enclosingStat)
+      throws InvalidSpecCompileException {
+    VariableExpression dataVar = createDataProcessorVariable(parameterization.getLeftExpression(), enclosingStat);
+
+    ExpressionStatement exprStat =
+        new ExpressionStatement(
+            new DeclarationExpression(
+                dataVar,
+                Token.newSymbol(Types.ASSIGN, -1, -1),
+                parameterization.getRightExpression()));
+
+    exprStat.setSourcePosition(enclosingStat);
+    dataProcessorStats.add(exprStat);
+  }
+
+  private void rewriteTableLikeParameterization(ListIterator<Statement> stats) throws InvalidSpecCompileException {
+    LinkedList<List<Expression>> rows = new LinkedList<List<Expression>>();
+
+    while (stats.hasNext()) {
+      Statement stat = stats.next();
+      BinaryExpression orExpr = getOrExpression(stat);
+      if (orExpr == null) {
+        stats.previous();
+        break;
+      }
+
+      List<Expression> row = new ArrayList<Expression>();
+      splitRow(orExpr, row);
+      if (rows.size() > 0 && rows.getLast().size() != row.size())
+        throw new InvalidSpecCompileException(stat, String.format("Row in data table has wrong number of elements (%s instead of %s)", row.size(), rows.getLast().size()));
+      rows.add(row);
+    }
+
+    for (List<Expression> column : transposeTable(rows))
+      turnIntoSimpleParameterization(column);
+  }
+
+  List<List<Expression>> transposeTable(List<List<Expression>> rows) {
+    List<List<Expression>> columns = new ArrayList<List<Expression>>();
+    if (rows.isEmpty()) return columns;
+
+    for (int i = 0; i < rows.get(0).size(); i++)
+      columns.add(new ArrayList<Expression>());
+
+    for (List<Expression> row : rows)
+      for (int i = 0; i < row.size(); i++)
+        columns.get(i).add(row.get(i));
+
+    return columns;
+  }
+
+  private void turnIntoSimpleParameterization(List<Expression> column) throws InvalidSpecCompileException {
+    VariableExpression varExpr = ObjectUtil.asInstance(column.get(0), VariableExpression.class);
+    if (varExpr == null)
+      throw new InvalidSpecCompileException(column.get(0),
+          "Header of data table may only contain variable names");
+    if (AstUtil.isWildcardRef(varExpr)) {
+      // assertion: column has a wildcard header, but the method's
+      // explicit parameter list does not have a wildcard parameter
+      return; // ignore column (see https://github.com/spockframework/spock/pull/48/)
+    }
+
+    ListExpression listExpr = new ListExpression(column.subList(1, column.size()));
+    BinaryExpression binExpr = new BinaryExpression(varExpr, Token.newSymbol(Types.LEFT_SHIFT, -1, -1), listExpr);
+    // NOTE: varExpr may not be the "perfect" source position here, but as long as we rewrite data tables
+    // into simple parameterizations, it seems like the best approximation; also this source position is
+    // unlikely to make it into a compile error, because header variable has already been checked, and the
+    // assignment itself is unlikely to cause a compile error. (It's more likely that the rval causes a
+    // compile error, but the rval's source position is retained.)
+    rewriteSimpleParameterization(binExpr, varExpr);
+  }
+
+  private void splitRow(Expression row, List<Expression> parts) {
+    BinaryExpression orExpr = getOrExpression(row);
+    if (orExpr == null)
+      parts.add(row);
+    else {
+      splitRow(orExpr.getLeftExpression(), parts);
+      splitRow(orExpr.getRightExpression(), parts);
+    }
+  }
+  
+  private BinaryExpression getOrExpression(Statement stat) {
+    Expression expr = AstUtil.getExpression(stat, Expression.class);
+    return getOrExpression(expr);
+  }
+  
+  private BinaryExpression getOrExpression(Expression expr) {
+    BinaryExpression binExpr = ObjectUtil.asInstance(expr, BinaryExpression.class);
+    if (binExpr == null) return null;
+    
+    int binExprType = binExpr.getOperation().getType();
+    if (binExprType == Types.BITWISE_OR || binExprType == Types.LOGICAL_OR) return binExpr;
+    
+    return null;
+  }
+
+  private VariableExpression createDataProcessorVariable(Expression varExpr, ASTNode sourcePos)
+      throws InvalidSpecCompileException {
+    if (!(varExpr instanceof VariableExpression))
+      notAParameterization(sourcePos);
+
+    VariableExpression typedVarExpr = (VariableExpression)varExpr;
+    verifyDataProcessorVariable(typedVarExpr);
+
+    VariableExpression result = new VariableExpression(typedVarExpr.getName(), typedVarExpr.getType());
+    dataProcessorVars.add(result);
+    return result;
+  }
+
+  private void verifyDataProcessorVariable(VariableExpression varExpr) {
+    Variable accessedVar = varExpr.getAccessedVariable();
+
+    if (accessedVar instanceof VariableExpression) { // local variable
+      resources.getErrorReporter().error(varExpr, "A variable named '%s' already exists in this scope", varExpr.getName());
+      return;
+    }
+
+    if (getDataProcessorVariable(varExpr.getName()) != null) {
+      resources.getErrorReporter().error(varExpr, "Duplicate declaration of data variable '%s'", varExpr.getName());
+      return;
+    }
+
+    if (examplesBlock.getParent().getAst().getParameters().length > 0 && !(accessedVar instanceof Parameter)) {
+      resources.getErrorReporter().error(varExpr,
+          "Data variable '%s' needs to be declared as method parameter",
+          varExpr.getName());
+    }
+  }
+
+  private VariableExpression getDataProcessorVariable(String name) {
+    for (VariableExpression var : dataProcessorVars)
+      if (var.getName().equals(name)) return var;
+
+    return null;
+  }
+
+  private void handleFeatureParameters() {
+    Parameter[] parameters = examplesBlock.getParent().getAst().getParameters();
+    if (parameters.length == 0)
+      addFeatureParameters();
+    else
+      checkAllParametersAreDataVariables(parameters);
+  }
+
+  private void checkAllParametersAreDataVariables(Parameter[] parameters) {
+    for (Parameter param : parameters)
+      if (getDataProcessorVariable(param.getName()) == null)
+        resources.getErrorReporter().error(param, "Parameter '%s' does not refer to a data variable", param.getName());
+  }
+
+  private void addFeatureParameters() {
+    Parameter[] parameters = new Parameter[dataProcessorVars.size()];
+    for (int i = 0; i < dataProcessorVars.size(); i++)
+      parameters[i] = new Parameter(ClassHelper.DYNAMIC_TYPE, dataProcessorVars.get(i).getName());
+    examplesBlock.getParent().getAst().setParameters(parameters);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void createDataProcessorMethod() {
+    if (dataProcessorVars.isEmpty()) return;
+    
+    dataProcessorStats.add(
+        new ReturnStatement(
+            new ArrayExpression(
+                ClassHelper.OBJECT_TYPE,
+                (List) dataProcessorVars)));
+
+    BlockStatement blockStat = new BlockStatement(dataProcessorStats, new VariableScope());
+    new DataProcessorVariableRewriter().visitBlockStatement(blockStat);
+
+    examplesBlock.getParent().getParent().getAst().addMethod(
+      new MethodNode(
+          InternalIdentifiers.getDataProcessorName(examplesBlock.getParent().getAst().getName()),
+          Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
+          ClassHelper.OBJECT_TYPE,
+          dataProcessorParams.toArray(new Parameter[dataProcessorParams.size()]),
+          ClassNode.EMPTY_ARRAY,
+          blockStat));
+  }
+
+  private static void notAParameterization(ASTNode stat) throws InvalidSpecCompileException {
+    throw new InvalidSpecCompileException(stat,
+"examples-blocks may only contain parameterizations (e.g. 'salary << [1000, 5000, 9000]; salaryk = salary / 1000')");
+  }
+
+  private class DataProcessorVariableRewriter extends ClassCodeVisitorSupport {
+    @Override
+    protected SourceUnit getSourceUnit() {
+      throw new UnsupportedOperationException("getSourceUnit");
+    }
+
+    @Override
+    public void visitClosureExpression(ClosureExpression expr) {
+      super.visitClosureExpression(expr);
+      AstUtil.fixUpLocalVariables(dataProcessorVars, expr.getVariableScope(), true);
+    }
+
+    @Override
+    public void visitBlockStatement(BlockStatement stat) {
+      super.visitBlockStatement(stat);
+      AstUtil.fixUpLocalVariables(dataProcessorVars, stat.getVariableScope(), false);
+    }
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecAnnotator.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecAnnotator.java
@@ -127,4 +127,9 @@ public class SpecAnnotator extends AbstractSpecVisitor {
   public void visitWhereBlock(WhereBlock block) throws Exception {
     addBlockMetadata(block, BlockKind.WHERE);
   }
+
+  @Override
+  public void visitExamplesBlock(ExamplesBlock block) throws Exception {
+    addBlockMetadata(block, BlockKind.EXAMPLES);
+  }
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
@@ -216,7 +216,7 @@ public class SpecParser implements GroovyClassVisitor {
         block.getDescriptions().add(description);
 
       return block;
-		}
+    }
 
 		throw new InvalidSpecCompileException(stat, "Unrecognized block label: " + label);
   }

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -238,7 +238,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
       AstUtil.setVisibility(method.getAst(), Opcodes.ACC_PRIVATE);
     } else if (method instanceof FeatureMethod) {
       transplantMethod(method);
-      handleWhereBlock(method);
+      handleWhereOrExamplesBlock(method);
     }
   }
 
@@ -277,15 +277,18 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
     return newMethod;
   }
 
-  // where block must be rewritten before all other blocks
+  // examples and where blocks must be rewritten before all other blocks
   // s.t. missing method parameters are added; these parameters
   // will then be used by DeepBlockRewriter
-  private void handleWhereBlock(Method method) {
+  private void handleWhereOrExamplesBlock(Method method) {
     Block block = method.getLastBlock();
-    if (!(block instanceof WhereBlock)) return;
-
-    new DeepBlockRewriter(this).visit(block);
-    WhereBlockRewriter.rewrite((WhereBlock) block, this);
+    if (block instanceof WhereBlock) {
+    	new DeepBlockRewriter(this).visit(block);
+        WhereBlockRewriter.rewrite((WhereBlock) block, this);
+    } else if (block instanceof ExamplesBlock) {
+    	new DeepBlockRewriter(this).visit(block);
+        ExamplesBlockRewriter.rewrite((ExamplesBlock) block, this);
+    }
   }
 
   public void visitMethodAgain(Method method) {
@@ -382,7 +385,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     method.getStatements().add(tryFinally);
 
-    // a cleanup-block may only be followed by a where-block, whose
+    // a cleanup-block may only be followed by a where-block or an examples-block, whose
     // statements are copied to newly generated methods rather than
     // the original method
     movedStatsBackToMethod = true;

--- a/spock-core/src/main/java/org/spockframework/compiler/model/BlockParseInfo.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/model/BlockParseInfo.java
@@ -37,16 +37,25 @@ public enum BlockParseInfo {
       return method.addBlock(new AnonymousBlock(method));
     }
     public EnumSet<BlockParseInfo> getSuccessors(Method method) {
-      return EnumSet.of(SETUP, GIVEN, EXPECT, WHEN, CLEANUP, WHERE, METHOD_END);
+      return EnumSet.of(SETUP, GIVEN, EXPECT, WHEN, CLEANUP, WHERE, EXAMPLES, METHOD_END);
     }
   },
+
+  BUT {
+	    public EnumSet<BlockParseInfo> getSuccessors(Method method) {
+	      return method.getLastBlock().getParseInfo().getSuccessors(method);
+	    }
+	    public Block addNewBlock(Method method) {
+	      return method.getLastBlock();
+	    }
+	  },
 
   SETUP {
     public Block addNewBlock(Method method) {
       return method.addBlock(new SetupBlock(method));
     }
     public EnumSet<BlockParseInfo> getSuccessors(Method method) {
-      return EnumSet.of(AND, EXPECT, WHEN, CLEANUP, WHERE, METHOD_END);
+      return EnumSet.of(AND, BUT, EXPECT, WHEN, CLEANUP, WHERE, EXAMPLES, METHOD_END);
     }
   },
 
@@ -64,7 +73,7 @@ public enum BlockParseInfo {
       return method.addBlock(new ExpectBlock(method));
     }
     public EnumSet<BlockParseInfo> getSuccessors(Method method) {
-      return EnumSet.of(AND, WHEN, CLEANUP, WHERE, METHOD_END);
+      return EnumSet.of(AND, BUT, WHEN, CLEANUP, WHERE, EXAMPLES, METHOD_END);
     }
   },
 
@@ -73,7 +82,7 @@ public enum BlockParseInfo {
       return method.addBlock(new WhenBlock(method));
     }
     public EnumSet<BlockParseInfo> getSuccessors(Method method) {
-      return EnumSet.of(AND, THEN);
+      return EnumSet.of(AND, BUT, THEN);
     }
   },
 
@@ -82,7 +91,7 @@ public enum BlockParseInfo {
       return method.addBlock(new ThenBlock(method));
     }
     public EnumSet<BlockParseInfo> getSuccessors(Method method) {
-      return EnumSet.of(AND, EXPECT, WHEN, THEN, CLEANUP, WHERE, METHOD_END);
+      return EnumSet.of(AND, BUT, EXPECT, WHEN, THEN, CLEANUP, WHERE, EXAMPLES, METHOD_END);
     }
   },
 
@@ -91,7 +100,7 @@ public enum BlockParseInfo {
       return method.addBlock(new CleanupBlock(method));
     }
     public EnumSet<BlockParseInfo> getSuccessors(Method method) {
-      return EnumSet.of(AND, WHERE, METHOD_END);
+      return EnumSet.of(AND, BUT, WHERE, EXAMPLES, METHOD_END);
     }
   },
 
@@ -100,9 +109,18 @@ public enum BlockParseInfo {
       return method.addBlock(new WhereBlock(method));
     }
     public EnumSet<BlockParseInfo> getSuccessors(Method method) {
-      return EnumSet.of(AND, METHOD_END);
+      return EnumSet.of(AND, BUT, METHOD_END);
     }
   },
+
+  EXAMPLES {
+	    public Block addNewBlock(Method method) {
+	      return method.addBlock(new ExamplesBlock(method));
+	    }
+	    public EnumSet<BlockParseInfo> getSuccessors(Method method) {
+	      return EnumSet.of(AND, BUT, METHOD_END);
+	    }
+	  },
 
   METHOD_END {
     public Block addNewBlock(Method method) {

--- a/spock-core/src/main/java/org/spockframework/compiler/model/ExamplesBlock.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/model/ExamplesBlock.java
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-package org.spockframework.runtime.model;
+package org.spockframework.compiler.model;
 
-/**
- * The different kind of blocks that a <tt>BlockInfo</tt> instance can represent.
- * 
- * @author Peter Niederwieser
- */
-public enum BlockKind {
-  SETUP,
-  EXPECT,
-  WHEN,
-  THEN,
-  CLEANUP,
-  WHERE,
-  EXAMPLES
+public class ExamplesBlock extends Block {
+  public ExamplesBlock(Method parent) {
+    super(parent);
+    setName("Examples");
+  }
+
+  @Override
+  public void accept(ISpecVisitor visitor) throws Exception {
+    visitor.visitAnyBlock(this);
+    visitor.visitExamplesBlock(this);
+  }
+
+  public BlockParseInfo getParseInfo() {
+    return BlockParseInfo.EXAMPLES;
+  }
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/model/ISpecVisitor.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/model/ISpecVisitor.java
@@ -33,4 +33,5 @@ public interface ISpecVisitor {
   void visitThenBlock(ThenBlock block) throws Exception;
   void visitCleanupBlock(CleanupBlock block) throws Exception;
   void visitWhereBlock(WhereBlock block) throws Exception;
+  void visitExamplesBlock(ExamplesBlock block) throws Exception;
 }

--- a/spock-report/src/test/groovy/org/spockframework/report/sample/FightOrFlightSpec.groovy
+++ b/spock-report/src/test/groovy/org/spockframework/report/sample/FightOrFlightSpec.groovy
@@ -47,6 +47,21 @@ class FightOrFlightSpec extends Specification {
     impl()
   }
 
+  @Ignore
+  def "Ninja should cast a tee-mac-woo spell when attacked by an invisible opponent (but hope for the best)"() {
+    given:
+    impl()
+
+    when:
+    impl()
+
+    then:
+    impl()
+
+    but:
+    impl()
+  }
+
   @See(["http://en.wikipedia.org/wiki/Ninja", "http://en.wikipedia.org/wiki/Sega_Ninja"])
   def "Ninja should engage a weak opponent"() {
     given:

--- a/spock-specs/src/test/groovy/org/spockframework/example/FeatureUnrolling.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/example/FeatureUnrolling.groovy
@@ -32,6 +32,15 @@ class FeatureUnrolling extends Specification {
     length << [4, 5, 6]
   }
 
+  def "without unrolling - using examples"() {
+    expect:
+    name.size() == length
+
+    examples:
+    name << ["Kirk", "Spock", "Scotty"]
+    length << [4, 5, 6]
+  }
+
   @Unroll
   def "with unrolling"() {
     expect:
@@ -42,12 +51,32 @@ class FeatureUnrolling extends Specification {
     length << [4, 5, 6]
   }
 
+  @Unroll
+  def "with unrolling - using examples"() {
+    expect:
+    name.size() == length
+
+    examples:
+    name << ["Kirk", "Spock", "Scotty"]
+    length << [4, 5, 6]
+  }
+
   @Unroll("length of '#name' should be #length")
   def "with unrolling and custom naming pattern"() {
     expect:
     name.size() == length
 
     where:
+    name << ["Kirk", "Spock", "Scotty"]
+    length << [4, 5, 6]
+  }
+
+  @Unroll("length of '#name' should be #length")
+  def "with unrolling and custom naming pattern - using examples"() {
+    expect:
+    name.size() == length
+
+    examples:
     name << ["Kirk", "Spock", "Scotty"]
     length << [4, 5, 6]
   }

--- a/spock-specs/src/test/groovy/org/spockframework/groovy/SourcePositionPhaseSemanticAnalysis.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/groovy/SourcePositionPhaseSemanticAnalysis.groovy
@@ -85,7 +85,7 @@ println(  List  )
     node2.lastLineNumber == 3
     node2.lastColumnNumber == 5
 
-    and:
+    but:
     ASTNode node3 = inspector.scriptExpressions[2].arguments.expressions[0]
     node3 instanceof ClassExpression
     node3.lineNumber == 4
@@ -109,6 +109,29 @@ List.class.methods
     node1.lastColumnNumber == 11
 
     and:
+    ASTNode node2 = inspector.scriptExpressions[1].objectExpression
+    node2 instanceof ClassExpression
+    node2.lineNumber == 3
+    node2.columnNumber == 1
+    node2.lastLineNumber == 3
+    node2.lastColumnNumber == 11
+  }
+
+  def "long-form class literals have accurate line/column info using but block"() {
+    inspector.load("""
+List.class
+List.class.methods
+    """)
+
+    expect:
+    ASTNode node1 = inspector.scriptExpressions[0]
+    node1 instanceof ClassExpression
+    node1.lineNumber == 2
+    node1.columnNumber == 1
+    node1.lastLineNumber == 2
+    node1.lastColumnNumber == 11
+
+    but:
     ASTNode node2 = inspector.scriptExpressions[1].objectExpression
     node2 instanceof ClassExpression
     node2.lineNumber == 3

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/Blocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/Blocks.groovy
@@ -37,9 +37,25 @@ def m1() {
   and: "where2"
 }
 
+def m1b() {
+  setup: "setup"
+  but: "setup2"
+  when: "when"
+  but: "when2"
+  then: "then"
+  but: "then2"
+  where: "where"
+  but: "where2"
+}
+
 def m2() {
   expect: "expect"
   and: "expect2"
+}
+
+def m2b() {
+  expect: "expect"
+  but: "expect2"
 }
 
 def m3() {
@@ -50,6 +66,15 @@ def m3() {
   where: ""
   and: z << 1
 }
+
+def m3b() {
+  given: "given"
+  but: def x
+  expect: def y
+  but: "but"
+  where: ""
+  but: z << 1
+}
     """)
 
     def specInfo = new SpecInfoBuilder(specClass).build()
@@ -59,15 +84,31 @@ def m3() {
     m1.blocks*.kind == [SETUP,WHEN,THEN,WHERE]
     m1.blocks*.texts.flatten() == ["setup","setup2","when","when2","then","then2","where","where2"]
 
+
     and:
-    def m2 = specInfo.features[1]
+    def m1b = specInfo.features[1]
+    m1b.blocks*.kind == [SETUP,WHEN,THEN,WHERE]
+    m1b.blocks*.texts.flatten() == ["setup","setup2","when","when2","then","then2","where","where2"]
+
+    and:
+    def m2 = specInfo.features[2]
     m2.blocks*.kind == [EXPECT]
     m2.blocks*.texts.flatten() == ["expect","expect2"]
 
     and:
-    def m3 = specInfo.features[2]
+    def m2b = specInfo.features[3]
+    m2b.blocks*.kind == [EXPECT]
+    m2b.blocks*.texts.flatten() == ["expect","expect2"]
+
+    and:
+    def m3 = specInfo.features[4]
     m3.blocks*.kind == [SETUP,EXPECT,WHERE]
     m3.blocks*.texts.flatten() == ["given","and",""]
+
+    and:
+    def m3b = specInfo.features[5]
+    m3b.blocks*.kind == [SETUP,EXPECT,WHERE]
+    m3b.blocks*.texts.flatten() == ["given","but",""]
   }
 
   def "unknown label"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/SetupBlocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/SetupBlocks.groovy
@@ -47,6 +47,11 @@ class SetupBlocks extends EmbeddedSpecification {
     and: def b = 2
   }
 
+  def "but-ed"() {
+    setup: def a = 1
+    but: def b = 2
+  }
+
   def "full house"() {
     def a = 1
     def b = 2
@@ -89,6 +94,12 @@ setup: b = 2
     expect: a == 4
   }
 
+  def "blocks are executed - with but-ed block"() {
+    def a = 1
+    setup: a += 1
+    but: "blah"; a += 2
+    expect: a == 4
+  }
   def "given is alias for setup"() {
     def a
     given: a = 1


### PR DESCRIPTION
Wanted to make it easier for people using Cucumber, or other Gherkin-based tools, to use Spock.

The 'but' block is a clone of 'and', and the 'examples' block is a clone of 'where'. SpecWriter got a small change to it treats an 'examples' block like a 'where' block.
