### PR TITLE
Allowing automatic on-user-demand snapshot releases using jitpack.io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ description = "Spock Framework"
 ext {
   variants = [2.0, 2.3, 2.4]
   variant = System.getProperty("variant") as BigDecimal ?: variants.first()
+  //jitpack.io users probably want to be on the bleeding edge
+  if (System.getProperty('user.home')?.contains('jitpack')) {
+    variant = variants.last()
+  }
   if (variant == 2.0) {
     groovyVersion = "2.0.8"
     minGroovyVersion = "2.0.0"

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
   }
   javaVersions = [1.6, 1.7, 1.8]
   javaVersion = System.getProperty("java.specification.version") as BigDecimal
-  baseVersion = "1.1"
+  baseVersion = project.version
   snapshotVersion = true
   fullVersion = "$baseVersion-groovy-$variant" + (snapshotVersion ? "-SNAPSHOT" : "")
   variantLessVersion = baseVersion + (snapshotVersion ? "-SNAPSHOT" : "")
@@ -54,7 +54,6 @@ ext {
 allprojects {
   ext.displayName = null
 
-  group = "org.spockframework"
   version = fullVersion
 
   apply from: script("common")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+group=org.spockframework
+version=1.1

--- a/gradle/publishMaven.gradle
+++ b/gradle/publishMaven.gradle
@@ -89,4 +89,8 @@ modifyPom { pom ->
   pom.dependencies.removeAll { it.scope == "test" }
 }
 
-deployers*.beforeDeployment { signing.signPom(it) }
+deployers*.beforeDeployment {
+  if (gradle.taskGraph.hasTask(uploadArchives)) {
+    signing.signPom(it)
+  }
+}


### PR DESCRIPTION
Inspired by [Spock 1.1?](https://groups.google.com/d/topic/spockframework/LjJS848xGy0/discussion) group topic and the sheer awesomeness of [jitpack.io](http://jitpack.io).

After merging this PR users will be able to download jars/resolve dependencies built from whatever git commit they need to, just by specifying the dependency as follows (gradle):

```
testCompile('com.github.spockframework.spock:spock-core:7d9b5c004e')
testCompile('com.github.spockframework.spock:spock-reports:7d9b5c004e')
```

The jars will be built automatically upon first request for a given version, which means no maintainer interaction is needed to download a snapshot release.

Additionally, after a [adding a simple DNS entry](https://jitpack.io/docs/#custom-domain-name) for spockframework.org the following will be possible:

```
testCompile('org.spockframework.spock:spock-core:7d9b5c004e')
testCompile('org.spockframework.spock:spock-reports:7d9b5c004e')
```

The pull request assumes that users interested in a snapshot version want to live on the bleeding edge and are using the latest groovy. If that's not the case, we can consider emitting jars for all groovy versions whenever the build/jar/install task is invoked.

Hope you like it! :)
