### PR TITLE
Add support for detached mocks, stubs, and spies (java-only)

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/IMockConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IMockConfiguration.java
@@ -5,12 +5,13 @@ import java.util.List;
 
 import org.spockframework.util.Beta;
 import org.spockframework.util.Nullable;
+import spock.mock.MockingApi;
 
 /**
  * Configuration options for mock objects. Once a mock object has been created, its configuration cannot be changed.
  *
  * <p>{@link #getNature()} and {@link #getImplementation()} are mandatory options that are typically
- * determined by choosing the appropriate {@link spock.lang.MockingApi} factory method. {@link #getType()}
+ * determined by choosing the appropriate {@link MockingApi} factory method. {@link #getType()}
  * is a mandatory option that is typically passed directly to a {@code MockingApi} factory method, or inferred
  * from the left-hand side of the enclosing variable assignment. The remaining options are optional and are
  * typically passed to a {@code MockingApi} factory method as named arguments. For example,

--- a/spock-core/src/main/java/org/spockframework/mock/IMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IMockFactory.java
@@ -19,4 +19,5 @@ import spock.lang.Specification;
 public interface IMockFactory {
   public boolean canCreate(IMockConfiguration configuration);
   public Object create(IMockConfiguration configuration, Specification specification);
+  public Object createDetached(IMockConfiguration configuration, ClassLoader classLoader);
 }

--- a/spock-core/src/main/java/org/spockframework/mock/IMockObject.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IMockObject.java
@@ -14,13 +14,14 @@
 
 package org.spockframework.mock;
 
+import org.spockframework.mock.runtime.SpecificationAttachable;
 import org.spockframework.util.Nullable;
 
 import spock.lang.Specification;
 
 import java.lang.reflect.Type;
 
-public interface IMockObject {
+public interface IMockObject extends SpecificationAttachable {
   /**
    * Returns the name of this mock object, or {@code null} if it has no name.
    *
@@ -70,6 +71,7 @@ public interface IMockObject {
    *
    * @return the specification that this mock object is attached to
    */
+  @Nullable
   Specification getSpecification();
 
   /**

--- a/spock-core/src/main/java/org/spockframework/mock/ISpockMockObject.java
+++ b/spock-core/src/main/java/org/spockframework/mock/ISpockMockObject.java
@@ -16,7 +16,7 @@ package org.spockframework.mock;
 
 /**
  * Marker-like interface implemented by all mock objects that allows
- * {@link MockDetector} to detect mock objects. Not intended for direct use.
+ * {@link MockUtil} to detect mock objects. Not intended for direct use.
  */
 public interface ISpockMockObject {
   IMockObject $spock_get();

--- a/spock-core/src/main/java/org/spockframework/mock/MockImplementation.java
+++ b/spock-core/src/main/java/org/spockframework/mock/MockImplementation.java
@@ -15,23 +15,24 @@
 package org.spockframework.mock;
 
 import org.spockframework.util.Beta;
+import spock.mock.MockingApi;
 
 /**
  * Determines how method calls are processed and matched against interactions. A mock implementation
- * is chosen at mock creation time, typically by selecting the appropriate {@link spock.lang.MockingApi} factory method.
+ * is chosen at mock creation time, typically by selecting the appropriate {@link MockingApi} factory method.
  */
 @Beta
 public enum MockImplementation {
   /**
-   * A generic implementation targeting any callers. Used by the {@link spock.lang.MockingApi#Mock},
-   * {@link spock.lang.MockingApi#Stub}, and {@link spock.lang.MockingApi#Spy} factory methods.
+   * A generic implementation targeting any callers. Used by the {@link MockingApi#Mock},
+   * {@link MockingApi#Stub}, and {@link MockingApi#Spy} factory methods.
    */
   JAVA,
   /**
    * An implementation specifically targeting Groovy callers. Supports mocking of dynamic methods,
    * constructors, static methods, and "magic" mocking of all objects of a particular type.
-   * Used by the {@link spock.lang.MockingApi#GroovyMock}, {@link spock.lang.MockingApi#GroovyStub},
-   * and {@link spock.lang.MockingApi#GroovySpy} factory methods.
+   * Used by the {@link MockingApi#GroovyMock}, {@link MockingApi#GroovyStub},
+   * and {@link MockingApi#GroovySpy} factory methods.
    */
   GROOVY
 }

--- a/spock-core/src/main/java/org/spockframework/mock/MockNature.java
+++ b/spock-core/src/main/java/org/spockframework/mock/MockNature.java
@@ -15,10 +15,11 @@
 package org.spockframework.mock;
 
 import org.spockframework.util.Beta;
+import spock.mock.MockingApi;
 
 /**
  * A named set of defaults for a mock's configuration options. A mock nature is chosen at
- * mock creation time, typically by selecting the appropriate {@link spock.lang.MockingApi} factory method.
+ * mock creation time, typically by selecting the appropriate {@link MockingApi} factory method.
  */
 @Beta
 public enum MockNature {

--- a/spock-core/src/main/java/org/spockframework/mock/MockUtil.java
+++ b/spock-core/src/main/java/org/spockframework/mock/MockUtil.java
@@ -14,13 +14,21 @@
 
 package org.spockframework.mock;
 
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import org.spockframework.mock.runtime.CompositeMockFactory;
+import org.spockframework.mock.runtime.MockConfiguration;
 import org.spockframework.util.Beta;
+import org.spockframework.util.Nullable;
+
+import spock.lang.Specification;
 
 /**
  * Detects mock objects and provides information about them.
  */
 @Beta
-public class MockDetector {
+public class MockUtil {
   /**
    * Tells whether the given object is a (Spock) mock object.
    *
@@ -48,5 +56,44 @@ public class MockDetector {
 
     ISpockMockObject handle = (ISpockMockObject) object;
     return handle.$spock_get();
+  }
+
+  /**
+   * Attaches mock to a Specification.
+   *
+   * @param object a mock object
+   * @param specification the Specification to attach to
+   */
+  public void attachMock(Object object, Specification specification) {
+    asMock(object).attach(specification);
+  }
+
+  /**
+   * Detaches mock from its current Specification.
+   *
+   * @param object a mock object
+   */
+  public void detachMock(Object object) {
+    asMock(object).detach();
+  }
+
+  /**
+   * Creates a detached mock.
+   *
+   * @param name the name
+   * @param type the type of the mock
+   * @param nature the nature
+   * @param implementation the implementation
+   * @param options the options
+   * @param classloader the classloader to use
+   * @return the mock
+   */
+  @Beta
+  public Object createDetachedMock(@Nullable String name, Type type, MockNature nature,
+      MockImplementation implementation, Map<String, Object> options,  ClassLoader classloader) {
+
+    Object mock = CompositeMockFactory.INSTANCE.createDetached(
+        new MockConfiguration(name, type, nature, implementation, options), classloader);
+    return mock;
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/CompositeMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/CompositeMockFactory.java
@@ -47,4 +47,15 @@ public class CompositeMockFactory implements IMockFactory {
 
     throw new InternalSpockError("No matching mock factory found");
   }
+
+	public Object createDetached(IMockConfiguration configuration,
+			ClassLoader classLoader) {
+	  for (IMockFactory factory : mockFactories) {
+      if (factory.canCreate(configuration)) {
+        return factory.createDetached(configuration, classLoader);
+      }
+    }
+
+    throw new InternalSpockError("No matching mock factory found");
+	}
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockFactory.java
@@ -71,4 +71,9 @@ public class GroovyMockFactory implements IMockFactory {
   private boolean isFinalClass(Class<?> type) {
     return !type.isInterface() && Modifier.isFinal(type.getModifiers());
   }
+
+  public Object createDetached(IMockConfiguration configuration, ClassLoader classLoader) {
+    throw new CannotCreateMockException(configuration.getType(),
+        ". Detached mocking is only possible for JavaMocks but not GroovyMocks at the moment.");
+  }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockInterceptor.java
@@ -40,7 +40,7 @@ public class GroovyMockInterceptor implements IProxyBasedMockInterceptor {
 
   public Object intercept(Object target, Method method, Object[] arguments, IResponseGenerator realMethodInvoker) {
     IMockObject mockObject = new MockObject(mockConfiguration.getName(), mockConfiguration.getExactType(), target,
-        mockConfiguration.isVerified(), mockConfiguration.isGlobal(), mockConfiguration.getDefaultResponse(), specification);
+        mockConfiguration.isVerified(), mockConfiguration.isGlobal(), mockConfiguration.getDefaultResponse(), specification, this);
 
     if (method.getDeclaringClass() == ISpockMockObject.class) {
       return mockObject;
@@ -82,5 +82,13 @@ public class GroovyMockInterceptor implements IProxyBasedMockInterceptor {
 
   private boolean isMethod(Method method, String name, Class<?>... parameterTypes) {
     return method.getName().equals(name) && Arrays.equals(method.getParameterTypes(), parameterTypes);
+  }
+
+  public void attach(Specification specification) {
+    // NO-OP since GroovyMocks do not support detached mocks at the moment
+  }
+
+  public void detach() {
+    // NO-OP since GroovyMocks do not support detached mocks at the moment
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockMetaClass.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockMetaClass.java
@@ -27,7 +27,7 @@ import org.spockframework.util.ReflectionUtil;
 
 import spock.lang.Specification;
 
-public class GroovyMockMetaClass extends DelegatingMetaClass {
+public class GroovyMockMetaClass extends DelegatingMetaClass implements SpecificationAttachable {
   private final IMockConfiguration configuration;
   private final Specification specification;
 
@@ -116,7 +116,7 @@ public class GroovyMockMetaClass extends DelegatingMetaClass {
   private IMockInvocation createMockInvocation(MetaMethod metaMethod, Object target,
       String methodName, Object[] arguments, boolean isStatic) {
     IMockObject mockObject = new MockObject(configuration.getName(), configuration.getExactType(), target,
-        configuration.isVerified(), configuration.isGlobal(), configuration.getDefaultResponse(), specification);
+        configuration.isVerified(), configuration.isGlobal(), configuration.getDefaultResponse(), specification, this);
     IMockMethod mockMethod;
     if (metaMethod != null) {
       List<Type> parameterTypes = Arrays.<Type>asList(metaMethod.getNativeParameterTypes());
@@ -125,5 +125,13 @@ public class GroovyMockMetaClass extends DelegatingMetaClass {
       mockMethod = new DynamicMockMethod(methodName, arguments.length, isStatic);
     }
     return new MockInvocation(mockObject, mockMethod, Arrays.asList(arguments), new GroovyRealMethodInvoker(getAdaptee()));
+  }
+
+  public void attach(Specification specification) {
+    // NO-OP since GroovyMocks do not support detached mocks at the moment
+  }
+
+  public void detach() {
+    // NO-OP since GroovyMocks do not support detached mocks at the moment
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/IProxyBasedMockInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/IProxyBasedMockInterceptor.java
@@ -18,6 +18,6 @@ import java.lang.reflect.Method;
 
 import org.spockframework.mock.IResponseGenerator;
 
-public interface IProxyBasedMockInterceptor {
+public interface IProxyBasedMockInterceptor extends SpecificationAttachable {
   Object intercept(Object target, Method method, Object[] arguments, IResponseGenerator realMethodInvoker);
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/JavaMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/JavaMockFactory.java
@@ -37,6 +37,14 @@ public class JavaMockFactory implements IMockFactory {
   }
 
   public Object create(IMockConfiguration configuration, Specification specification) {
+    return createInternal(configuration, specification, specification.getClass().getClassLoader());
+  }
+
+	public Object createDetached(IMockConfiguration configuration, ClassLoader classLoader) {
+		 return createInternal(configuration, null, classLoader);
+	}
+
+  private Object createInternal(IMockConfiguration configuration, Specification specification, ClassLoader classLoader) {
     if (Modifier.isFinal(configuration.getType().getModifiers())) {
       throw new CannotCreateMockException(configuration.getType(),
           " because Java mocks cannot mock final classes. If the code under test is written in Groovy, use a Groovy mock.");
@@ -49,7 +57,7 @@ public class JavaMockFactory implements IMockFactory {
     MetaClass mockMetaClass = GroovyRuntimeUtil.getMetaClass(configuration.getType());
     IProxyBasedMockInterceptor interceptor = new JavaMockInterceptor(configuration, specification, mockMetaClass);
     return ProxyBasedMockFactory.INSTANCE.create(configuration.getType(), Collections.<Class<?>>emptyList(),
-        configuration.getConstructorArgs(), interceptor, specification.getClass().getClassLoader(),
+        configuration.getConstructorArgs(), interceptor, classLoader,
         configuration.isUseObjenesis());
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/JavaMockInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/JavaMockInterceptor.java
@@ -28,7 +28,8 @@ import spock.lang.Specification;
 
 public class JavaMockInterceptor implements IProxyBasedMockInterceptor {
   private final IMockConfiguration mockConfiguration;
-  private final Specification specification;
+  private Specification specification;
+  private MockController fallbackMockController;
   private final MetaClass mockMetaClass;
 
   public JavaMockInterceptor(IMockConfiguration mockConfiguration, Specification specification, MetaClass mockMetaClass) {
@@ -39,7 +40,7 @@ public class JavaMockInterceptor implements IProxyBasedMockInterceptor {
 
   public Object intercept(Object target, Method method, Object[] arguments, IResponseGenerator realMethodInvoker) {
     IMockObject mockObject = new MockObject(mockConfiguration.getName(), mockConfiguration.getExactType(),
-        target, mockConfiguration.isVerified(), false, mockConfiguration.getDefaultResponse(), specification);
+        target, mockConfiguration.isVerified(), false, mockConfiguration.getDefaultResponse(), specification, this);
 
     if (method.getDeclaringClass() == ISpockMockObject.class) {
       return mockObject;
@@ -67,13 +68,30 @@ public class JavaMockInterceptor implements IProxyBasedMockInterceptor {
 
     IMockMethod mockMethod = new StaticMockMethod(method, mockConfiguration.getExactType());
     IMockInvocation invocation = new MockInvocation(mockObject, mockMethod, Arrays.asList(normalizedArgs), realMethodInvoker);
-    IMockController mockController = specification.getSpecificationContext().getMockController();
+    IMockController mockController = specification == null ? getFallbackMockController() :
+                                                             specification.getSpecificationContext().getMockController();
 
     return mockController.handle(invocation);
   }
 
   private boolean isMethod(Method method, String name, Class<?>... parameterTypes) {
     return method.getName().equals(name) && Arrays.equals(method.getParameterTypes(), parameterTypes);
+  }
+
+	public void attach(Specification specification) {
+		this.specification = specification;
+
+	}
+
+	public void detach() {
+	  this.specification = null;
+	}
+
+	public MockController getFallbackMockController() {
+	  if (fallbackMockController == null) {
+	    fallbackMockController = new MockController();
+	  }
+    return fallbackMockController;
   }
 }
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockObject.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockObject.java
@@ -33,10 +33,12 @@ public class MockObject implements IMockObject {
   private final boolean verified;
   private final boolean global;
   private final IDefaultResponse defaultResponse;
-  private final Specification specification;
+  private final SpecificationAttachable mockInterceptor;
 
-  public MockObject(@Nullable String name, Type type, Object instance,
-      boolean verified, boolean global, IDefaultResponse defaultResponse, Specification specification) {
+  private Specification specification;
+
+  public MockObject(@Nullable String name, Type type, Object instance, boolean verified, boolean global,
+      IDefaultResponse defaultResponse, Specification specification, SpecificationAttachable mockInterceptor) {
     this.name = name;
     this.type = type;
     this.instance = instance;
@@ -44,6 +46,7 @@ public class MockObject implements IMockObject {
     this.global = global;
     this.defaultResponse = defaultResponse;
     this.specification = specification;
+    this.mockInterceptor = mockInterceptor;
   }
 
   @Nullable
@@ -91,5 +94,15 @@ public class MockObject implements IMockObject {
       throw new InvalidSpecException("Stub '%s' matches the following required interaction:" +
           "\n\n%s\n\nRemove the cardinality (e.g. '1 *'), or turn the stub into a mock.\n").withArgs(mockName, interaction);
     }
+  }
+
+  public void attach(Specification spec) {
+    this.specification = spec;
+    this.mockInterceptor.attach(spec);
+  }
+
+  public void detach() {
+    this.specification = null;
+    this.mockInterceptor.detach();
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/SpecificationAttachable.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/SpecificationAttachable.java
@@ -1,0 +1,25 @@
+package org.spockframework.mock.runtime;
+
+import spock.lang.Specification;
+
+/**
+ * The Object implementing this interface can be attached to and
+ * detached from a {@link Specification}.
+ *
+ * @author Leonard Bruenings
+ */
+public interface SpecificationAttachable {
+
+  /**
+   * Attaches the mock to a specification.
+   *
+   * @param specification specification that this mock object should attached to
+   */
+  void attach(Specification specification);
+
+  /**
+   * Detaches the mock from its current specification.
+   */
+  void detach();
+
+}

--- a/spock-core/src/main/java/spock/lang/Specification.java
+++ b/spock-core/src/main/java/spock/lang/Specification.java
@@ -24,6 +24,7 @@ import org.spockframework.lang.Wildcard;
 import org.spockframework.util.ExceptionUtil;
 import org.spockframework.runtime.*;
 import org.spockframework.runtime.GroovyRuntimeUtil;
+import spock.mock.MockingApi;
 
 /**
  * Base class for Spock specifications. All specifications must inherit from

--- a/spock-core/src/main/java/spock/mock/DetachedMockFactory.java
+++ b/spock-core/src/main/java/spock/mock/DetachedMockFactory.java
@@ -1,0 +1,152 @@
+package spock.mock;
+
+import org.spockframework.mock.MockImplementation;
+import org.spockframework.mock.MockNature;
+import org.spockframework.mock.MockUtil;
+import org.spockframework.util.Beta;
+import org.spockframework.util.Nullable;
+import spock.lang.Specification;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * This factory allows the creations of mocks outside of a {@link spock.lang.Specification},
+ * e.g., in a Spring configuration.
+ * <p/>
+ * In order to be usable those Mocks must be manually attached to the {@link spock.lang.Specification}
+ * using {@link MockUtil#attachMock(Object, Specification)} and detached afterwards {@link MockUtil#detachMock(Object)}.
+ */
+@Beta
+public class DetachedMockFactory implements MockFactory {
+  /**
+     * Creates a mock with the specified type. The mock name will be the types simple name.
+     *
+     * Example:
+     *
+     * <pre>
+     *   def person = Mock(Person) // type is Person.class, name is "person"
+     * </pre>
+     *
+     * @param type the interface or class type of the mock
+     * @param <T> the interface or class type of the mock
+     *
+     * @return a mock with the specified type
+     */
+  @Override
+  public <T> T Mock(Class<T> type) {
+    return createMock(inferNameFromType(type), type, MockNature.MOCK, Collections.<String, Object>emptyMap());
+  }
+
+  /**
+     * Creates a mock with the specified options and type. The mock name will be the types simple name.
+     *
+     * Example:
+     *
+     * <pre>
+     *   def person = Mock(Person, name: "myPerson") // type is Person.class, name is "myPerson"
+     * </pre>
+     *
+     * @param options optional options for creating the mock
+     * @param type the interface or class type of the mock
+     * @param <T> the interface or class type of the mock
+     *
+     * @return a mock with the specified options and type
+     */
+  @Override
+  public <T> T Mock(Map<String, Object> options, Class<T> type) {
+    return createMock(inferNameFromType(type), type, MockNature.MOCK, options);
+  }
+
+  /**
+     * Creates a stub with the specified type. The mock name will be the types simple name.
+     *
+     * Example:
+     *
+     * <pre>
+     *   def person = Stub(Person) // type is Person.class, name is "person"
+     * </pre>
+     *
+     * @param type the interface or class type of the stub
+     * @param <T> the interface or class type of the stub
+     *
+     * @return a stub with the specified type
+     */
+  @Override
+  public <T> T Stub(Class<T> type) {
+    return createMock(inferNameFromType(type), type, MockNature.STUB, Collections.<String, Object>emptyMap());
+  }
+
+  /**
+     * Creates a stub with the specified options and type. The mock name will be the types simple name.
+     *
+     * Example:
+     *
+     * <pre>
+     *   def person = Stub(Person, name: "myPerson") // type is Person.class, name is "myPerson"
+     * </pre>
+     *
+     * @param options optional options for creating the stub
+     * @param type the interface or class type of the stub
+     * @param <T> the interface or class type of the stub
+     *
+     * @return a stub with the specified options and type
+     */
+  @Override
+  public <T> T Stub(Map<String, Object> options, Class<T> type) {
+    return createMock(inferNameFromType(type), type, MockNature.STUB, options);
+  }
+
+  /**
+     * Creates a spy with the specified type. The mock name will be the types simple name.
+     *
+     * Example:
+     *
+     * <pre>
+     *   def person = Spy(Person) // type is Person.class, name is "person"
+     * </pre>
+     *
+     * @param type the class type of the spy
+     * @param <T> the class type of the spy
+     *
+     * @return a spy with the specified type
+     */
+  @Override
+  public <T> T Spy(Class<T> type) {
+    return createMock(inferNameFromType(type), type, MockNature.SPY, Collections.<String, Object>emptyMap());
+  }
+
+  /**
+     * Creates a spy with the specified options and type. The mock name will be the types simple name.
+     *
+     * Example:
+     *
+     * <pre>
+     *   def person = Spy(Person, name: "myPerson") // type is Person.class, name is "myPerson"
+     * </pre>
+     *
+     * @param options optional options for creating the spy
+     * @param type the class type of the spy
+     * @param <T> the class type of the spy
+     *
+     * @return a spy with the specified options and type
+     */
+  @Override
+  public <T> T Spy(Map<String, Object> options, Class<T> type) {
+    return createMock(inferNameFromType(type), type, MockNature.SPY, options);
+  }
+
+
+  @SuppressWarnings("unchecked")
+  public <T> T createMock(@Nullable String name, Class<T> type, MockNature nature, Map<String, Object> options) {
+    ClassLoader classLoader = type.getClassLoader();
+    if (classLoader == null) {
+      classLoader = ClassLoader.getSystemClassLoader();
+    }
+    return (T) new MockUtil().createDetachedMock(name, type, nature, MockImplementation.JAVA, options, classLoader);
+  }
+
+  private String inferNameFromType(Class<?> type) {
+    return type.getSimpleName();
+  }
+}

--- a/spock-core/src/main/java/spock/mock/MockFactory.java
+++ b/spock-core/src/main/java/spock/mock/MockFactory.java
@@ -1,0 +1,115 @@
+package spock.mock;
+
+import org.spockframework.util.Beta;
+
+import java.util.Map;
+
+/**
+ * Base interface for Java based mocks see {@link MockingApi} or {@link DetachedMockFactory} for more examples.
+ */
+public interface MockFactory {
+  /**
+   * Creates a mock with the specified type.
+   *
+   * Example:
+   *
+   * <pre>
+   *   def person = Mock(Person) // type is Person.class, name is "person"
+   * </pre>
+   *
+   * @param type the interface or class type of the mock
+   * @param <T> the interface or class type of the mock
+   *
+   * @return a mock with the specified type
+   */
+  <T> T Mock(Class<T> type);
+
+  /**
+   * Creates a mock with the specified options and type.
+   *
+   * Example:
+   *
+   * <pre>
+   *   def person = Mock(Person, name: "myPerson") // type is Person.class, name is "myPerson"
+   * </pre>
+   *
+   * @param options optional options for creating the mock
+   * @param type the interface or class type of the mock
+   * @param <T> the interface or class type of the mock
+   *
+   * @return a mock with the specified options and type
+   */
+  @Beta
+  <T> T Mock(Map<String, Object> options, Class<T> type);
+
+  /**
+   * Creates a stub with the specified type.
+   *
+   * Example:
+   *
+   * <pre>
+   *   def person = Stub(Person) // type is Person.class, name is "person"
+   * </pre>
+   *
+   * @param type the interface or class type of the stub
+   * @param <T> the interface or class type of the stub
+   *
+   * @return a stub with the specified type
+   */
+  @Beta
+  <T> T Stub(Class<T> type);
+
+  /**
+   * Creates a stub with the specified options and type.
+   *
+   * Example:
+   *
+   * <pre>
+   *   def person = Stub(Person, name: "myPerson") // type is Person.class, name is "myPerson"
+   * </pre>
+   *
+   * @param options optional options for creating the stub
+   * @param type the interface or class type of the stub
+   * @param <T> the interface or class type of the stub
+   *
+   * @return a stub with the specified options and type
+   */
+  @Beta
+  <T> T Stub(Map<String, Object> options, Class<T> type);
+
+  /**
+   * Creates a spy with the specified type.
+   *
+   * Example:
+   *
+   * <pre>
+   *   def person = Spy(Person) // type is Person.class, name is "person"
+   * </pre>
+   *
+   * @param type the class type of the spy
+   * @param <T> the class type of the spy
+   *
+   * @return a spy with the specified type
+   */
+  @Beta
+  <T> T Spy(Class<T> type);
+
+  /**
+   * Creates a spy with the specified options and type.
+   *
+   * Example:
+   *
+   * <pre>
+   *   def person = Spy(Person, name: "myPerson") // type is Person.class, name is "myPerson"
+   * </pre>
+   *
+   * @param options optional options for creating the spy
+   * @param type the class type of the spy
+   * @param <T> the class type of the spy
+   *
+   * @return a spy with the specified options and type
+   */
+  @Beta
+  <T> T Spy(Map<String, Object> options, Class<T> type);
+
+}

--- a/spock-core/src/main/java/spock/mock/MockingApi.java
+++ b/spock-core/src/main/java/spock/mock/MockingApi.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package spock.lang;
+package spock.mock;
 
 import java.util.Map;
 
@@ -67,7 +67,7 @@ import org.spockframework.runtime.GroovyRuntimeUtil;
  * </pre>
  */
 @SuppressWarnings("unused")
-public class MockingApi extends SpecInternals {
+public class MockingApi extends SpecInternals implements MockFactory {
   /**
    * Encloses one or more interaction definitions in a <tt>then</tt> block.
    * Required when an interaction definition uses a statement that doesn't
@@ -179,6 +179,7 @@ public class MockingApi extends SpecInternals {
    *
    * @return a mock with the specified type
    */
+  @Override
   public <T> T Mock(Class<T> type) {
     invalidMockCreation();
     return null;
@@ -200,6 +201,7 @@ public class MockingApi extends SpecInternals {
    *
    * @return a mock with the specified options and type
    */
+  @Override
   @Beta
   public <T> T Mock(Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
@@ -363,6 +365,7 @@ public class MockingApi extends SpecInternals {
    *
    * @return a stub with the specified type
    */
+  @Override
   @Beta
   public <T> T Stub(Class<T> type) {
     invalidMockCreation();
@@ -385,6 +388,7 @@ public class MockingApi extends SpecInternals {
    *
    * @return a stub with the specified options and type
    */
+  @Override
   @Beta
   public <T> T Stub(Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
@@ -548,6 +552,7 @@ public class MockingApi extends SpecInternals {
    *
    * @return a spy with the specified type
    */
+  @Override
   @Beta
   public <T> T Spy(Class<T> type) {
     invalidMockCreation();
@@ -570,6 +575,7 @@ public class MockingApi extends SpecInternals {
    *
    * @return a spy with the specified options and type
    */
+  @Override
   @Beta
   public <T> T Spy(Map<String, Object> options, Class<T> type) {
     invalidMockCreation();

--- a/spock-core/src/main/resources/dsld/spk.dsld
+++ b/spock-core/src/main/resources/dsld/spk.dsld
@@ -40,7 +40,7 @@ contribute(
 // works for all mock factory methods and all overloads that include a type
 contribute(
     enclosingClass(subType("spock.lang.Specification")) &
-    enclosingCallDeclaringType("spock.lang.MockingApi") &
+    enclosingCallDeclaringType("spock.mock.MockingApi") &
     bind(theCalls: enclosingCall(name("Mock") | name("Stub") | name("Spy") | name("GroovyMock") | name("GroovyStub") | name("GroovySpy"))) &
 	enclosingClosure()) {
   def args = theCalls.iterator().next().arguments.expressions

--- a/spock-core/src/main/resources/org/spockframework/idea/spock.gdsl
+++ b/spock-core/src/main/resources/org/spockframework/idea/spock.gdsl
@@ -50,7 +50,7 @@ contributor(ctx, {
   if (call) {
     def method = call.bind()
     def clazz = method?.containingClass
-    if (clazz?.qualName == "spock.lang.MockingApi") {
+    if (clazz?.qualName == "spock.mock.MockingApi") {
       def mockType = call.arguments.find { it.type.className == "Class" }
       if (mockType) {
         def typeParameter = mockType.type.parameters[0]

--- a/spock-specs/src/test/groovy/org/spockframework/mock/DetachedMockFactorySpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/DetachedMockFactorySpec.groovy
@@ -1,0 +1,135 @@
+package org.spockframework.mock
+
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.mock.DetachedMockFactory
+
+class DetachedMockFactorySpec extends Specification {
+
+  @Subject
+  DetachedMockFactory factory = new DetachedMockFactory()
+
+  def "Mock(class)"() {
+    given:
+    IMockMe mock = factory.Mock(IMockMe)
+    attach(mock)
+
+    when:
+    mock.foo(2)
+
+    then:
+    1 * mock.foo(2)
+    getMockName(mock) == 'IMockMe'
+
+    cleanup:
+    detach(mock)
+  }
+
+  def "Mock(options, class)"() {
+    given:
+    IMockMe mock = factory.Mock(IMockMe, name: 'customName')
+    attach(mock)
+
+    when:
+    mock.foo(2)
+
+    then:
+    1 * mock.foo(2)
+    getMockName(mock) == 'customName'
+
+    cleanup:
+    detach(mock)
+  }
+
+  def "Stub(class)"() {
+    given:
+    IMockMe stub = factory.Stub(IMockMe)
+    attach(stub)
+    stub.foo(2) >> 4
+
+    expect:
+    stub.foo(2) == 4
+    stub.foo(1) == 0
+    getMockName(stub) == 'IMockMe'
+
+    cleanup:
+    detach(stub)
+  }
+
+  def "Stub(options, class)"() {
+    given:
+    IMockMe stub = factory.Stub(IMockMe, name: 'customName')
+    attach(stub)
+    stub.foo(2) >> 4
+
+    expect:
+    stub.foo(2) == 4
+    stub.foo(1) == 0
+    getMockName(stub) == 'customName'
+
+    cleanup:
+    detach(stub)
+  }
+
+  def "Spy(class)"() {
+    given:
+    IMockMe spy = factory.Spy(MockMe.class)
+    attach(spy)
+
+    when:
+    int result = spy.foo(2)
+
+    then:
+    result == 1
+    1 * spy.foo(2)
+
+    cleanup:
+    detach(spy)
+  }
+
+  def "Spy(options, class)"() {
+    given:
+    IMockMe spy = factory.Spy(MockMe.class, constructorArgs: [42])
+    attach(spy)
+
+    when:
+    int result = spy.foo(2)
+
+    then:
+    result == 42
+    1 * spy.foo(2)
+
+    cleanup:
+    detach(spy)
+  }
+
+  private String getMockName(IMockMe mock) {
+    new MockUtil().asMock(mock).name
+  }
+
+  void attach(Object mock) {
+    new MockUtil().attachMock(mock, this)
+  }
+
+  void detach(Object mock) {
+    new MockUtil().detachMock(mock)
+  }
+}
+
+interface IMockMe {
+  int foo(int i)
+}
+
+class MockMe implements IMockMe {
+  private int defaultAnswer = 1
+
+  MockMe(){}
+
+  MockMe(int defaultAnswer) {
+    this.defaultAnswer = defaultAnswer
+  }
+
+  int foo(int i) {
+    defaultAnswer
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/mock/DetachedMockSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/DetachedMockSpec.groovy
@@ -1,0 +1,46 @@
+package org.spockframework.mock
+
+import spock.lang.Shared;
+import spock.lang.Specification;
+import spock.lang.Stepwise;
+
+@Stepwise
+class DetachedMockSpec extends Specification {
+
+  @Shared
+  MockUtil mockUtil = new MockUtil()
+
+  @Shared
+  List listMock
+
+  def setupSpec() {
+    listMock = mockUtil.createDetachedMock("listMock", List, MockNature.MOCK, MockImplementation.JAVA, [:], getClass().classLoader)
+  }
+
+  def setup () {
+    mockUtil.attachMock(listMock, this)
+  }
+
+  def cleanup() {
+    mockUtil.detachMock(listMock)
+  }
+
+
+  def "Mock returns default answer"() {
+    expect:
+    listMock.size() == 0
+  }
+
+  def "Configure and test mock"() {
+    when:
+    assert listMock.size() == 1
+
+    then:
+    1 * listMock.size() >> 1
+  }
+
+  def "Mock returns default answer after being configured and reattached"() {
+    expect:
+    listMock.size() == 0
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/mock/MockDetectorSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/MockDetectorSpec.groovy
@@ -16,7 +16,7 @@ package org.spockframework.mock
 import spock.lang.Specification
 
 class MockDetectorSpec extends Specification {
-  def detector = new MockDetector()
+  def detector = new MockUtil()
   
   def "detects interface based mocks"() {
     expect:

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/StubDefaultResponses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/StubDefaultResponses.groovy
@@ -16,7 +16,7 @@
 
 package org.spockframework.smoke.mock
 
-import org.spockframework.mock.MockDetector
+import org.spockframework.mock.MockUtil
 
 import spock.lang.Specification
 
@@ -109,7 +109,7 @@ class StubDefaultResponses extends Specification {
 
     expect:
     with(stub.getUnknownInterface()) {
-      new MockDetector().isMock(it)
+      new MockUtil().isMock(it)
       name == ""
       age == 0
       children == []
@@ -121,7 +121,7 @@ class StubDefaultResponses extends Specification {
 
     expect:
     with(stub.getUnknownClassWithDefaultCtor()) {
-      !new MockDetector().isMock(it)
+      !new MockUtil().isMock(it)
       name == "default"
       age == 0
       children == null
@@ -133,7 +133,7 @@ class StubDefaultResponses extends Specification {
 
     expect:
     with(stub.getUnknownClassWithoutDefaultCtor()) {
-      new MockDetector().isMock(it)
+      new MockUtil().isMock(it)
       name == ""
       age == 0
       children == []

--- a/spock-spring/spring.gradle
+++ b/spock-spring/spring.gradle
@@ -15,8 +15,8 @@ dependencies {
   compile project(":spock-core")
   compile "org.springframework:spring-test:$springVersion", provided
   compile "org.springframework:spring-beans:$springVersion", provided
+  compile "org.springframework:spring-context:$springVersion", provided
 
-  testCompile "org.springframework:spring-context:$springVersion"
   // not used directly at compile-time, but needed by groovyc
   testCompile "org.springframework:spring-core:$springVersion"
   testCompile "org.springframework:spring-jdbc:$springVersion"

--- a/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
@@ -1,0 +1,71 @@
+package org.spockframework.spring;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.spockframework.mock.ISpockMockObject;
+import org.spockframework.mock.MockUtil;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+
+import spock.lang.Specification;
+
+/**
+ * This {@link TestExecutionListener} takes care of attaching and detaching the
+ * mocks to the current {@link Specification}.
+ *
+ * @author Leonard Bruenings
+ */
+public class SpringMockTestExecutionListener implements TestExecutionListener {
+
+  public static final String MOCKED_BEANS_LIST = "org.spockframework.spring.SpringMockTestExecutionListener.MOCKED_BEANS_LIST";
+
+  private final MockUtil mockUtil = new MockUtil();
+
+  public void beforeTestClass(TestContext testContext) throws Exception {
+  }
+
+  public void prepareTestInstance(TestContext testContext) throws Exception {
+  }
+
+  public void beforeTestMethod(TestContext testContext) throws Exception {
+    Object testInstance = testContext.getTestInstance();
+
+    if (testInstance instanceof Specification) {
+      Specification specification = (Specification) testInstance;
+
+      ApplicationContext applicationContext = testContext.getApplicationContext();
+      String[] mockBeanNames = applicationContext.getBeanDefinitionNames();
+      List<Object> mockedBeans = new ArrayList<Object>();
+
+      for (String beanName : mockBeanNames) {
+        Object bean = applicationContext.getBean(beanName);
+        if (mockUtil.isMock(bean)) {
+          mockUtil.attachMock(bean, specification);
+          mockedBeans.add(bean);
+        }
+      }
+
+      testContext.setAttribute(MOCKED_BEANS_LIST, mockedBeans);
+
+    } else {
+      throw new IllegalArgumentException("SpringMockTestExecutionListener is only applicable for spock specifications.");
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public void afterTestMethod(TestContext testContext) throws Exception {
+    List<Object> mockedBeans = (List<Object>) testContext.getAttribute(MOCKED_BEANS_LIST);
+
+    if (mockedBeans != null) {
+      for (Object object : mockedBeans) {
+        mockUtil.detachMock(object);
+      }
+    }
+  }
+
+  public void afterTestClass(TestContext testContext) throws Exception {
+  }
+
+}

--- a/spock-spring/src/main/java/org/spockframework/spring/SpringTestContextManager.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringTestContextManager.java
@@ -33,6 +33,7 @@ public class SpringTestContextManager {
 
   public SpringTestContextManager(Class<?> testClass) {
     delegate = new TestContextManager(testClass);
+    delegate.registerTestExecutionListeners(new SpringMockTestExecutionListener());
   }
 
   public void beforeTestClass() throws Exception {

--- a/spock-spring/src/main/java/org/spockframework/spring/xml/MockBeanDefinitionParser.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/xml/MockBeanDefinitionParser.java
@@ -1,0 +1,43 @@
+package org.spockframework.spring.xml;
+
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.w3c.dom.Element;
+
+/**
+ * Adds support for the spock:mock element.
+ *
+ * Spring integration of spock mocks is heavily inspired by
+ * Springokito {@see https://bitbucket.org/kubek2k/springockito}.
+ *
+ * @author Leonard Bruenings
+ */
+public class MockBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+  @Override
+  protected Class<?> getBeanClass(Element element) {
+    return SpockMockFactoryBean.class;
+  }
+
+  @Override
+  protected String getBeanClassName(Element element) {
+    return getBeanClass(element).getName();
+  }
+
+  @Override
+  protected void doParse(Element element, BeanDefinitionBuilder builder) {
+
+    // configure MockFactory
+    builder.addConstructorArgValue(element.getAttribute("class"));
+    builder.addPropertyValue("name", element.getAttribute("id"));
+    builder.addPropertyValue("mockNature", element.getLocalName());
+  }
+
+  @Override
+  protected void postProcessComponentDefinition(BeanComponentDefinition componentDefinition) {
+    super.postProcessComponentDefinition(componentDefinition);
+    componentDefinition.getBeanDefinition().setPrimary(true);
+  }
+
+}

--- a/spock-spring/src/main/java/org/spockframework/spring/xml/SpockMockFactoryBean.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/xml/SpockMockFactoryBean.java
@@ -1,0 +1,62 @@
+package org.spockframework.spring.xml;
+
+import java.util.Collections;
+
+import spock.mock.DetachedMockFactory;
+import org.spockframework.mock.MockNature;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Takes care of instantiating detached spock Mocks.
+ *
+ * Spring integration of spock mocks is heavily inspired by
+ * Springokito {@see https://bitbucket.org/kubek2k/springockito}.
+ *
+ * @author Leonard Bruenings
+ */
+public class SpockMockFactoryBean<T> implements FactoryBean<T> {
+
+  private final Class<T> targetClass;
+  private String name;
+  private String mockNature = MockNature.MOCK.name();
+
+  private T instance;
+
+  public SpockMockFactoryBean (Class<T> targetClass) {
+    this.targetClass = targetClass;
+  }
+
+  @SuppressWarnings("unchecked")
+  public T getObject() throws Exception {
+    if (instance == null) {
+      MockNature nature = MockNature.valueOf(mockNature.toUpperCase());
+      instance =  new DetachedMockFactory().createMock(name, targetClass, nature,
+        Collections.<String, Object>emptyMap());
+    }
+    return instance;
+  }
+
+  public Class<?> getObjectType() {
+    return targetClass;
+  }
+
+  public boolean isSingleton() {
+    return true;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getMockNature() {
+    return mockNature;
+  }
+
+  public void setMockNature(String mockNature) {
+    this.mockNature = mockNature;
+  }
+}

--- a/spock-spring/src/main/java/org/spockframework/spring/xml/SpockNamespaceHandler.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/xml/SpockNamespaceHandler.java
@@ -1,0 +1,20 @@
+package org.spockframework.spring.xml;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * Adds support for the spock namespace.
+ *
+ * Spring integration of spock mocks is heavily inspired by
+ * Springokito {@see https://bitbucket.org/kubek2k/springockito}.
+ *
+ * @author Leonard Bruenings
+ */
+public class SpockNamespaceHandler extends NamespaceHandlerSupport {
+
+  public void init() {
+    registerBeanDefinitionParser("mock", new MockBeanDefinitionParser());
+    registerBeanDefinitionParser("spy", new MockBeanDefinitionParser());
+    registerBeanDefinitionParser("stub", new MockBeanDefinitionParser());
+  }
+}

--- a/spock-spring/src/main/resources/META-INF/spring.handlers
+++ b/spock-spring/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,1 @@
+http\://www.spockframework.org/spring=org.spockframework.spring.xml.SpockNamespaceHandler

--- a/spock-spring/src/main/resources/META-INF/spring.schemas
+++ b/spock-spring/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,1 @@
+http\://www.spockframework.org/spring/spock.xsd=org/spockframework/spock.xsd

--- a/spock-spring/src/main/resources/org/spockframework/spock.xsd
+++ b/spock-spring/src/main/resources/org/spockframework/spock.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://www.spockframework.org/spring"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+           xmlns:spock="http://www.spockframework.org/spring"
+           targetNamespace="http://www.spockframework.org/spring"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <xs:import namespace="http://www.springframework.org/schema/beans"
+               schemaLocation="http://www.springframework.org/schema/beans/spring-beans.xsd"/>
+
+    <xs:complexType name="mockDefinitionType">
+        <xs:complexContent>
+            <xs:extension base="beans:identifiedType">
+                <xs:attribute name="class" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation source="java:java.lang.Class">
+                            <![CDATA[ The fully qualified name of the mocks class. ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="mock" type="spock:mockDefinitionType"/>
+    <xs:element name="spy" type="spock:mockDefinitionType"/>
+    <xs:element name="stub" type="spock:mockDefinitionType"/>
+</xs:schema>

--- a/spock-spring/src/test/groovy/org/spockframework/spring/MockInjectionExample.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/MockInjectionExample.groovy
@@ -1,0 +1,60 @@
+package org.spockframework.spring;
+
+import org.spockframework.mock.MockUtil
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration;
+
+import spock.lang.Specification
+
+import javax.inject.Named;
+
+@ContextConfiguration(locations = "classpath:MockExamples-context.xml")
+public class MockInjectionExample extends Specification {
+
+  @Autowired @Named('serviceMock')
+  IService1 serviceMock
+
+
+  @Autowired @Named('serviceStub')
+  IService1 serviceStub
+
+  @Autowired @Named('serviceSpy')
+  IService2 serviceSpy
+
+  @Autowired @Named('service2')
+  IService2 service2
+
+  def "Injected services are mocks"() {
+    expect:
+    new MockUtil().isMock(serviceMock)
+    new MockUtil().isMock(serviceStub)
+    new MockUtil().isMock(serviceSpy)
+    new MockUtil().isMock(service2)
+  }
+
+  def "Mocks can be configured"() {
+    given:
+    serviceStub.generateString() >> "I can be configured"
+
+    when:
+    assert serviceMock.generateString() == "I can be configured"
+    assert serviceStub.generateString() == "I can be configured"
+    assert serviceSpy.generateQuickBrownFox() == "I can be configured"
+    assert service2.generateQuickBrownFox() == "The quick brown fox..."
+
+    then:
+    1 * serviceMock.generateString() >> "I can be configured"
+    1 * serviceSpy.generateQuickBrownFox() >> "I can be configured"
+    1 * service2.generateQuickBrownFox() >> "The quick brown fox..."
+  }
+
+  def "Unconfigured mocks return default"() {
+    expect:
+    serviceMock.generateString() == null
+    serviceStub.generateString() == ""
+    serviceSpy.generateQuickBrownFox() == "The quick brown fox jumps over the lazy dog."
+    service2.generateQuickBrownFox() == null
+
+  }
+
+}

--- a/spock-spring/src/test/groovy/org/spockframework/spring/MockInjectionWithEmbeddedConfig.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/MockInjectionWithEmbeddedConfig.groovy
@@ -1,0 +1,59 @@
+package org.spockframework.spring
+
+import spock.mock.DetachedMockFactory
+import org.spockframework.mock.MockUtil
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.support.AnnotationConfigContextLoader
+
+import spock.lang.Specification
+
+@ContextConfiguration(loader=AnnotationConfigContextLoader)
+class MockInjectionWithEmbeddedConfig extends Specification {
+
+  @Configuration
+  static class Config {
+    private DetachedMockFactory factory = new DetachedMockFactory()
+
+    @Bean
+    public IService1 service1() {
+        return factory.Mock(IService1, name: "service1")
+    }
+
+    @Bean
+    public IService2 service2() {
+        return factory.Mock(IService2, name: "service2")
+    }
+  }
+
+  @Autowired
+  IService1 service1
+
+  @Autowired
+  IService2 service2
+
+  def "Injected services are mocks"() {
+    expect:
+    new MockUtil().isMock(service1)
+    new MockUtil().isMock(service2)
+  }
+
+  def "Mocks can be configured"() {
+    when:
+    assert service1.generateString() == "I can be configured"
+    assert service2.generateQuickBrownFox() == "The quick brown fox..."
+
+    then:
+    1 * service1.generateString() >> "I can be configured"
+    1 * service2.generateQuickBrownFox() >> "The quick brown fox..."
+  }
+
+  def "Unconfigured mocks return default"() {
+    expect:
+    service1.generateString() == null
+    service2.generateQuickBrownFox() == null
+
+  }
+}

--- a/spock-spring/src/test/resources/MockExamples-context.xml
+++ b/spock-spring/src/test/resources/MockExamples-context.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:spock="http://www.spockframework.org/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.spockframework.org/spring http://www.spockframework.org/spring/spock.xsd">
+
+  <spock:mock id="serviceMock" class="org.spockframework.spring.IService1"/>
+  <spock:stub id="serviceStub" class="org.spockframework.spring.IService1"/>
+  <spock:spy id="serviceSpy" class="org.spockframework.spring.Service2"/>
+
+  <bean id="service2" class="org.spockframework.spring.xml.SpockMockFactoryBean">
+    <constructor-arg value="org.spockframework.spring.IService2"/>
+  </bean>
+
+  <bean id="nonMock" class="java.util.ArrayList"/>
+</beans>


### PR DESCRIPTION
This implements #427
Move MockingApi to new spock.mock package.

Replaces PR #17 