### PR TITLE
Block asserts

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/AbstractDeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AbstractDeepBlockRewriter.java
@@ -38,6 +38,7 @@ public class AbstractDeepBlockRewriter extends StatementReplacingVisitorSupport 
 
   // following fields are filled in by subclasses
   protected boolean conditionFound;
+  protected boolean groupConditionFound;
   protected boolean interactionFound;
   protected MethodCallExpression foundExceptionCondition;
   protected final List<Statement> thenBlockInteractionStats = new ArrayList<Statement>();
@@ -48,6 +49,10 @@ public class AbstractDeepBlockRewriter extends StatementReplacingVisitorSupport 
 
   public boolean isConditionFound() {
     return conditionFound;
+  }
+
+  public boolean isGroupConditionFound() {
+    return groupConditionFound;
   }
 
   public boolean isExceptionConditionFound() {
@@ -128,7 +133,9 @@ public class AbstractDeepBlockRewriter extends StatementReplacingVisitorSupport 
     ClosureExpression oldClosure = currClosure;
     currClosure = expr;
     boolean oldConditionFound = conditionFound;
+    boolean oldGroupConditionFound = groupConditionFound;
     conditionFound = false; // any closure terminates conditionFound scope
+    groupConditionFound = false;
     ISpecialMethodCall oldSpecialMethodCall = currSpecialMethodCall;
     if (!currSpecialMethodCall.isMatch(expr)) {
       currSpecialMethodCall = NoSpecialMethodCall.INSTANCE; // unrelated closure terminates currSpecialMethodCall scope
@@ -138,6 +145,7 @@ public class AbstractDeepBlockRewriter extends StatementReplacingVisitorSupport 
     } finally {
       currClosure = oldClosure;
       conditionFound = oldConditionFound;
+      groupConditionFound = oldGroupConditionFound;
       currSpecialMethodCall = oldSpecialMethodCall;
     }
   }

--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -34,6 +34,7 @@ import spock.lang.*;
 public class AstNodeCache {
   public final ClassNode SpockRuntime = ClassHelper.makeWithoutCaching(SpockRuntime.class);
   public final ClassNode ValueRecorder = ClassHelper.makeWithoutCaching(ValueRecorder.class);
+  public final ClassNode ErrorCollector = ClassHelper.makeWithoutCaching(org.spockframework.runtime.ErrorCollector.class);
   public final ClassNode Specification = ClassHelper.makeWithoutCaching(Specification.class);
   public final ClassNode SpecInternals = ClassHelper.makeWithoutCaching(org.spockframework.lang.SpecInternals.class);
 
@@ -60,6 +61,9 @@ public class AstNodeCache {
 
   public final MethodNode ValueRecorder_RealizeNas =
       ValueRecorder.getDeclaredMethods(org.spockframework.runtime.ValueRecorder.REALIZE_NAS).get(0);
+
+  public final MethodNode ErrorCollector_Validate =
+      ErrorCollector.getDeclaredMethods(org.spockframework.runtime.ErrorCollector.VALIDATE_COLLECTED_ERRORS).get(0);
 
   // annotations and annotation elements
   public final ClassNode SpecMetadata = ClassHelper.makeWithoutCaching(SpecMetadata.class);

--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -43,6 +43,9 @@ public class AstNodeCache {
   public final MethodNode SpockRuntime_VerifyCondition =
       SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.VERIFY_CONDITION).get(0);
 
+  public final MethodNode SpockRuntime_ConditionFailedWithException =
+      SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.CONDITION_FAILED_WITH_EXCEPTION).get(0);
+
   public final MethodNode SpockRuntime_VerifyMethodCondition =
       SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.VERIFY_METHOD_CONDITION).get(0);
 
@@ -51,6 +54,9 @@ public class AstNodeCache {
 
   public final MethodNode ValueRecorder_Record =
       ValueRecorder.getDeclaredMethods(org.spockframework.runtime.ValueRecorder.RECORD).get(0);
+
+  public final MethodNode ValueRecorder_StartRecordingValue =
+      ValueRecorder.getDeclaredMethods(org.spockframework.runtime.ValueRecorder.START_RECORDING_VALUE).get(0);
 
   public final MethodNode ValueRecorder_RealizeNas =
       ValueRecorder.getDeclaredMethods(org.spockframework.runtime.ValueRecorder.REALIZE_NAS).get(0);

--- a/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
@@ -18,7 +18,9 @@ package org.spockframework.compiler;
 
 import java.util.*;
 
+import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.expr.*;
 import org.codehaus.groovy.ast.stmt.*;
 import org.codehaus.groovy.classgen.BytecodeExpression;
@@ -438,10 +440,17 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
   }
 
   private Expression record(Expression expr) {
+    // replace expr with $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(recordCount++), <expr>)
     return AstUtil.createDirectMethodCall(
         new VariableExpression("$spock_valueRecorder"),
         resources.getAstNodeCache().ValueRecorder_Record,
-        new ArgumentListExpression(new ConstantExpression(recordCount++), expr));
+        new ArgumentListExpression(
+            AstUtil.createDirectMethodCall(
+                new VariableExpression("$spock_valueRecorder"),
+                resources.getAstNodeCache().ValueRecorder_StartRecordingValue,
+                new ArgumentListExpression(new ConstantExpression(recordCount++))
+            ),
+            expr));
   }
 
   private Expression realizeNas(Expression expr) {
@@ -486,13 +495,33 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
     return ((ArgumentListExpression)methodExpr.getArguments()).getExpression(1);
   }
 
+  // extractVariableNumber(record(expr)) ==
+  // extractVariableNumber($spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(variableNumber), expr) ==
+  // variableNumber
+  private int extractVariableNumber(Expression expr){
+    if (!(expr instanceof MethodCallExpression)) return -1;
+    MethodCallExpression methodExpr = (MethodCallExpression) expr;
+    Expression targetExpr = methodExpr.getObjectExpression();
+    if (!(targetExpr instanceof VariableExpression)) return -1;
+    VariableExpression var = (VariableExpression)targetExpr;
+    if (!var.getName().equals("$spock_valueRecorder")) return -1;
+    if(!methodExpr.getMethodAsString().equals(ValueRecorder.RECORD)) return -1;
+    Expression startRecordingEpr = ((ArgumentListExpression) methodExpr.getArguments()).getExpression(0);
+    if (!(startRecordingEpr instanceof MethodCallExpression)) return -1;
+    MethodCallExpression startRecording = (MethodCallExpression) startRecordingEpr;
+    if (!startRecording.getMethodAsString().equals(ValueRecorder.START_RECORDING_VALUE)) return -1;
+    final Expression variableNumExpression = ((ArgumentListExpression) startRecording.getArguments()).getExpression(0);
+    if (! (variableNumExpression instanceof ConstantExpression)) return -1;
+    return (Integer)((ConstantExpression)variableNumExpression).getValue();
+  }
+
   private Statement rewriteCondition(Statement conditionStat, Expression conditionExpr, Expression message, boolean explicit) {
-    Statement result = new ExpressionStatement(rewriteCondition(conditionExpr, message, explicit));
+    Statement result = rewriteCondition(conditionExpr, message, explicit);
     result.setSourcePosition(conditionStat);
     return result;
   }
 
-  private Expression rewriteCondition(Expression expr, Expression message, boolean explicit) {
+  private Statement rewriteCondition(Expression expr, Expression message, boolean explicit) {
     // method conditions with spread operator are not lifted because MOP doesn't support spreading
     if (expr instanceof MethodCallExpression && !((MethodCallExpression) expr).isSpreadSafe())
       return rewriteMethodCondition((MethodCallExpression) expr, message, explicit);
@@ -503,9 +532,17 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
     return rewriteOtherCondition(expr, message);
   }
 
-  private Expression rewriteMethodCondition(MethodCallExpression condition, Expression message, boolean explicit) {
-    MethodCallExpression rewritten = message == null ?
-        (MethodCallExpression) unrecord(convert(condition)) : condition;
+  private Statement rewriteMethodCondition(MethodCallExpression condition, Expression message, boolean explicit) {
+    MethodCallExpression rewritten;
+    int lastVariableNum;
+    if (message == null){
+      final Expression converted = convert(condition);
+      rewritten = (MethodCallExpression) unrecord(converted);
+      lastVariableNum = extractVariableNumber(converted);
+    }else{
+      rewritten = condition;
+      lastVariableNum = -1;
+    }
 
     List<Expression> args = new ArrayList<Expression>();
     args.add(rewritten.getObjectExpression());
@@ -514,14 +551,30 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
     // rewriting has produced N/A's that haven't been realized yet, so do that now
     args.add(realizeNas(new ConstantExpression(rewritten.isSafe())));
     args.add(new ConstantExpression(explicit));
+    args.add(new ConstantExpression(lastVariableNum));
 
-    return rewriteToSpockRuntimeCall(resources.getAstNodeCache().SpockRuntime_VerifyMethodCondition, condition, message, args);
+    return surroundWithTryCatch(
+        condition,
+        message,
+        rewriteToSpockRuntimeCall(
+            resources.getAstNodeCache().SpockRuntime_VerifyMethodCondition,
+            condition,
+            message,
+            args));
   }
 
-  private Expression rewriteStaticMethodCondition(StaticMethodCallExpression condition, Expression message,
+  private Statement rewriteStaticMethodCondition(StaticMethodCallExpression condition, Expression message,
       boolean explicit) {
-    StaticMethodCallExpression rewritten = message == null ?
-        (StaticMethodCallExpression) unrecord(convert(condition)) : condition;
+    StaticMethodCallExpression rewritten;
+    int lastVariableNum;
+    if (message == null){
+      final Expression converted = convert(condition);
+      rewritten = (StaticMethodCallExpression) unrecord(converted);
+      lastVariableNum = extractVariableNumber(converted);
+    }else{
+      rewritten = condition;
+      lastVariableNum = -1;
+    }
 
     List<Expression> args = new ArrayList<Expression>();
     args.add(new ClassExpression(rewritten.getOwnerType()));
@@ -530,15 +583,53 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
     // rewriting has produced N/A's that haven't been realized yet, so do that now
     args.add(realizeNas(ConstantExpression.FALSE));
     args.add(new ConstantExpression(explicit));
+    args.add(new ConstantExpression(lastVariableNum));
 
-    return rewriteToSpockRuntimeCall(resources.getAstNodeCache().SpockRuntime_VerifyMethodCondition, condition, message, args);
+    return surroundWithTryCatch(
+        condition,
+        message,
+        rewriteToSpockRuntimeCall(
+            resources.getAstNodeCache().SpockRuntime_VerifyMethodCondition,
+            condition,
+            message,
+            args));
   }
 
-  private Expression rewriteOtherCondition(Expression condition, Expression message) {
+  private Statement rewriteOtherCondition(Expression condition, Expression message) {
     Expression rewritten = message == null ? convert(condition) : condition;
 
-    return rewriteToSpockRuntimeCall(resources.getAstNodeCache().SpockRuntime_VerifyCondition,
+    final Expression executeAndVerify = rewriteToSpockRuntimeCall(resources.getAstNodeCache().SpockRuntime_VerifyCondition,
         condition, message, Collections.singletonList(rewritten));
+
+    return surroundWithTryCatch(condition, message, executeAndVerify);
+  }
+
+  private TryCatchStatement surroundWithTryCatch(Expression condition, Expression message, Expression executeAndVerify) {
+    final TryCatchStatement tryCatchStatement = new TryCatchStatement(
+        new ExpressionStatement(executeAndVerify),
+        new EmptyStatement()
+    );
+
+    tryCatchStatement.addCatch(
+        new CatchStatement(
+            new Parameter(new ClassNode(Throwable.class), "throwable"),
+            new ExpressionStatement(
+                AstUtil.createDirectMethodCall(
+                    new ClassExpression(resources.getAstNodeCache().SpockRuntime),
+                    resources.getAstNodeCache().SpockRuntime_ConditionFailedWithException,
+                    new ArgumentListExpression(Arrays.asList(
+                        message == null ? new VariableExpression("$spock_valueRecorder") : ConstantExpression.NULL, // recorder
+                        new ConstantExpression(resources.getSourceText(condition)),                                 // text
+                        new ConstantExpression(condition.getLineNumber()),                                          // line
+                        new ConstantExpression(condition.getColumnNumber()),                                        // column
+                        message == null ? ConstantExpression.NULL : message,                                        // message
+                        new VariableExpression("throwable")                                                         // throwable
+                    ))
+                )
+            )
+        )
+    );
+    return tryCatchStatement;
   }
 
   private Expression rewriteToSpockRuntimeCall(MethodNode method, Expression condition, Expression message,

--- a/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
@@ -618,6 +618,7 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
                     new ClassExpression(resources.getAstNodeCache().SpockRuntime),
                     resources.getAstNodeCache().SpockRuntime_ConditionFailedWithException,
                     new ArgumentListExpression(Arrays.asList(
+                        new VariableExpression("$spock_errorCollector"),
                         message == null ? new VariableExpression("$spock_valueRecorder") : ConstantExpression.NULL, // recorder
                         new ConstantExpression(resources.getSourceText(condition)),                                 // text
                         new ConstantExpression(condition.getLineNumber()),                                          // line
@@ -640,6 +641,7 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
         new ClassExpression(resources.getAstNodeCache().SpockRuntime), method,
         new ArgumentListExpression(args));
 
+    args.add(new VariableExpression("$spock_errorCollector"));
     args.add(message == null ?
         AstUtil.createDirectMethodCall(
             new VariableExpression("$spock_valueRecorder"),

--- a/spock-core/src/main/java/org/spockframework/compiler/IRewriteResources.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/IRewriteResources.java
@@ -19,7 +19,6 @@ package org.spockframework.compiler;
 import java.util.List;
 
 import org.codehaus.groovy.ast.ASTNode;
-import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
@@ -38,7 +37,7 @@ public interface IRewriteResources {
   Method getCurrentMethod();
   Block getCurrentBlock();
 
-  void defineValueRecorder(List<Statement> stats);
+  void defineRecorders(List<Statement> stats, boolean enableErrorCollector);
   VariableExpression captureOldValue(Expression oldValue);
   MethodCallExpression getMockInvocationMatcher();
 

--- a/spock-core/src/main/java/org/spockframework/compiler/ISpecialMethodCall.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ISpecialMethodCall.java
@@ -37,6 +37,8 @@ public interface ISpecialMethodCall {
 
   boolean isConditionBlock();
 
+  boolean isGroupConditionBlock();
+
   boolean isTestDouble();
 
   boolean isExceptionCondition(MethodCallExpression expr);

--- a/spock-core/src/main/java/org/spockframework/compiler/NoSpecialMethodCall.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/NoSpecialMethodCall.java
@@ -55,6 +55,10 @@ public class NoSpecialMethodCall implements ISpecialMethodCall {
     return false;
   }
 
+  public boolean isGroupConditionBlock() {
+    return false;
+  }
+
   public boolean isTestDouble() {
     return false;
   }

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -33,7 +33,7 @@ import org.spockframework.util.*;
 
 /**
  * A Spec visitor responsible for most of the rewriting of a Spec's AST.
- * 
+ *
  * @author Peter Niederwieser
  */
 // IDEA: mock controller / leaveScope calls should only be inserted when necessary (increases robustness)
@@ -176,7 +176,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
      class DerivedSpec extends BaseSpec {}
 
      // when DerivedSpec is run:
-     
+
      def sharedInstance = new DerivedSpec()
 
      def spec = new DerivedSpec()
@@ -291,9 +291,6 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
   public void visitMethodAgain(Method method) {
     this.block = null;
 
-    if (methodHasCondition)
-      defineValueRecorder(method.getStatements());
-
     if (!movedStatsBackToMethod)
       for (Block b : method.getBlocks())
         method.getStatements().addAll(b.getAst());
@@ -301,6 +298,9 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
     // for global required interactions
     if (method instanceof FeatureMethod)
       method.getStatements().add(createMockControllerCall(MockController.LEAVE_SCOPE));
+
+    if (methodHasCondition)
+      defineRecorders(method.getStatements(), false);
   }
 
   public void visitAnyBlock(Block block) {
@@ -309,7 +309,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     DeepBlockRewriter deep = new DeepBlockRewriter(this);
     deep.visit(block);
-    methodHasCondition |= deep.isConditionFound();
+    methodHasCondition |= deep.isConditionFound() || deep.isGroupConditionFound();
   }
 
   public void visitThenBlock(ThenBlock block) {
@@ -317,7 +317,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     DeepBlockRewriter deep = new DeepBlockRewriter(this);
     deep.visit(block);
-    methodHasCondition |= deep.isConditionFound();
+    methodHasCondition |= deep.isConditionFound() || deep.isGroupConditionFound();
 
     if (deep.isExceptionConditionFound()) {
       if (thenBlockChainHasExceptionCondition) {
@@ -402,17 +402,39 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
     return block;
   }
 
-  public void defineValueRecorder(List<Statement> stats) {
+  public void defineRecorders(List<Statement> stats, boolean enableErrorCollector) {
     // recorder variable needs to be defined in outermost scope,
     // hence we insert it at the beginning of the block
+    List<Statement> allStats = new ArrayList<Statement>(stats);
+
+    stats.clear();
+
     stats.add(0,
         new ExpressionStatement(
             new DeclarationExpression(
-                new VariableExpression("$spock_valueRecorder"),
+                new VariableExpression("$spock_valueRecorder", nodeCache.ValueRecorder),
                 Token.newSymbol(Types.ASSIGN, -1, -1),
                 new ConstructorCallExpression(
                     nodeCache.ValueRecorder,
                     ArgumentListExpression.EMPTY_ARGUMENTS))));
+    stats.add(0,
+        new ExpressionStatement(
+            new DeclarationExpression(
+                new VariableExpression("$spock_errorCollector", nodeCache.ErrorCollector),
+                Token.newSymbol(Types.ASSIGN, -1, -1),
+                new ConstructorCallExpression(
+                    nodeCache.ErrorCollector,
+                    new ArgumentListExpression(Collections.<Expression>singletonList(new ConstantExpression(enableErrorCollector, true)))))));
+
+    stats.add(
+      new TryCatchStatement(
+        new BlockStatement(allStats, new VariableScope()),
+        new ExpressionStatement(
+          AstUtil.createDirectMethodCall(
+            new VariableExpression("$spock_errorCollector"),
+            nodeCache.ErrorCollector_Validate,
+            ArgumentListExpression.EMPTY_ARGUMENTS
+          ))));
   }
 
   public VariableExpression captureOldValue(Expression oldValue) {

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecialMethodCall.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecialMethodCall.java
@@ -86,6 +86,10 @@ public class SpecialMethodCall implements ISpecialMethodCall {
     return conditionBlock;
   }
 
+  public boolean isGroupConditionBlock() {
+    return isMethodName(Identifiers.VERIFY_ALL);
+  }
+
   public boolean isTestDouble() {
     return isOneOfMethodNames(Identifiers.TEST_DOUBLE_METHODS);
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/Condition.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/Condition.java
@@ -16,6 +16,7 @@
 
 package org.spockframework.runtime;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.spockframework.runtime.model.ExpressionInfo;
@@ -30,24 +31,28 @@ import org.spockframework.util.Nullable;
 public class Condition {
   private static final Pattern pattern = Pattern.compile("\\s*\n\\s*");
 
-  private final Iterable<Object> values;
+  private final List<Object> values;
   private final String text;
   private final TextPosition position;
   private final String message;
+  private final Integer notRecordedVarNumberBecauseOfException;
+  private final Throwable exception;
 
   private volatile ExpressionInfo expression;
   private volatile String rendering;
 
-  public Condition(@Nullable Iterable<Object> values, @Nullable String text, TextPosition position,
-      @Nullable String message) {
+  public Condition(@Nullable List<Object> values, @Nullable String text, TextPosition position,
+      @Nullable String message, @Nullable Integer notRecordedVarNumberBecauseOfException, @Nullable Throwable exception) {
     this.text = text;
     this.position = position;
     this.values = values;
     this.message = message;
+    this.notRecordedVarNumberBecauseOfException = notRecordedVarNumberBecauseOfException;
+    this.exception = exception;
   }
 
   @Nullable
-  public Iterable<Object> getValues() {
+  public List<Object> getValues() {
     return values;
   }
 
@@ -84,7 +89,7 @@ public class Condition {
 
   private void createExpression() {
     if (text == null || values == null) return;
-    expression = new ExpressionInfoBuilder(flatten(text), TextPosition.create(1, 1), values).build();
+    expression = new ExpressionInfoBuilder(flatten(text), TextPosition.create(1, 1), values, notRecordedVarNumberBecauseOfException, exception).build();
   }
 
   private void createRendering() {

--- a/spock-core/src/main/java/org/spockframework/runtime/ConditionNotSatisfiedError.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ConditionNotSatisfiedError.java
@@ -26,6 +26,11 @@ public class ConditionNotSatisfiedError extends SpockAssertionError {
     this.condition = condition;
   }
 
+  public ConditionNotSatisfiedError(Condition condition, Throwable cause) {
+    super(cause);
+    this.condition = condition;
+  }
+
   public Condition getCondition() {
     return condition;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/ErrorCollector.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ErrorCollector.java
@@ -1,0 +1,35 @@
+package org.spockframework.runtime;
+
+import org.junit.runners.model.MultipleFailureException;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class ErrorCollector {
+  private final boolean errorCollectionEnabled;
+
+  private final List<Throwable> throwables = new CopyOnWriteArrayList<Throwable>();
+
+  public ErrorCollector(boolean enabled) {
+    errorCollectionEnabled = enabled;
+  }
+
+
+  public <T extends Throwable> void collectOrThrow(T error) throws T {
+    if (errorCollectionEnabled){
+      throwables.add(error);
+    }else {
+      throw error;
+    }
+  }
+
+  public static final String VALIDATE_COLLECTED_ERRORS = "validateCollectedErrors";
+
+  public void validateCollectedErrors() throws MultipleFailureException {
+    if (errorCollectionEnabled){
+      if (!throwables.isEmpty()){
+        throw new MultipleFailureException(throwables);
+      }
+    }
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/InvalidSpecException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/InvalidSpecException.java
@@ -22,7 +22,7 @@ package org.spockframework.runtime;
  *
  * @author Peter Niederwieser
  */
-public class InvalidSpecException extends RuntimeException {
+public class InvalidSpecException extends SpockException {
   private String msg;
 
   public InvalidSpecException(String msg) {

--- a/spock-core/src/main/java/org/spockframework/runtime/JUnitSupervisor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/JUnitSupervisor.java
@@ -70,7 +70,7 @@ public class JUnitSupervisor implements IRunSupervisor {
   public void beforeIteration(IterationInfo iteration) {
     masterListener.beforeIteration(iteration);
     currentIteration = iteration;
-    
+
     iterationCount++;
     if (currentFeature.isReportIterations())
       notifier.fireTestStarted(iteration.getDescription());
@@ -116,22 +116,29 @@ public class JUnitSupervisor implements IRunSupervisor {
   private boolean isFailedEqualityComparison(Throwable exception) {
     if (!(exception instanceof ConditionNotSatisfiedError)) return false;
 
-    Condition condition = ((ConditionNotSatisfiedError) exception).getCondition();
+    ConditionNotSatisfiedError conditionNotSatisfiedError = (ConditionNotSatisfiedError) exception;
+    Condition condition = conditionNotSatisfiedError.getCondition();
     ExpressionInfo expr = condition.getExpression();
-    return expr != null && expr.isEqualityComparison();
+    return expr != null && expr.isEqualityComparison() && // it is equality
+        conditionNotSatisfiedError.getCause() == null;    // and it is not failed because of exception
   }
 
   // enables IDE support (diff dialog)
   private Throwable convertToComparisonFailure(Throwable exception) {
     assert isFailedEqualityComparison(exception);
 
-    Condition condition = ((ConditionNotSatisfiedError) exception).getCondition();
+    ConditionNotSatisfiedError conditionNotSatisfiedError = (ConditionNotSatisfiedError) exception;
+    Condition condition = conditionNotSatisfiedError.getCondition();
     ExpressionInfo expr = condition.getExpression();
 
     String actual = renderValue(expr.getChildren().get(0).getValue());
     String expected = renderValue(expr.getChildren().get(1).getValue());
     ComparisonFailure failure = new SpockComparisonFailure(condition, expected, actual);
     failure.setStackTrace(exception.getStackTrace());
+
+    if (conditionNotSatisfiedError.getCause()!=null){
+      failure.initCause(conditionNotSatisfiedError.getCause());
+    }
 
     return failure;
   }
@@ -170,7 +177,7 @@ public class JUnitSupervisor implements IRunSupervisor {
     masterListener.afterIteration(iteration);
     if (currentFeature.isReportIterations())
       notifier.fireTestFinished(iteration.getDescription());
-    
+
     currentIteration = null;
   }
 
@@ -205,7 +212,7 @@ public class JUnitSupervisor implements IRunSupervisor {
   private Description getCurrentDescription() {
     if (currentIteration != null && currentFeature.isReportIterations())
       return currentIteration.getDescription();
-    if (currentFeature != null) 
+    if (currentFeature != null)
       return currentFeature.getDescription();
     return spec.getDescription();
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/JUnitSupervisor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/JUnitSupervisor.java
@@ -16,7 +16,7 @@ package org.spockframework.runtime;
 
 import org.junit.ComparisonFailure;
 import org.junit.internal.AssumptionViolatedException;
-import org.junit.internal.runners.model.MultipleFailureException;
+import org.junit.runners.model.MultipleFailureException;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockException.java
@@ -1,0 +1,19 @@
+package org.spockframework.runtime;
+
+public class SpockException extends RuntimeException {
+  public SpockException() {
+    super();
+  }
+
+  public SpockException(String message) {
+    super(message);
+  }
+
+  public SpockException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public SpockException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionException.java
@@ -21,7 +21,7 @@ package org.spockframework.runtime;
  *
  * @author Peter Niederwieser
  */
-public class SpockExecutionException extends RuntimeException {
+public class SpockExecutionException extends SpockException {
   private volatile String msg;
 
   public SpockExecutionException(String msg) {

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockRuntime.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockRuntime.java
@@ -34,21 +34,44 @@ public abstract class SpockRuntime {
       @Nullable String text, int line, int column, @Nullable Object message, @Nullable Object condition) {
     if (!GroovyRuntimeUtil.isTruthy(condition)) {
       throw new ConditionNotSatisfiedError(
-          new Condition(getValues(recorder), text, TextPosition.create(line, column), messageToString(message)));
+          new Condition(getValues(recorder), text, TextPosition.create(line, column), messageToString(message), null, null));
     }
+  }
+
+  public static final String CONDITION_FAILED_WITH_EXCEPTION = "conditionFailedWithException";
+
+  public static void conditionFailedWithException(@Nullable ValueRecorder recorder, @Nullable String text, int line, int column, @Nullable Object message, Throwable throwable){
+    if (throwable instanceof SpockAssertionError){
+      throw (SpockAssertionError) throwable; // this is our exception - it already has good message
+    }
+    if (throwable instanceof SpockException){
+      throw (SpockException) throwable; // this is our exception - it already has good message
+    }
+    throw new ConditionNotSatisfiedError(
+        new Condition(
+            getValues(recorder),
+            text,
+            TextPosition.create(line, column),
+            messageToString(message),
+            recorder == null ? null : recorder.getCurrentRecordingVarNum(),
+            recorder == null ? null : throwable),
+        throwable);
   }
 
   public static final String VERIFY_METHOD_CONDITION = "verifyMethodCondition";
 
   // method calls with spread-dot operator are not rewritten, hence this method doesn't have to care about spread-dot
   public static void verifyMethodCondition(@Nullable ValueRecorder recorder, @Nullable String text, int line, int column,
-      @Nullable Object message, Object target, String method, Object[] args, boolean safe, boolean explicit) {
+      @Nullable Object message, Object target, String method, Object[] args, boolean safe, boolean explicit, int lastVariableNum) {
     MatcherCondition matcherCondition = MatcherCondition.parse(target, method, args, safe);
     if (matcherCondition != null) {
       matcherCondition.verify(getValues(recorder), text, line, column, messageToString(message));
       return;
     }
 
+    if (recorder != null) {
+      recorder.startRecordingValue(lastVariableNum);
+    }
     Object result = safe ? GroovyRuntimeUtil.invokeMethodNullSafe(target, method, args) :
         GroovyRuntimeUtil.invokeMethod(target, method, args);
 
@@ -58,7 +81,7 @@ public abstract class SpockRuntime {
       List<Object> values = getValues(recorder);
       if (values != null) CollectionUtil.setLastElement(values, result);
       throw new ConditionNotSatisfiedError(
-          new Condition(values, text, TextPosition.create(line, column), messageToString(message)));
+          new Condition(values, text, TextPosition.create(line, column), messageToString(message), null, null));
     }
   }
 
@@ -103,7 +126,7 @@ public abstract class SpockRuntime {
       }
 
       String description = HamcrestFacade.getFailureDescription(matcher, actual, message);
-      Condition condition = new Condition(values, text, TextPosition.create(line, column), description);
+      Condition condition = new Condition(values, text, TextPosition.create(line, column), description, null, null);
       throw new ConditionNotSatisfiedError(condition);
     }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/ValueRecorder.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ValueRecorder.java
@@ -27,6 +27,7 @@ import org.spockframework.runtime.model.ExpressionInfo;
  */
 public class ValueRecorder {
   private final ArrayList<Object> values = new ArrayList<Object>();
+  private final Deque<Integer> startedRecordings = new ArrayDeque<Integer>();
 
   public static final String RESET = "reset";
 
@@ -36,7 +37,7 @@ public class ValueRecorder {
   }
 
   public static final String RECORD = "record";
-  
+
   /**
    * Records and returns the specified value. Hence an expression can be replaced
    * with record(expression) without impacting evaluation of the expression.
@@ -44,7 +45,27 @@ public class ValueRecorder {
   public Object record(int index, Object value) {
     realizeNas(index, null);
     values.add(value);
+
+    boolean foundThisCallOnStack = false;
+    while (!startedRecordings.isEmpty()){
+      final Integer indexFromStack = startedRecordings.pop();
+      if (indexFromStack==index){
+        foundThisCallOnStack = true;
+        break;
+      }
+    }
+    if (!foundThisCallOnStack){
+      throw new IllegalStateException("can not found call #"+index+" on stack. Invalid call of record method?");
+    }
+
     return value;
+  }
+
+  public static final String START_RECORDING_VALUE = "startRecordingValue";
+
+  public int startRecordingValue(int index){
+    startedRecordings.push(index);
+    return index;
   }
 
   public static final String REALIZE_NAS = "realizeNas";
@@ -60,5 +81,13 @@ public class ValueRecorder {
 
   public List<Object> getValues() {
     return new ArrayList<Object>(values);
+  }
+
+  public Integer getCurrentRecordingVarNum() {
+    if (startedRecordings.isEmpty()) {
+      return null;
+    } else {
+      return startedRecordings.peek();
+    }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/ExtensionException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/ExtensionException.java
@@ -16,7 +16,9 @@
 
 package org.spockframework.runtime.extension;
 
-public class ExtensionException extends RuntimeException {
+import org.spockframework.runtime.SpockException;
+
+public class ExtensionException extends SpockException {
   private String message;
 
   public ExtensionException(String message) {

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ExpressionInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ExpressionInfo.java
@@ -141,14 +141,10 @@ public class ExpressionInfo implements Iterable<ExpressionInfo> {
     };
   }
 
-  public Iterable<ExpressionInfo> inPostfixOrder(final boolean skipIrrelevant) {
-    return new Iterable<ExpressionInfo>() {
-      public Iterator<ExpressionInfo> iterator() {
-        List<ExpressionInfo> list = new ArrayList<ExpressionInfo>();
-        collectPostfix(list, skipIrrelevant);
-        return list.iterator();
-      }
-    };
+  public List<ExpressionInfo> inPostfixOrder(final boolean skipIrrelevant) {
+    List<ExpressionInfo> list = new ArrayList<ExpressionInfo>();
+    collectPostfix(list, skipIrrelevant);
+    return list;
   }
 
   public Iterable<ExpressionInfo> inCustomOrder(boolean skipIrrelevant, Comparator<ExpressionInfo> comparator) {

--- a/spock-core/src/main/java/org/spockframework/util/Identifiers.java
+++ b/spock-core/src/main/java/org/spockframework/util/Identifiers.java
@@ -23,12 +23,12 @@ import java.util.Set;
 
 /**
  * Identifiers used throughout the core.
- * 
+ *
  * @author Peter Niederwieser
  */
 public abstract class Identifiers {
   // Tokens -------------------------------------------------------------------
-  
+
   public static final String SETUP = "setup";
 
   public static final String GIVEN = "given";
@@ -61,7 +61,7 @@ public abstract class Identifiers {
   public static final String SETUP_METHOD = "setup";
 
   public static final String CLEANUP_METHOD = "cleanup";
-  
+
   /**
    * Method name identifying a fixture method that is executed before each spec.
    */
@@ -72,12 +72,14 @@ public abstract class Identifiers {
    */
   public static final String CLEANUP_SPEC_METHOD = "cleanupSpec";
 
-  public static final List<String> FIXTURE_METHODS = Arrays.asList(SETUP_METHOD, CLEANUP_METHOD, 
+  public static final List<String> FIXTURE_METHODS = Arrays.asList(SETUP_METHOD, CLEANUP_METHOD,
 		  SETUP_SPEC_METHOD, CLEANUP_SPEC_METHOD);
 
   public static final String GET_SPECIFICATION_CONTEXT = "getSpecificationContext";
 
   public static final String WITH = "with";
+
+  public static final String VERIFY_ALL = "verifyAll";
 
   public static final String STUB = "Stub";
   public static final String MOCK = "Mock";
@@ -95,7 +97,7 @@ public abstract class Identifiers {
   public static final String OLD = "old";
 
   public static final Set<String> BUILT_IN_METHODS = new HashSet<String>(Arrays.asList(THROWN, NOT_THROWN,
-      NO_EXCEPTION_THROWN, OLD, WITH, INTERACTION, STUB, MOCK, SPY, GROOVY_STUB, GROOVY_MOCK, GROOVY_SPY));
+      NO_EXCEPTION_THROWN, OLD, WITH, VERIFY_ALL, INTERACTION, STUB, MOCK, SPY, GROOVY_STUB, GROOVY_MOCK, GROOVY_SPY));
 
   public static final Set<String> TEST_DOUBLE_METHODS = new HashSet<String>(
       Arrays.asList(STUB, MOCK, SPY, GROOVY_STUB, GROOVY_MOCK, GROOVY_SPY));

--- a/spock-core/src/main/java/org/spockframework/util/IncompatibleGroovyVersionException.java
+++ b/spock-core/src/main/java/org/spockframework/util/IncompatibleGroovyVersionException.java
@@ -14,7 +14,9 @@
 
 package org.spockframework.util;
 
-public class IncompatibleGroovyVersionException extends RuntimeException {
+import org.spockframework.runtime.SpockException;
+
+public class IncompatibleGroovyVersionException extends SpockException {
   public IncompatibleGroovyVersionException(String message) {
     super(message);
   }

--- a/spock-core/src/main/java/org/spockframework/util/WrappedException.java
+++ b/spock-core/src/main/java/org/spockframework/util/WrappedException.java
@@ -14,13 +14,15 @@
 
 package org.spockframework.util;
 
+import org.spockframework.runtime.SpockException;
+
 /**
  * Wraps a checked exception s.t. it can be thrown from a method that doesn't
  * declare to throw it.
  *
  * @author Peter Niederwieser
  */
-public class WrappedException extends RuntimeException {
+public class WrappedException extends SpockException {
   public WrappedException(Throwable cause) {
     super(cause);
   }

--- a/spock-core/src/main/java/spock/lang/Specification.java
+++ b/spock-core/src/main/java/spock/lang/Specification.java
@@ -28,7 +28,7 @@ import org.spockframework.runtime.GroovyRuntimeUtil;
 /**
  * Base class for Spock specifications. All specifications must inherit from
  * this class, either directly or indirectly.
- * 
+ *
  * @author Peter Niederwieser
  */
 @RunWith(Sputnik.class)
@@ -215,5 +215,9 @@ public abstract class Specification extends MockingApi {
           type, target.getClass().getName()));
     }
     with(target, closure);
+  }
+
+  public void verifyAll(Closure closure){
+    GroovyRuntimeUtil.invokeClosure(closure);
   }
 }

--- a/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
+++ b/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
@@ -157,7 +157,7 @@ public class PollingConditions {
         lastAttempt = System.currentTimeMillis();
         GroovyRuntimeUtil.invokeClosure(conditions);
         return;
-      } catch (AssertionError e) {
+      } catch (Throwable e) {
         long elapsedTime = lastAttempt - start;
         if (elapsedTime >= timeoutMillis) {
           String msg = String.format("Condition not satisfied after %1.2f seconds and %d attempts", elapsedTime / 1000d, attempts);

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionsInConditions.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionsInConditions.groovy
@@ -1,0 +1,156 @@
+package org.spockframework.smoke.condition
+
+import junit.framework.Assert
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.ConditionNotSatisfiedError
+import org.spockframework.runtime.SpockException
+import spock.lang.FailsWith
+import spock.lang.Specification
+
+
+class ExceptionsInConditions extends EmbeddedSpecification {
+  def "null pointer exception in condition"() {
+    when:
+    runner.runFeatureBody(
+        """
+                def map = new HashMap<String, String>()
+                expect:
+                map.get("key").length() == 0
+            """)
+
+    then:
+    ConditionNotSatisfiedError e = thrown()
+
+
+    def expected = """\
+            map.get("key").length() == 0
+            |   |          |
+            [:] null       java.lang.NullPointerException: Cannot invoke method length() on null object
+        """.stripIndent()
+    expected == e.getCondition().getRendering()
+    e.getCause() instanceof NullPointerException
+  }
+
+  def "null pointer exception in method condition"() {
+    when:
+    runner.runFeatureBody(
+        """
+                def map = new HashMap<String, String>()
+                expect:
+                map.get("key").isEmpty()
+            """)
+
+    then:
+    ConditionNotSatisfiedError e = thrown()
+
+
+    def expected = """\
+            map.get("key").isEmpty()
+            |   |          |
+            [:] null       java.lang.NullPointerException: Cannot invoke method isEmpty() on null object
+        """.stripIndent()
+    expected == e.getCondition().getRendering()
+    e.getCause() instanceof NullPointerException
+  }
+
+  def "exception while invoking condition"() {
+    when:
+    runner.runFeatureBody(
+        """
+                    def getKey = { map, key ->
+                        def result = map.get(key)
+                        if (result == null) {
+                            throw new IllegalArgumentException("key does not exists")
+                        }
+                        return result;
+                    }
+                  def map = new HashMap<String, String>()
+                  expect:
+                  getKey(map, "key").length() == 0
+                """)
+
+    then:
+    ConditionNotSatisfiedError e = thrown()
+
+
+    def expected = """\
+            getKey(map, "key").length() == 0
+            |      |
+            |      [:]
+            java.lang.IllegalArgumentException: key does not exists
+        """.stripIndent()
+    expected == e.getCondition().getRendering()
+
+    e.getCause() instanceof IllegalArgumentException
+  }
+
+
+  def "spock assertion errors should be processed as is"() {
+    when:
+    runner.runFeatureBody(
+        """
+                    def getKey = { map, key ->
+                        def result = map.get(key)
+                        assert result
+                        return result;
+                    }
+                  def map = new HashMap<String, String>()
+                  expect:
+                  getKey(map, "key").length() == 0
+                """)
+
+    then:
+    ConditionNotSatisfiedError e = thrown()
+
+
+    def expected = """\
+            result
+            |
+            null
+        """.stripIndent()
+    expected == e.getCondition().getRendering()
+
+    e.getCause() == null
+  }
+
+  def "spock exceptions should be processed as is"() {
+    when:
+    runner.runFeatureBody(
+        """
+                    def getKey = { map, key ->
+                        def result = map.get(key)
+                        if (result==null){
+                            throw new org.spockframework.runtime.SpockException("key does not exists")
+                        }
+                        return result;
+                    }
+                  def map = new HashMap<String, String>()
+                  expect:
+                  getKey(map, "key").length() == 0
+                """)
+
+    then:
+    SpockException e = thrown()
+    e.getMessage() == "key does not exists"
+  }
+
+  def "deep nesting"() {
+    when:
+    runner.runFeatureBody(
+        """
+                  def map = new HashMap<String, String>()
+                  expect:
+                  map.get("key").b.c.d.e()
+                """)
+
+    then:
+    ConditionNotSatisfiedError e = thrown()
+    e.getMessage() == """\
+      Condition not satisfied:
+
+      map.get("key").b.c.d.e()
+      |   |          |
+      [:] null       java.lang.NullPointerException: Cannot get property 'b' on null object
+      """.stripIndent()
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/MatcherConditions.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/MatcherConditions.groovy
@@ -130,7 +130,7 @@ class MatcherConditions extends EmbeddedSpecification {
     42 equalTo(x)
   }
 
-  @FailsWith(MissingMethodException)
+  @FailsWith(ConditionNotSatisfiedError)
   def "cannot have a string literal as actual (because matcher expression gets parsed as a method call)"() {
     def x = "fred"
 
@@ -150,7 +150,7 @@ class MatcherConditions extends EmbeddedSpecification {
     String property = "property"
   }
 
-  @FailsWith(MissingMethodException)
+  @FailsWith(ConditionNotSatisfiedError)
   def "cannot have a method expression as actual in Groovy 1.8 (because matcher expression gets parsed as a chained method call)"() {
     def foo = new Foo()
 
@@ -165,7 +165,7 @@ class MatcherConditions extends EmbeddedSpecification {
     that foo.method(), equalTo("method")
   }
 
-  @FailsWith(MissingMethodException)
+  @FailsWith(ConditionNotSatisfiedError)
   def "cannot have a property expression as actual (because matcher expression gets parsed as a method call)"() {
     def foo = new Foo()
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
@@ -167,7 +167,7 @@ loadLogFile([{
                 "err1\\n"
             ],
             "exceptions": [
-                "java.io.IOException: ouch\\n\\tat DeclaringClass.methodName(filename:42)\\n"
+                "Condition not satisfied:\\n\\nthrowException()\\n|\\njava.io.IOException: ouch\\n\\n\\tat apackage.MySpec.some feature(scriptXXXXXXXXXXXXXXXXXXXXXXX.groovy:XX)\\nCaused by: java.io.IOException: ouch\\n\\tat DeclaringClass.methodName(filename:XX)\\n"
             ],
             "end": 1360051647586,
             "result": "failed",

--- a/spock-specs/src/test/groovy/org/spockframework/verifyall/VerifyAllSpecification.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/verifyall/VerifyAllSpecification.groovy
@@ -1,0 +1,86 @@
+package org.spockframework.verifyall
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.SpockTimeoutError
+
+class VerifyAllSpecification extends EmbeddedSpecification {
+
+  def "verifyAll"() {
+    when:
+    def clazz = compiler.compileWithImports(
+        """
+                    public class Test extends Specification {
+                        def "test1"() {
+                            expect:
+                                verifyAll{
+                                  1 == 2
+                                  3 == 4
+                                }
+                        }
+                    }""")
+    runner.throwFailure = false
+    def result = runner.runClass(clazz[0])
+    then:
+    result.failures.size() == 2
+    result.failures[0].exception.expected.trim() == "2"
+    result.failures[0].exception.actual.trim() == "1"
+    result.failures[1].exception.expected.trim() == "4"
+    result.failures[1].exception.actual.trim() == "3"
+  }
+
+  def "assertion blocks should work as expected (reported only once)"() {
+    when:
+        def clazz = compiler.compileWithImports(
+          """
+                    import spock.util.concurrent.PollingConditions
+                    public class Test extends Specification {
+                        def "test1"() {
+                            when:
+                                def x = 2
+                                def y = 3
+                            then:
+                                verifyAll {
+                                    PollingConditions pollingConditions = new PollingConditions()
+                                    pollingConditions.eventually {
+                                      x == 3
+                                      y == 4
+                                    }
+                                }
+                        }
+                    }""")
+        runner.throwFailure = false
+        def result = runner.runClass(clazz[0])
+    then:
+        result.failures.size() == 1
+        result.failures[0].exception instanceof SpockTimeoutError
+  }
+
+  def "if exception is not in condition, all already failed conditions should be reported"(){
+    when:
+        def clazz = compiler.compileWithImports(
+          """
+                    import spock.util.concurrent.PollingConditions
+                    public class Test extends Specification {
+                        def "test1"() {
+                            when:
+                                def x = 2
+                                def y = 3
+                            then:
+                                verifyAll {
+                                    x == 3
+                                    y == 4
+                                    def urlWithSpaces = new URL("abc   ") //Invalid Url Exception
+                                    urlWithSpaces != null
+                                }
+                        }
+                    }""")
+        runner.throwFailure = false
+        def result = runner.runClass(clazz[0])
+    then:
+        result.failures.size() == 2
+        result.failures[0].exception.expected.trim() == "3"
+        result.failures[0].exception.actual.trim() == "2"
+        result.failures[1].exception.expected.trim() == "4"
+        result.failures[1].exception.actual.trim() == "3"
+  }
+
+}


### PR DESCRIPTION
Added new method `Specification.verifyAll(Closure)`. All conditions in provided closure will be evaluated and reported as MultipleFailureException. If an exception occures in non-condition statement, all previously captured exceptions will be reported.

Example:
```
public class Test extends Specification {
    def "test1"() {
        expect:
            verifyAll{
              1 == 2
              3 == 4
            }
    }
}
```
Will report two failures.

As #50 it is based on exceptions-in-conditions-as-condition-failure ( #549 for this PR and #49 for #50)