### PR TITLE
Refactoring runStatus processing.

### DIFF
--- a/spock-core/src/main/java/org/spockframework/lang/SpecInternals.java
+++ b/spock-core/src/main/java/org/spockframework/lang/SpecInternals.java
@@ -32,10 +32,10 @@ import spock.lang.Specification;
 
 @SuppressWarnings("UnusedDeclaration")
 public abstract class SpecInternals {
-  private final ISpecificationContext specificationContext = new SpecificationContext();
+  private final SpecificationContext specificationContext = new SpecificationContext();
 
   @Beta
-  public ISpecificationContext getSpecificationContext() {
+  public SpecificationContext getSpecificationContext() {
     return specificationContext;
   }
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockInstantiator.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockInstantiator.java
@@ -16,7 +16,7 @@ package org.spockframework.mock.runtime;
 
 import java.util.List;
 
-import org.objenesis.ObjenesisHelper;
+import org.objenesis.ObjenesisStd;
 import org.spockframework.mock.CannotCreateMockException;
 import org.spockframework.runtime.GroovyRuntimeUtil;
 import org.spockframework.util.Nullable;
@@ -42,7 +42,7 @@ public class MockInstantiator {
   // inner class to defer class loading
   private static class ObjenesisInstantiator {
     static Object instantiate(Class<?> clazz) {
-      return clazz.cast(ObjenesisHelper.newInstance(clazz));
+      return clazz.cast(new ObjenesisStd(false).newInstance(clazz));
     }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/BaseSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/BaseSpecRunner.java
@@ -26,6 +26,8 @@ import org.spockframework.util.InternalSpockError;
 
 import spock.lang.Specification;
 
+import java.util.List;
+
 import static org.spockframework.runtime.RunStatus.*;
 
 /**
@@ -37,23 +39,29 @@ import static org.spockframework.runtime.RunStatus.*;
  */
 public class BaseSpecRunner {
   protected static final Object[] EMPTY_ARGS = new Object[0];
+  protected static final FeatureInfo NO_CURRENT_FEATURE = null;
+  protected static final IterationInfo NO_CURRENT_ITERATION = null;
 
   protected final SpecInfo spec;
   protected final IRunSupervisor supervisor;
-
-  protected FeatureInfo currentFeature;
-  protected IterationInfo currentIteration;
+  protected final Scheduler scheduler;
 
   protected Specification sharedInstance;
-  protected Specification currentInstance;
-  protected int runStatus = OK;
+  protected ThreadLocal<Integer> runStatus = new ThreadLocal<Integer>(){
+    @Override
+    protected Integer initialValue() {
+      return OK;
+    }
+  };
 
-  public BaseSpecRunner(SpecInfo spec, IRunSupervisor supervisor) {
+  public BaseSpecRunner(SpecInfo spec, IRunSupervisor supervisor, Scheduler scheduler) {
     this.spec = spec;
     this.supervisor = supervisor;
+    this.scheduler = scheduler;
   }
 
   public int run() {
+    runStatus.set(OK);
     // Sometimes a spec run is requested even though the spec has been excluded
     // (e.g. if JUnit is in control). In such a case, the best thing we can do
     // is to treat the spec as skipped.
@@ -62,7 +70,15 @@ public class BaseSpecRunner {
       return OK;
     }
 
-    createSpecInstance(true);
+    try {
+        sharedInstance = (Specification) spec.getReflection().newInstance();
+    } catch (Throwable t) {
+      throw new InternalSpockError("Failed to instantiate spec '%s'", t).withArgs(spec.getName());
+    }
+
+    sharedInstance.getSpecificationContext().setCurrentSpec(spec);
+    sharedInstance.getSpecificationContext().setSharedInstance(sharedInstance);
+
     runSharedInitializer();
     runSpec();
 
@@ -70,10 +86,10 @@ public class BaseSpecRunner {
   }
 
   private void runSpec() {
-    if (runStatus != OK) return;
+    if (runStatus.get() != OK) return;
 
     supervisor.beforeSpec(spec);
-    invoke(this, createMethodInfoForDoRunSpec());
+    invoke(NO_CURRENT_FEATURE, NO_CURRENT_ITERATION, sharedInstance, this, createMethodInfoForDoRunSpec());
     supervisor.afterSpec(spec);
   }
 
@@ -99,31 +115,13 @@ public class BaseSpecRunner {
     runCleanupSpec();
   }
 
-  private void createSpecInstance(boolean shared) {
-    if (runStatus != OK) return;
-
-    try {
-      if (shared) {
-        sharedInstance = (Specification) spec.getReflection().newInstance();
-        currentInstance = sharedInstance;
-      } else {
-        currentInstance = (Specification) spec.getReflection().newInstance();
-      }
-    } catch (Throwable t) {
-      throw new InternalSpockError("Failed to instantiate spec '%s'", t).withArgs(spec.getName());
-    }
-
-    getSpecificationContext().setCurrentSpec(spec);
-    getSpecificationContext().setSharedInstance(sharedInstance);
-  }
-
   private void runSharedInitializer() {
     runSharedInitializer(spec);
   }
 
   private void runSharedInitializer(SpecInfo spec) {
     if (spec == null) return;
-    invoke(this, createMethodInfoForDoRunSharedInitializer(spec), spec);
+    invoke(NO_CURRENT_FEATURE, NO_CURRENT_ITERATION, sharedInstance, this, createMethodInfoForDoRunSharedInitializer(spec), spec);
   }
 
   private MethodInfo createMethodInfoForDoRunSharedInitializer(final SpecInfo spec) {
@@ -144,8 +142,8 @@ public class BaseSpecRunner {
 
   public void doRunSharedInitializer(SpecInfo spec) {
     runSharedInitializer(spec.getSuperSpec());
-    if (runStatus != OK) return;
-    invoke(currentInstance, spec.getSharedInitializerMethod());
+    if (runStatus.get() != OK) return;
+    invoke(NO_CURRENT_FEATURE, NO_CURRENT_ITERATION, sharedInstance, sharedInstance, spec.getSharedInitializerMethod());
   }
 
   private void runSetupSpec() {
@@ -154,7 +152,7 @@ public class BaseSpecRunner {
 
   private void runSetupSpec(SpecInfo spec) {
     if (spec == null) return;
-    invoke(this, createMethodInfoForDoRunSetupSpec(spec), spec);
+    invoke(NO_CURRENT_FEATURE, NO_CURRENT_ITERATION, sharedInstance, this, createMethodInfoForDoRunSetupSpec(spec), spec);
   }
 
   private MethodInfo createMethodInfoForDoRunSetupSpec(final SpecInfo spec) {
@@ -176,28 +174,42 @@ public class BaseSpecRunner {
   public void doRunSetupSpec(SpecInfo spec) {
     runSetupSpec(spec.getSuperSpec());
     for (MethodInfo method : spec.getSetupSpecMethods()) {
-      if (runStatus != OK) return;
-      invoke(currentInstance, method);
+      if (runStatus.get() != OK) return;
+      invoke(NO_CURRENT_FEATURE, NO_CURRENT_ITERATION, sharedInstance, sharedInstance, method);
     }
   }
 
   private void runFeatures() {
-    for (FeatureInfo feature : spec.getAllFeaturesInExecutionOrder()) {
+    List<FeatureInfo> allFeaturesInExecutionOrder = spec.getAllFeaturesInExecutionOrder();
+    Scheduler scheduler = this.scheduler.deriveScheduler(!spec.isSupportParallelExecution());
+    final int featureCount = allFeaturesInExecutionOrder.size();
+    for (int i = 0; i < featureCount; i++) {
+      final FeatureInfo feature = allFeaturesInExecutionOrder.get(i);
       if (resetStatus(FEATURE) != OK) return;
-      currentFeature = feature;
-      runFeature();
-      currentFeature = null;
+
+      final boolean isLastFeature = i == featureCount - 1;
+      if (isLastFeature) {// let's not waste threads and execute last iteration in current
+        runFeature(feature);
+      } else {
+        scheduler.schedule(new Runnable() {
+          @Override
+          public void run() {
+            runStatus.set(OK);
+            runFeature(feature);
+          }
+        });
+      }
     }
+    scheduler.waitFinished();
   }
 
   private void runCleanupSpec() {
-    currentInstance = sharedInstance;
     runCleanupSpec(spec);
   }
 
   private void runCleanupSpec(SpecInfo spec) {
     if (spec == null) return;
-    invoke(this, createMethodForDoRunCleanupSpec(spec), spec);
+    invoke(NO_CURRENT_FEATURE, NO_CURRENT_ITERATION, sharedInstance, this, createMethodForDoRunCleanupSpec(spec), spec);
   }
 
   private MethodInfo createMethodForDoRunCleanupSpec(final SpecInfo spec) {
@@ -218,275 +230,288 @@ public class BaseSpecRunner {
 
   public void doRunCleanupSpec(SpecInfo spec) {
     for (MethodInfo method : spec.getCleanupSpecMethods()) {
-      if (action(runStatus) == ABORT) return;
-      invoke(currentInstance, method);
+      if (action(runStatus.get()) == ABORT) return;
+      invoke(NO_CURRENT_FEATURE, NO_CURRENT_ITERATION, sharedInstance, sharedInstance, method);
     }
     runCleanupSpec(spec.getSuperSpec());
   }
 
-  private void runFeature() {
-    if (runStatus != OK) return;
+  private void runFeature(FeatureInfo feature) {
+    if (runStatus.get() != OK) return;
 
-    if (currentFeature.isExcluded()) return;
+    if (feature.isExcluded()) return;
 
-    if (currentFeature.isSkipped()) {
-      supervisor.featureSkipped(currentFeature);
+    if (feature.isSkipped()) {
+      supervisor.featureSkipped(feature);
       return;
     }
 
-    supervisor.beforeFeature(currentFeature);
-    invoke(this, createMethodInfoForDoRunFeature());
-    supervisor.afterFeature(currentFeature);
+    supervisor.beforeFeature(feature);
+    invoke(feature, NO_CURRENT_ITERATION, sharedInstance, this, createMethodInfoForDoRunFeature(feature));
+    supervisor.afterFeature(feature);
   }
 
-  private MethodInfo createMethodInfoForDoRunFeature() {
+  private MethodInfo createMethodInfoForDoRunFeature(final FeatureInfo feature) {
     MethodInfo result = new MethodInfo() {
       @Override
       public Object invoke(Object target, Object... arguments) {
-        doRunFeature();
+        doRunFeature(feature);
         return null;
       }
     };
-    result.setParent(currentFeature.getParent());
+    result.setParent(feature.getParent());
     result.setKind(MethodKind.FEATURE_EXECUTION);
-    result.setFeature(currentFeature);
-    result.setDescription(currentFeature.getDescription());
-    for (IMethodInterceptor interceptor : currentFeature.getInterceptors())
+    result.setFeature(feature);
+    result.setDescription(feature.getDescription());
+    for (IMethodInterceptor interceptor : feature.getInterceptors()){
       result.addInterceptor(interceptor);
+    }
     return result;
   }
 
-  public void doRunFeature() {
-    currentFeature.setIterationNameProvider(new SafeIterationNameProvider(currentFeature.getIterationNameProvider()));
-    if (currentFeature.isParameterized())
-      runParameterizedFeature();
-    else runSimpleFeature();
+  public void doRunFeature(FeatureInfo feature) {
+    feature.setIterationNameProvider(new SafeIterationNameProvider(feature.getIterationNameProvider()));
+    if (feature.isParameterized()){
+      runParameterizedFeature(feature);
+    }else {
+      runSimpleFeature(feature);
+    }
   }
 
-  private void runSimpleFeature() {
-    if (runStatus != OK) return;
+  private void runSimpleFeature(FeatureInfo feature) {
+    if (runStatus.get() != OK) return;
 
-    initializeAndRunIteration(EMPTY_ARGS, 1);
+    initializeAndRunIteration(feature, EMPTY_ARGS, 1);
     resetStatus(ITERATION);
   }
 
-  protected void initializeAndRunIteration(Object[] dataValues, int estimatedNumIterations) {
-    if (runStatus != OK) return;
+  protected void initializeAndRunIteration(FeatureInfo feature, Object[] dataValues, int estimatedNumIterations) {
+    if (runStatus.get() != OK) return;
 
-    createSpecInstance(false);
-    runInitializer();
-    runIteration(dataValues, estimatedNumIterations);
+    Specification currentInstance;
+    try {
+      currentInstance = (Specification) spec.getReflection().newInstance();
+    } catch (Throwable t) {
+      throw new InternalSpockError("Failed to instantiate spec '%s'", t).withArgs(spec.getName());
+    }
+
+    currentInstance.getSpecificationContext().setCurrentSpec(spec);
+    currentInstance.getSpecificationContext().setSharedInstance(sharedInstance);
+
+    runInitializer(feature, currentInstance);
+    runIteration(feature, currentInstance, dataValues, estimatedNumIterations);
   }
 
-  private void runIteration(Object[] dataValues, int estimatedNumIterations) {
-    if (runStatus != OK) return;
+  private void runIteration(FeatureInfo feature, Specification currentInstance, Object[] dataValues, int estimatedNumIterations) {
+    if (runStatus.get() != OK) return;
 
-    currentIteration = createIterationInfo(dataValues, estimatedNumIterations);
-    getSpecificationContext().setCurrentIteration(currentIteration);
+    IterationInfo currentIteration = createIterationInfo(feature, dataValues, estimatedNumIterations);
+    currentInstance.getSpecificationContext().setCurrentIteration(currentIteration);
 
-    supervisor.beforeIteration(currentIteration);
-    invoke(this, createMethodInfoForDoRunIteration());
-    supervisor.afterIteration(currentIteration);
+    supervisor.beforeIteration(feature, currentIteration);
+    invoke(feature, currentIteration, currentInstance, this, createMethodInfoForDoRunIteration(feature, currentInstance, currentIteration));
+    supervisor.afterIteration(feature, currentIteration);
 
-    getSpecificationContext().setCurrentIteration(null);
-    currentIteration = null;
+    currentInstance.getSpecificationContext().setCurrentIteration(null);
   }
 
-  private IterationInfo createIterationInfo(Object[] dataValues, int estimatedNumIterations) {
-    IterationInfo result = new IterationInfo(currentFeature, dataValues, estimatedNumIterations);
-    String iterationName = currentFeature.getIterationNameProvider().getName(result);
+  private IterationInfo createIterationInfo(FeatureInfo feature, Object[] dataValues, int estimatedNumIterations) {
+    IterationInfo result = new IterationInfo(feature, dataValues, estimatedNumIterations);
+    String iterationName = feature.getIterationNameProvider().getName(result);
     result.setName(iterationName);
     Description description = Description.createTestDescription(spec.getReflection(),
-        iterationName, currentFeature.getFeatureMethod().getAnnotations());
+        iterationName, feature.getFeatureMethod().getAnnotations());
     result.setDescription(description);
     return result;
   }
 
-  private MethodInfo createMethodInfoForDoRunIteration() {
+  private MethodInfo createMethodInfoForDoRunIteration(final FeatureInfo feature, final Specification currentInstance, final IterationInfo currentIteration) {
     MethodInfo result = new MethodInfo() {
       @Override
       public Object invoke(Object target, Object... arguments) {
-        doRunIteration();
+        doRunIteration(feature, currentInstance, currentIteration);
         return null;
       }
     };
-    result.setParent(currentFeature.getParent());
+    result.setParent(feature.getParent());
     result.setKind(MethodKind.ITERATION_EXECUTION);
-    result.setFeature(currentFeature);
-    result.setDescription(currentFeature.getDescription());
-    for (IMethodInterceptor interceptor : currentFeature.getIterationInterceptors())
+    result.setFeature(feature);
+    result.setDescription(feature.getDescription());
+    for (IMethodInterceptor interceptor : feature.getIterationInterceptors()){
       result.addInterceptor(interceptor);
+    }
     return result;
   }
 
-  public void doRunIteration() {
-    runSetup();
-    runFeatureMethod();
-    runCleanup();
+  public void doRunIteration(FeatureInfo feature, Specification currentInstance, IterationInfo currentIteration) {
+    runSetup(feature, currentInstance, currentIteration);
+    runFeatureMethod(feature, currentInstance, currentIteration);
+    runCleanup(feature, currentInstance, currentIteration);
   }
 
   protected int resetStatus(int scope) {
-    if (scope(runStatus) <= scope) runStatus = OK;
-    return runStatus;
+    if (scope(runStatus.get()) <= scope) runStatus.set(OK);
+    return runStatus.get();
   }
 
-  protected void runParameterizedFeature() {
+  protected void runParameterizedFeature(FeatureInfo currentFeature) {
     throw new UnsupportedOperationException("This runner cannot run parameterized features");
   }
 
-  private void runInitializer() {
-    runInitializer(spec);
+  private void runInitializer(FeatureInfo feature, final Specification currentInstance) {
+    runInitializer(spec, feature, currentInstance);
   }
 
-  private void runInitializer(SpecInfo spec) {
+  private void runInitializer(SpecInfo spec, FeatureInfo feature, final Specification currentInstance) {
     if (spec == null) return;
-    invoke(this, createMethodInfoForDoRunInitializer(spec), spec);
+    invoke(feature, NO_CURRENT_ITERATION, currentInstance, this, createMethodInfoForDoRunInitializer(spec, feature, currentInstance), spec);
   }
 
-  private MethodInfo createMethodInfoForDoRunInitializer(final SpecInfo spec) {
+  private MethodInfo createMethodInfoForDoRunInitializer(final SpecInfo spec, final FeatureInfo feature, final Specification currentInstance) {
     MethodInfo result = new MethodInfo() {
       @Override
       public Object invoke(Object target, Object... arguments) {
-        doRunInitializer(spec);
+        doRunInitializer(spec, feature, currentInstance);
         return null;
       }
     };
-    result.setParent(currentFeature.getParent());
+    result.setParent(feature.getParent());
     result.setKind(MethodKind.INITIALIZER);
-    result.setFeature(currentFeature);
-    result.setDescription(currentFeature.getDescription());
-    for (IMethodInterceptor interceptor : spec.getInitializerInterceptors())
+    result.setFeature(feature);
+    result.setDescription(feature.getDescription());
+    for (IMethodInterceptor interceptor : spec.getInitializerInterceptors()){
       result.addInterceptor(interceptor);
+    }
     return result;
   }
 
-  public void doRunInitializer(SpecInfo spec) {
-    runInitializer(spec.getSuperSpec());
-    if (runStatus != OK) return;
-    invoke(currentInstance, spec.getInitializerMethod());
+  public void doRunInitializer(SpecInfo spec, FeatureInfo feature, Specification currentInstance) {
+    runInitializer(spec.getSuperSpec(), feature, currentInstance);
+    if (runStatus.get() != OK) return;
+    invoke(feature, NO_CURRENT_ITERATION, currentInstance, currentInstance, spec.getInitializerMethod());
   }
 
-  private void runSetup() {
-    runSetup(spec);
+  private void runSetup(FeatureInfo feature, Specification currentInstance, IterationInfo currentIteration) {
+    runSetup(spec, feature, currentInstance, currentIteration);
   }
 
-  private void runSetup(SpecInfo spec) {
+  private void runSetup(SpecInfo spec, FeatureInfo feature, Specification currentInstance, IterationInfo currentIteration) {
     if (spec == null) return;
-    invoke(this, createMethodInfoForDoRunSetup(spec), spec);
+    invoke(feature, currentIteration, currentInstance, this, createMethodInfoForDoRunSetup(spec, feature, currentInstance, currentIteration), spec);
   }
 
-  private MethodInfo createMethodInfoForDoRunSetup(final SpecInfo spec) {
+  private MethodInfo createMethodInfoForDoRunSetup(final SpecInfo spec, final FeatureInfo feature, final Specification currentInstance, final IterationInfo currentIteration) {
     MethodInfo result = new MethodInfo() {
       @Override
       public Object invoke(Object target, Object... arguments) {
-        doRunSetup(spec);
+        doRunSetup(spec, feature, currentInstance, currentIteration);
         return null;
       }
     };
-    result.setParent(currentFeature.getParent());
+    result.setParent(feature.getParent());
     result.setKind(MethodKind.SETUP);
-    result.setFeature(currentFeature);
-    result.setDescription(currentFeature.getDescription());
-    for (IMethodInterceptor interceptor : spec.getSetupInterceptors())
+    result.setFeature(feature);
+    result.setDescription(feature.getDescription());
+    for (IMethodInterceptor interceptor : spec.getSetupInterceptors()){
       result.addInterceptor(interceptor);
+    }
     return result;
   }
 
-  public void doRunSetup(SpecInfo spec) {
-    runSetup(spec.getSuperSpec());
+  public void doRunSetup(SpecInfo spec, FeatureInfo feature, final Specification currentInstance, IterationInfo currentIteration) {
+    runSetup(spec.getSuperSpec(), feature, currentInstance, currentIteration);
     for (MethodInfo method : spec.getSetupMethods()) {
-      if (runStatus != OK) return;
-      method.setFeature(currentFeature);
-      invoke(currentInstance, method);
+      if (runStatus.get() != OK){
+        return;
+      }
+      invoke(feature, currentIteration, currentInstance, currentInstance, method);
     }
   }
 
-  private void runFeatureMethod() {
-    if (runStatus != OK) return;
-    invoke(currentInstance, currentFeature.getFeatureMethod(), currentIteration.getDataValues());
+  private void runFeatureMethod(FeatureInfo feature, final Specification currentInstance, IterationInfo currentIteration) {
+    if (runStatus.get() != OK){
+      return;
+    }
+    invoke(feature, currentIteration, currentInstance, currentInstance, feature.getFeatureMethod(), currentIteration.getDataValues());
   }
 
-  private void runCleanup() {
-    runCleanup(spec);
+  private void runCleanup(FeatureInfo feature, final Specification currentInstance, IterationInfo currentIteration) {
+    runCleanup(spec, feature, currentInstance, currentIteration);
   }
 
-  private void runCleanup(SpecInfo spec) {
+  private void runCleanup(SpecInfo spec, FeatureInfo feature, final Specification currentInstance, IterationInfo currentIteration) {
     if (spec == null) return;
-    invoke(this, createMethodInfoForDoRunCleanup(spec), spec);
+    invoke(feature, currentIteration, currentInstance, this, createMethodInfoForDoRunCleanup(spec, feature, currentInstance, currentIteration), spec);
   }
 
-  private MethodInfo createMethodInfoForDoRunCleanup(final SpecInfo spec) {
+  private MethodInfo createMethodInfoForDoRunCleanup(final SpecInfo spec, final FeatureInfo feature, final Specification currentInstance, final IterationInfo currentIteration) {
     MethodInfo result = new MethodInfo() {
       @Override
       public Object invoke(Object target, Object... arguments) {
-        doRunCleanup(spec);
+        doRunCleanup(spec, feature, currentInstance, currentIteration);
         return null;
       }
     };
-    result.setParent(currentFeature.getParent());
+    result.setParent(feature.getParent());
     result.setKind(MethodKind.CLEANUP);
-    result.setFeature(currentFeature);
-    result.setDescription(currentFeature.getDescription());
-    for (IMethodInterceptor interceptor : spec.getCleanupInterceptors())
+    result.setFeature(feature);
+    result.setDescription(feature.getDescription());
+    for (IMethodInterceptor interceptor : spec.getCleanupInterceptors()){
       result.addInterceptor(interceptor);
+    }
     return result;
   }
 
-  public void doRunCleanup(SpecInfo spec) {
+  public void doRunCleanup(SpecInfo spec, FeatureInfo feature, final Specification currentInstance, IterationInfo currentIteration) {
     if (spec.getIsBottomSpec()) {
-      runIterationCleanups();
-      if (action(runStatus) == ABORT) return;
+      runIterationCleanups(feature, currentIteration);
+      if (action(runStatus.get()) == ABORT) return;
     }
     for (MethodInfo method : spec.getCleanupMethods()) {
-      if (action(runStatus) == ABORT) return;
-      invoke(currentInstance, method);
+      if (action(runStatus.get()) == ABORT) return;
+      invoke(feature, currentIteration, currentInstance, currentInstance, method);
     }
-    runCleanup(spec.getSuperSpec());
+    runCleanup(spec.getSuperSpec(), feature, currentInstance, currentIteration);
   }
 
-  private void runIterationCleanups() {
+  private void runIterationCleanups(FeatureInfo currentFeature, IterationInfo currentIteration) {
     for (Runnable cleanup : currentIteration.getCleanups()) {
-      if (action(runStatus) == ABORT) return;
+      if (action(runStatus.get()) == ABORT) return;
       try {
         cleanup.run();
       } catch (Throwable t) {
         ErrorInfo error = new ErrorInfo(CollectionUtil.getFirstElement(spec.getCleanupMethods()), t);
-        runStatus = supervisor.error(error);
+        runStatus.set(supervisor.error(currentFeature, currentIteration, error));
       }
     }
   }
 
-  private void invoke(Object target, MethodInfo method, Object... arguments) {
+  private void invoke(FeatureInfo currentFeature, IterationInfo currentIteration, final Specification currentInstance, Object target, MethodInfo method, Object... arguments) {
     if (method == null || method.isExcluded()) return;
 
     // fast lane
     if (method.getInterceptors().isEmpty()) {
-      invokeRaw(target, method, arguments);
+      invokeRaw(currentFeature, currentIteration, target, method, arguments);
       return;
     }
 
     // slow lane
-    MethodInvocation invocation = new MethodInvocation(currentFeature,
-        currentIteration, sharedInstance, currentInstance, target, method, arguments);
+    MethodInvocation invocation = new MethodInvocation(currentFeature, currentIteration, sharedInstance, currentInstance, target, method, arguments);
     try {
       invocation.proceed();
     } catch (Throwable t) {
       ErrorInfo error = new ErrorInfo(method, t);
-      runStatus = supervisor.error(error);
+      runStatus.set(supervisor.error(currentFeature, currentIteration, error));
     }
   }
 
-  protected Object invokeRaw(Object target, MethodInfo method, Object... arguments) {
+  protected Object invokeRaw(FeatureInfo currentFeature, IterationInfo currentIteration, Object target, MethodInfo method, Object... arguments) {
     try {
       return method.invoke(target, arguments);
     } catch (Throwable t) {
-      runStatus = supervisor.error(new ErrorInfo(method, t));
+      runStatus.set(supervisor.error(currentFeature, currentIteration, new ErrorInfo(method, t)));
       return null;
     }
-  }
-
-  protected SpecificationContext getSpecificationContext() {
-    return (SpecificationContext) currentInstance.getSpecificationContext();
   }
 }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/IRunSupervisor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IRunSupervisor.java
@@ -38,7 +38,9 @@ public interface IRunSupervisor {
   void afterFeature(FeatureInfo feature);
   void afterSpec(SpecInfo spec);
 
-  int error(FeatureInfo currentFeature, IterationInfo currentIteration, ErrorInfo error);
+  void error(InvokeException invokeException);
+
+  void error(FeatureInfo currentFeature, IterationInfo currentIteration, ErrorInfo error);
 
   void specSkipped(SpecInfo spec);
   void featureSkipped(FeatureInfo feature);

--- a/spock-core/src/main/java/org/spockframework/runtime/IRunSupervisor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IRunSupervisor.java
@@ -31,13 +31,14 @@ public interface IRunSupervisor {
    * run. All parameterization values have been computed successfully
    * at this point. Not called for non-parameterized features.
    */
-  void beforeIteration(IterationInfo iteration);
+  void beforeIteration(FeatureInfo currentFeature, IterationInfo iteration);
 
-  void afterIteration(IterationInfo iteration);
+  void afterIteration(FeatureInfo currentFeature, IterationInfo iteration);
+  void noIterationFound(FeatureInfo currentFeature);
   void afterFeature(FeatureInfo feature);
   void afterSpec(SpecInfo spec);
 
-  int error(ErrorInfo error);
+  int error(FeatureInfo currentFeature, IterationInfo currentIteration, ErrorInfo error);
 
   void specSkipped(SpecInfo spec);
   void featureSkipped(FeatureInfo feature);

--- a/spock-core/src/main/java/org/spockframework/runtime/InvokeException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/InvokeException.java
@@ -1,0 +1,29 @@
+package org.spockframework.runtime;
+
+import org.spockframework.runtime.model.ErrorInfo;
+import org.spockframework.runtime.model.FeatureInfo;
+import org.spockframework.runtime.model.IterationInfo;
+
+class InvokeException extends Exception{
+  private final FeatureInfo currentFeature;
+  private final IterationInfo currentIteration;
+  private final ErrorInfo errorInfo;
+
+  public InvokeException(FeatureInfo currentFeature, IterationInfo currentIteration, ErrorInfo errorInfo) {
+    this.currentFeature = currentFeature;
+    this.currentIteration = currentIteration;
+    this.errorInfo = errorInfo;
+  }
+
+  public FeatureInfo getCurrentFeature() {
+    return currentFeature;
+  }
+
+  public IterationInfo getCurrentIteration() {
+    return currentIteration;
+  }
+
+  public ErrorInfo getErrorInfo() {
+    return errorInfo;
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/JUnitSupervisor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/JUnitSupervisor.java
@@ -35,12 +35,6 @@ public class JUnitSupervisor implements IRunSupervisor {
   private final IRunListener masterListener;
   private final IObjectRenderer<Object> diffedObjectRenderer;
 
-  private FeatureInfo currentFeature;
-  private IterationInfo currentIteration;
-
-  private int iterationCount;
-  private boolean errorSinceLastReset;
-
   public JUnitSupervisor(SpecInfo spec, RunNotifier notifier, IStackTraceFilter filter,
       IObjectRenderer<Object> diffedObjectRenderer) {
     this.spec = spec;
@@ -56,38 +50,30 @@ public class JUnitSupervisor implements IRunSupervisor {
 
   public void beforeFeature(FeatureInfo feature) {
     masterListener.beforeFeature(feature);
-    currentFeature = feature;
 
     if (!feature.isReportIterations())
       notifier.fireTestStarted(feature.getDescription());
-
-    if (feature.isParameterized()) {
-      iterationCount = 0;
-      errorSinceLastReset = false;
-    }
   }
 
-  public void beforeIteration(IterationInfo iteration) {
+  public void beforeIteration(FeatureInfo currentFeature, IterationInfo iteration) {
     masterListener.beforeIteration(iteration);
-    currentIteration = iteration;
-    
-    iterationCount++;
+
     if (currentFeature.isReportIterations())
       notifier.fireTestStarted(iteration.getDescription());
   }
 
-  public int error(ErrorInfo error) {
+  public int error(FeatureInfo currentFeature, IterationInfo currentIteration, ErrorInfo error) {
     Throwable exception = error.getException();
 
     if (exception instanceof MultipleFailureException)
-      return handleMultipleFailures(error);
+      return handleMultipleFailures(currentFeature, currentIteration, error);
 
     if (isFailedEqualityComparison(exception))
       exception = convertToComparisonFailure(exception);
 
     filter.filter(exception);
 
-    Failure failure = new Failure(getCurrentDescription(), exception);
+    Failure failure = new Failure(getCurrentDescription(currentFeature, currentIteration), exception);
 
     if (exception instanceof AssumptionViolatedException) {
       // Spock has no concept of "violated assumption", so we don't notify Spock listeners
@@ -100,16 +86,15 @@ public class JUnitSupervisor implements IRunSupervisor {
       notifier.fireTestFailure(failure);
     }
 
-    errorSinceLastReset = true;
     return statusFor(error);
   }
 
   // for better JUnit compatibility, e.g when a @Rule is used
-  private int handleMultipleFailures(ErrorInfo error) {
+  private int handleMultipleFailures(FeatureInfo currentFeature, IterationInfo currentIteration, ErrorInfo error) {
     MultipleFailureException multiFailure = (MultipleFailureException) error.getException();
     int runStatus = OK;
     for (Throwable failure : multiFailure.getFailures())
-      runStatus = error(new ErrorInfo(error.getMethod(), failure));
+      runStatus = error(currentFeature, currentIteration, new ErrorInfo(error.getMethod(), failure));
     return runStatus;
   }
 
@@ -118,7 +103,8 @@ public class JUnitSupervisor implements IRunSupervisor {
 
     Condition condition = ((ConditionNotSatisfiedError) exception).getCondition();
     ExpressionInfo expr = condition.getExpression();
-    return expr != null && expr.isEqualityComparison();
+    return expr != null && expr.isEqualityComparison() && // it is equality
+        exception.getCause() == null;    // and it is not failed because of exception
   }
 
   // enables IDE support (diff dialog)
@@ -166,26 +152,23 @@ public class JUnitSupervisor implements IRunSupervisor {
     }
   }
 
-  public void afterIteration(IterationInfo iteration) {
+  public void afterIteration(FeatureInfo currentFeature, IterationInfo iteration) {
     masterListener.afterIteration(iteration);
-    if (currentFeature.isReportIterations())
+    if (currentFeature.isReportIterations()) {
       notifier.fireTestFinished(iteration.getDescription());
-    
-    currentIteration = null;
+    }
+  }
+
+  public void noIterationFound(FeatureInfo currentFeature){
+    notifier.fireTestFailure(new Failure(currentFeature.getDescription(),
+      new SpockExecutionException("Data provider has no data")));
   }
 
   public void afterFeature(FeatureInfo feature) {
-    if (feature.isParameterized()) {
-      if (iterationCount == 0 && !errorSinceLastReset)
-        notifier.fireTestFailure(new Failure(feature.getDescription(),
-            new SpockExecutionException("Data provider has no data")));
-    }
-
     masterListener.afterFeature(feature);
-    if (!feature.isReportIterations())
+    if (!feature.isReportIterations()) {
       notifier.fireTestFinished(feature.getDescription());
-
-    currentFeature = null;
+    }
   }
 
   public void afterSpec(SpecInfo spec) {
@@ -202,11 +185,13 @@ public class JUnitSupervisor implements IRunSupervisor {
     notifier.fireTestIgnored(feature.getDescription());
   }
 
-  private Description getCurrentDescription() {
-    if (currentIteration != null && currentFeature.isReportIterations())
+  private Description getCurrentDescription(FeatureInfo currentFeature, IterationInfo currentIteration) {
+    if (currentIteration != null && currentFeature.isReportIterations()) {
       return currentIteration.getDescription();
-    if (currentFeature != null) 
+    }
+    if (currentFeature != null) {
       return currentFeature.getDescription();
+    }
     return spec.getDescription();
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/RunContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/RunContext.java
@@ -20,6 +20,7 @@ import java.util.*;
 
 import org.junit.runner.notification.RunNotifier;
 
+import org.junit.runners.model.RunnerScheduler;
 import org.spockframework.builder.DelegatingScript;
 import org.spockframework.runtime.condition.*;
 import org.spockframework.runtime.model.SpecInfo;
@@ -80,9 +81,11 @@ public class RunContext {
     return new ExtensionRunner(spec, globalExtensionRegistry, globalExtensionRegistry);
   }
 
-  public ParameterizedSpecRunner createSpecRunner(SpecInfo spec, RunNotifier notifier) {
-    return new ParameterizedSpecRunner(spec,
-        new JUnitSupervisor(spec, notifier, createStackTraceFilter(spec), diffedObjectRenderer));
+  public ParameterizedSpecRunner createSpecRunner(SpecInfo spec, RunNotifier notifier, Scheduler scheduler) {
+    return new ParameterizedSpecRunner(
+        spec,
+        new JUnitSupervisor(spec, notifier, createStackTraceFilter(spec), diffedObjectRenderer),
+        scheduler);
   }
 
   @Nullable

--- a/spock-core/src/main/java/org/spockframework/runtime/Scheduler.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/Scheduler.java
@@ -1,0 +1,67 @@
+package org.spockframework.runtime;
+
+import org.junit.runners.model.RunnerScheduler;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Scheduler {
+  private final RunnerScheduler runnerScheduler;
+  private final boolean forceSequential;
+  private final AtomicInteger scheduledTasksCount = new AtomicInteger(0);
+  private final Semaphore concurrentJobsSemaphore = new Semaphore(0);
+  private State state = State.SCHEDULING;
+
+  public Scheduler(RunnerScheduler runnerScheduler, boolean forceSequential) {
+    this.runnerScheduler = runnerScheduler;
+    this.forceSequential = forceSequential;
+  }
+
+  public void schedule(final Runnable task) {
+    synchronized (this){
+      if (state == State.WAITING) {
+        throw new IllegalStateException("No new tasks can be scheduled after waitFinished() was called");
+      }
+      scheduledTasksCount.incrementAndGet();
+    }
+    if (forceSequential) {
+      task.run();
+    } else {
+      runnerScheduler.schedule(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            task.run();
+          } finally {
+            concurrentJobsSemaphore.release();
+          }
+        }
+      });
+    }
+  }
+
+  public void waitFinished() {
+    synchronized (this){
+      if (state == State.WAITING) {
+        throw new IllegalStateException("waitFinished() can be called only once");
+      }
+      state = State.WAITING;
+    }
+    if (!forceSequential && scheduledTasksCount.get() > 0) {
+      try {
+        concurrentJobsSemaphore.acquire(scheduledTasksCount.get());
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public Scheduler deriveScheduler(boolean forceSequential) {
+    return new Scheduler(runnerScheduler, forceSequential);
+  }
+
+  private enum State {
+    SCHEDULING,
+    WAITING
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/SequentialRunnerScheduler.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SequentialRunnerScheduler.java
@@ -1,0 +1,15 @@
+package org.spockframework.runtime;
+
+import org.junit.runners.model.RunnerScheduler;
+
+public class SequentialRunnerScheduler implements RunnerScheduler{
+    @Override
+    public void schedule(Runnable childStatement) {
+        childStatement.run();
+    }
+
+    @Override
+    public void finished() {
+
+    }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/Sputnik.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/Sputnik.java
@@ -20,12 +20,16 @@ import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.manipulation.*;
 import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
 
+import org.junit.runners.model.RunnerScheduler;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.SpecInfo;
 import org.spockframework.util.IncompatibleGroovyVersionException;
 import org.spockframework.util.VersionChecker;
+
+import java.util.List;
 
 /**
  * A JUnit runner for Spock specifications. There is no need to put
@@ -36,19 +40,42 @@ import org.spockframework.util.VersionChecker;
  * @author Peter Niederwieser
  */
 // TODO: check if StoppedByUserException thrown in Notifier.fireTestStarted() is handled correctly on our side
-public class Sputnik extends Runner implements Filterable, Sortable {
+public class Sputnik extends ParentRunner implements Filterable, Sortable {
   private final Class<?> clazz;
   private SpecInfo spec;
   private boolean extensionsRun = false;
   private boolean descriptionGenerated = false;
+  private RunnerScheduler scheduler = new SequentialRunnerScheduler();
 
   public Sputnik(Class<?> clazz) throws InitializationError {
+    super(Object.class); // fake class - we need ParentRunner only to obtain RunnerScheduler
     try {
       VersionChecker.checkGroovyVersion("JUnit runner");
     } catch (IncompatibleGroovyVersionException e) {
       throw new InitializationError(e);
     }
     this.clazz = clazz;
+  }
+
+  @Override
+  protected List getChildren() {
+    throw new UnsupportedOperationException("workflow from ParentRunner not supported");
+  }
+
+  @Override
+  protected Description describeChild(Object child) {
+    throw new UnsupportedOperationException("workflow from ParentRunner not supported");
+  }
+
+  @Override
+  protected void runChild(Object child, RunNotifier notifier) {
+    throw new UnsupportedOperationException("workflow from ParentRunner not supported");
+  }
+
+  @Override
+  public void setScheduler(RunnerScheduler scheduler) {
+    super.setScheduler(scheduler);
+    this.scheduler = scheduler;
   }
 
   public Description getDescription() {
@@ -60,7 +87,8 @@ public class Sputnik extends Runner implements Filterable, Sortable {
   public void run(RunNotifier notifier) {
     runExtensionsIfNecessary();
     generateSpecDescriptionIfNecessary();
-    RunContext.get().createSpecRunner(getSpec(), notifier).run();
+    RunContext.get().createSpecRunner(getSpec(), notifier, new Scheduler(scheduler, false)).run();
+    scheduler.finished();
   }
 
   public void filter(Filter filter) throws NoTestsRemainException {

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConcurrentExecutionModeExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConcurrentExecutionModeExtension.java
@@ -1,0 +1,21 @@
+package org.spockframework.runtime.extension.builtin;
+
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension;
+import org.spockframework.runtime.model.FeatureInfo;
+import org.spockframework.runtime.model.SpecInfo;
+import spock.lang.ConcurrentExecutionMode;
+
+public class ConcurrentExecutionModeExtension extends AbstractAnnotationDrivenExtension<ConcurrentExecutionMode>{
+  @Override
+  public void visitSpecAnnotation(ConcurrentExecutionMode annotation, SpecInfo spec) {
+    spec.setSupportParallelExecution(annotation.value() == ConcurrentExecutionMode.Mode.USE_JUNIT_SCHEDULER);
+    for (FeatureInfo featureInfo : spec.getAllFeatures()) {
+      visitFeatureAnnotation(annotation, featureInfo);
+    }
+  }
+
+  @Override
+  public void visitFeatureAnnotation(ConcurrentExecutionMode annotation, FeatureInfo feature) {
+    feature.setSupportParallelExecution(annotation.value() == ConcurrentExecutionMode.Mode.USE_JUNIT_SCHEDULER);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/StepwiseExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/StepwiseExtension.java
@@ -26,6 +26,15 @@ public class StepwiseExtension extends AbstractAnnotationDrivenExtension {
     sortFeaturesInDeclarationOrder(spec);
     includeFeaturesBeforeLastIncludedFeature(spec);
     skipFeaturesAfterFirstFailingFeature(spec);
+
+    forceSequential(spec);
+  }
+
+  private void forceSequential(SpecInfo spec) {
+    spec.setSupportParallelExecution(false);
+    for (FeatureInfo featureInfo : spec.getAllFeaturesInExecutionOrder()) {
+      featureInfo.setSupportParallelExecution(false);
+    }
   }
 
   private void sortFeaturesInDeclarationOrder(SpecInfo spec) {

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -25,6 +25,8 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
 
   private boolean reportIterations = false;
 
+  private boolean supportParallelExecution = true;
+
   public SpecInfo getSpec() {
     return getParent();
   }
@@ -112,6 +114,14 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   
   public void setReportIterations(boolean flag) {
     reportIterations = flag;
+  }
+
+  public boolean isSupportParallelExecution() {
+    return supportParallelExecution;
+  }
+
+  public void setSupportParallelExecution(boolean supportParallelExecution) {
+    this.supportParallelExecution = supportParallelExecution;
   }
 
   @Nullable

--- a/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
@@ -56,6 +56,8 @@ public class SpecInfo extends SpecElementInfo<NodeInfo, Class<?>> implements IMe
 
   private final List<FeatureInfo> features = new ArrayList<FeatureInfo>();
 
+  private boolean supportParallelExecution = true;
+
   public String getPackage() {
     return pkg;
   }
@@ -94,6 +96,14 @@ public class SpecInfo extends SpecElementInfo<NodeInfo, Class<?>> implements IMe
 
   public void setSubSpec(SpecInfo subSpec) {
     this.subSpec = subSpec;
+  }
+
+  public boolean isSupportParallelExecution() {
+    return supportParallelExecution;
+  }
+
+  public void setSupportParallelExecution(boolean supportParallelExecution) {
+    this.supportParallelExecution = supportParallelExecution;
   }
 
   public SpecInfo getTopSpec() {

--- a/spock-core/src/main/java/spock/lang/ConcurrentExecutionMode.java
+++ b/spock-core/src/main/java/spock/lang/ConcurrentExecutionMode.java
@@ -1,0 +1,32 @@
+package spock.lang;
+
+import org.spockframework.runtime.extension.ExtensionAnnotation;
+import org.spockframework.runtime.extension.builtin.ConcurrentExecutionModeExtension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Sets concurrent execution mode.
+ * For parallel execution Spock use RunnerScheduler passed by JUnit (therefore features and iterations will be executed in parallel only if parallel scheduler passed to runner).
+ * <p/>
+ * If it is set on feature level if will describe can or not iterations be executed concurrently (should them be scheduled or should executed concurrently).
+ * It affects only @Unroll'ed features.
+ * <p/>
+ * On class level this annotations will describe can or not features and unrolled iterations be executed concurrently.
+ * <p/>
+ * If it is set on class level it will affect all features unless feature has it's own annotation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtensionAnnotation(ConcurrentExecutionModeExtension.class)
+public @interface ConcurrentExecutionMode {
+  Mode value();
+
+  enum Mode{
+    FORCE_SEQUENTIAL,
+    USE_JUNIT_SCHEDULER
+  }
+}

--- a/spock-core/src/test/java/org/spockframework/runtime/SchedulerTest.java
+++ b/spock-core/src/test/java/org/spockframework/runtime/SchedulerTest.java
@@ -1,0 +1,124 @@
+package org.spockframework.runtime;
+
+import org.junit.Test;
+import org.junit.runners.model.RunnerScheduler;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class SchedulerTest {
+
+  @Test
+  public void testSequentialParent() throws Exception {
+    final SequentialRunnerScheduler sequentialRunnerScheduler = new SequentialRunnerScheduler();
+    assertThatTasksProcessedSequentially(new Scheduler(sequentialRunnerScheduler, false));
+    assertThatTasksProcessedSequentially(new Scheduler(sequentialRunnerScheduler, true));
+    assertThatTasksProcessedSequentially(new Scheduler(sequentialRunnerScheduler, true).deriveScheduler(false));
+    assertThatTasksProcessedSequentially(new Scheduler(sequentialRunnerScheduler, true).deriveScheduler(true));
+  }
+
+  @Test
+  public void testParallelParent() throws Exception {
+    final ParallelRunnerScheduler sequentialRunnerScheduler = new ParallelRunnerScheduler();
+
+    assertThatTasksProcessedInParallel(new Scheduler(sequentialRunnerScheduler, false));
+    assertThatTasksProcessedInParallel(new Scheduler(sequentialRunnerScheduler, true).deriveScheduler(false));
+
+    assertThatTasksProcessedSequentially(new Scheduler(sequentialRunnerScheduler, true));
+    assertThatTasksProcessedSequentially(new Scheduler(sequentialRunnerScheduler, true).deriveScheduler(true));
+  }
+
+  private void assertThatTasksProcessedSequentially(Scheduler scheduler) {
+    final AtomicReference<Runnable> currentTask = new AtomicReference<Runnable>();
+    final AtomicBoolean sequentialExecutionWasFailed = new AtomicBoolean(false);
+    final AtomicInteger executedTaskCount = new AtomicInteger(0);
+
+    class Task implements Runnable {
+      @Override
+      public void run() {
+        currentTask.set(this);
+        sleep(200);
+        if (currentTask.get() != this) {
+          sequentialExecutionWasFailed.set(true);
+        }
+        sleep(200);
+        executedTaskCount.incrementAndGet();
+      }
+    }
+
+    for (int i = 0; i < 5; i++) {
+      scheduler.schedule(new Task());
+    }
+
+    scheduler.waitFinished();
+
+    assertFalse("should be executed sequentially", sequentialExecutionWasFailed.get());
+    assertEquals("all tasks should be executed", 5, executedTaskCount.get());
+  }
+
+  private void assertThatTasksProcessedInParallel(Scheduler scheduler) {
+    final int taskCount = 5;
+
+    final AtomicBoolean parallelExecutionWasFailed = new AtomicBoolean(false);
+    final AtomicInteger executedTaskCount = new AtomicInteger(0);
+    final AtomicInteger startedTaskCount = new AtomicInteger(0);
+
+    class Task implements Runnable {
+      @Override
+      public void run() {
+        startedTaskCount.incrementAndGet();
+        sleep(200);
+        if (startedTaskCount.get() != taskCount) { // all tasks should be being executed
+          parallelExecutionWasFailed.set(true);
+        }
+        sleep(200);
+        executedTaskCount.incrementAndGet();
+      }
+    }
+
+    for (int i = 0; i < taskCount; i++) {
+      scheduler.schedule(new Task());
+    }
+
+    scheduler.waitFinished();
+
+    assertFalse("should be executed in parallel", parallelExecutionWasFailed.get());
+    assertEquals("all tasks should be executed", taskCount, executedTaskCount.get());
+  }
+
+
+  private void sleep(int ms) {
+    try {
+      Thread.sleep(ms);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+  //------------------------------------------------------------------------
+
+  private static class ParallelRunnerScheduler implements RunnerScheduler {
+    private final ExecutorService fService = Executors.newCachedThreadPool();
+
+    public void schedule(Runnable childStatement) {
+      fService.submit(childStatement);
+    }
+
+    public void finished() {
+      try {
+        fService.shutdown();
+        fService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+      } catch (InterruptedException e) {
+        e.printStackTrace(System.err);
+      }
+    }
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/VerifyExecutionExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/VerifyExecutionExtension.groovy
@@ -72,5 +72,14 @@ class VerifyExecutionExtension extends AbstractAnnotationDrivenExtension<VerifyE
           }
         }
     )
+
+    forceSequential(spec);
+  }
+
+  private static void forceSequential(SpecInfo spec) {
+    spec.setSupportParallelExecution(false);
+    for (FeatureInfo featureInfo : spec.getAllFeaturesInExecutionOrder()) {
+      featureInfo.setSupportParallelExecution(false);
+    }
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/junit/scheduling/AllTestsInParallelTest.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/junit/scheduling/AllTestsInParallelTest.groovy
@@ -1,0 +1,118 @@
+package org.spockframework.junit.scheduling
+
+import org.junit.runner.JUnitCore
+import org.junit.runner.Result
+import org.junit.runner.notification.RunListener
+import org.spockframework.report.log.ReportLogConfigurationSpec
+import org.spockframework.runtime.ConfigurationScriptLoaderSpec
+import org.spockframework.runtime.RunContextSpec
+import org.spockframework.runtime.StandardStreamsCapturerSpec
+import org.spockframework.smoke.extension.ReportLogExtensionSpec
+import org.spockframework.smoke.extension.RestoreSystemPropertiesExtension
+import org.spockframework.smoke.extension.TimeoutExtensionThreadAffinity
+import org.spockframework.smoke.extension.UseRestoreSystemPropertiesOnSpecClass
+import org.spockframework.smoke.mock.GroovySpiesThatAreGlobal
+import org.spockframework.smoke.mock.InvokingMocksFromMultipleThreads
+import spock.lang.Specification
+import spock.util.EmbeddedSpecRunner
+
+import java.lang.reflect.Modifier
+import java.util.concurrent.atomic.AtomicReference
+
+class AllTestsInParallelTest extends Specification {
+  private static final Set<Class> excludeFromTest = [
+    AllTestsInParallelTest.class, // prevent recursion
+    RunContextSpec.class, // this spec tests top level naming, will not work under runner.withNewContext
+    ReportLogExtensionSpec.class, // LogExtension will not work in parallel mode
+    ReportLogConfigurationSpec.class,
+    ConfigurationScriptLoaderSpec.class, // sets system properties
+    StandardStreamsCapturerSpec.class, // sets System.out
+    GroovySpiesThatAreGlobal.class, // it use List as subject to mock, and mocks are global
+    TimeoutExtensionThreadAffinity.class, // it checks that execution is performed in "main" thread. It does not have sense in parallel mode.
+    RestoreSystemPropertiesExtension.class, // use system properties
+    UseRestoreSystemPropertiesOnSpecClass.class, // use system properties
+    InvokingMocksFromMultipleThreads.class, // starts new threads, can fail on slow boxes
+  ]
+
+  def "all spock-spec tests in parallel mode"() {
+
+    def listener = Mock(RunListener)
+    def jUnitCore = new JUnitCore()
+    jUnitCore.addListener(listener)
+
+    when:
+    def runner = new EmbeddedSpecRunner()
+    AtomicReference<Result> resultAR = new AtomicReference<>()
+    runner.withNewContext {
+      def parallelComputer = new ParallelComputerWithFixedPool(10)
+      def testClasses = getTestClasses("org.spockframework")
+      def testClassesAsArray = testClasses.toArray(new Class<?>[0])
+      def result = jUnitCore.run(parallelComputer, testClassesAsArray)
+      resultAR.set(result)
+    }
+
+    then:
+    resultAR.get().failures.isEmpty()
+  }
+
+  private static List<Class> getTestClasses(String packageName) {
+    ArrayList<Class> testClasses = new ArrayList<Class>();
+    def allClasses = getClasses(packageName)
+    for (Class aClass : allClasses) {
+      if (Specification.class.isAssignableFrom(aClass) && !Modifier.isAbstract(aClass.getModifiers()) && !excludeFromTest.contains(aClass)) {
+        testClasses.add(aClass);
+      }
+    }
+    return testClasses;
+  }
+
+  /**
+   * Scans all classes accessible from the context class loader which belong to the given package and subpackages.
+   *
+   * @param packageName The base package
+   * @return The classes
+   * @throws ClassNotFoundException
+   * @throws IOException
+   */
+  private static List<Class> getClasses(String packageName)
+    throws ClassNotFoundException, IOException {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    String path = packageName.replace('.', '/');
+    Enumeration<URL> resources = classLoader.getResources(path);
+    List<File> dirs = new ArrayList<File>();
+    while (resources.hasMoreElements()) {
+      URL resource = resources.nextElement();
+      dirs.add(new File(resource.getFile()));
+    }
+    ArrayList<Class> classes = new ArrayList<Class>();
+    for (File directory : dirs) {
+      classes.addAll(findClasses(directory, packageName));
+    }
+    return classes;
+  }
+
+/**
+ * Recursive method used to find all classes in a given directory and subdirs.
+ *
+ * @param directory The base directory
+ * @param packageName The package name for classes found inside the base directory
+ * @return The classes
+ * @throws ClassNotFoundException
+ */
+  private static List<Class> findClasses(File directory, String packageName) throws ClassNotFoundException {
+    List<Class> classes = new ArrayList<Class>();
+    if (!directory.exists()) {
+      return classes;
+    }
+    File[] files = directory.listFiles();
+    for (File file : files) {
+      if (file.isDirectory()) {
+        assert !file.getName().contains(".");
+        classes.addAll(findClasses(file, packageName + "." + file.getName()));
+      } else if (file.getName().endsWith(".class")) {
+        classes.add(Class.forName(packageName + '.' + file.getName().substring(0, file.getName().length() - 6)));
+      }
+    }
+    return classes;
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/junit/scheduling/ParallelComputerWithFixedPool.java
+++ b/spock-specs/src/test/groovy/org/spockframework/junit/scheduling/ParallelComputerWithFixedPool.java
@@ -1,0 +1,56 @@
+package org.spockframework.junit.scheduling;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.runner.Computer;
+import org.junit.runner.Runner;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
+import org.junit.runners.model.RunnerScheduler;
+
+public class ParallelComputerWithFixedPool extends Computer {
+  private final int threadCount;
+
+  public ParallelComputerWithFixedPool(int threadCount) {
+    this.threadCount = threadCount;
+  }
+
+  private Runner parallelize(Runner runner) {
+    if (runner instanceof ParentRunner) {
+      ((ParentRunner<?>) runner).setScheduler(new RunnerScheduler() {
+        private final ExecutorService fService = Executors.newFixedThreadPool(threadCount);
+
+        public void schedule(Runnable childStatement) {
+          fService.submit(childStatement);
+        }
+
+        public void finished() {
+          try {
+            fService.shutdown();
+            fService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+          } catch (InterruptedException e) {
+            e.printStackTrace(System.err);
+          }
+        }
+      });
+    }
+    return runner;
+  }
+
+  @Override
+  public Runner getSuite(RunnerBuilder builder, java.lang.Class<?>[] classes)
+    throws InitializationError {
+    Runner suite = super.getSuite(builder, classes);
+    return parallelize(suite);
+  }
+
+  @Override
+  protected Runner getRunner(RunnerBuilder builder, Class<?> testClass)
+    throws Throwable {
+    Runner runner = super.getRunner(builder, testClass);
+    return parallelize(runner);
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/junit/scheduling/SchedulingTest.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/junit/scheduling/SchedulingTest.groovy
@@ -1,0 +1,297 @@
+package org.spockframework.junit.scheduling
+
+import org.junit.experimental.ParallelComputer
+import org.junit.internal.requests.FilterRequest
+import org.junit.runner.Computer
+import org.junit.runner.Description
+import org.junit.runner.JUnitCore
+import org.junit.runner.notification.RunListener
+import org.junit.runners.AllTests
+import spock.lang.ConcurrentExecutionMode
+import spock.lang.Specification
+import spock.lang.Unroll
+import spock.util.EmbeddedSpecRunner
+
+class SchedulingTest extends Specification {
+
+  @Unroll
+  def "with sequential scheduler iterations and features should be executed sequentially [#clazz]"(Class clazz) {
+    def listener = Mock(RunListener)
+    def jUnitCore = new JUnitCore()
+    jUnitCore.addListener(listener)
+    when:
+    def runner = new EmbeddedSpecRunner()
+    runner.withNewContext {
+      jUnitCore.run(Computer.serial(), clazz);
+    }
+    then:
+    1 * listener.testRunStarted(_)
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test for x=1"))
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test for x=1"))
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test for x=2"))
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test for x=2"))
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test simple"))
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test simple"))
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test no unroll"))
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test no unroll"))
+    then:
+    1 * listener.testRunFinished(_)
+
+    where:
+    clazz << [SampleTest.class, SampleTestWithTimeout.class]
+  }
+
+  @Unroll
+  def "with parallel scheduler iterations and features should be executed concurrently [#clazz]"() {
+    def listener = Mock(RunListener)
+    def jUnitCore = new JUnitCore()
+    jUnitCore.addListener(listener)
+    when:
+    def runner = new EmbeddedSpecRunner()
+    runner.withNewContext {
+      jUnitCore.run(ParallelComputer.methods(), clazz);
+    }
+    then:
+    1 * listener.testRunStarted(_)
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test for x=1"))
+    1 * listener.testStarted(testDescription(clazz, "test for x=2"))
+    1 * listener.testStarted(testDescription(clazz, "test simple"))
+    1 * listener.testStarted(testDescription(clazz, "test no unroll"))
+    0 * listener.testFailure(_)
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test for x=1"))
+    1 * listener.testFinished(testDescription(clazz, "test for x=2"))
+    1 * listener.testFinished(testDescription(clazz, "test simple"))
+    1 * listener.testFinished(testDescription(clazz, "test no unroll"))
+    0 * listener.testFailure(_)
+    then:
+    1 * listener.testRunFinished(_)
+
+    where:
+    clazz << [SampleTest.class, SampleTestWithTimeout.class]
+  }
+
+  @Unroll
+  def "with parallel scheduler iterations and features should be executed sequentially if FORCE_SEQUENTIAL for all class"() {
+    def listener = Mock(RunListener)
+    def jUnitCore = new JUnitCore()
+    jUnitCore.addListener(listener)
+
+    def clazz = SampleTestWithSequentialOnClassLevel.class
+    when:
+    def runner = new EmbeddedSpecRunner()
+    runner.withNewContext {
+      jUnitCore.run(ParallelComputer.methods(), clazz);
+    }
+    then:
+    1 * listener.testRunStarted(_)
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test for x=1"))
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test for x=1"))
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test for x=2"))
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test for x=2"))
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test simple"))
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test simple"))
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test no unroll"))
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test no unroll"))
+    then:
+    1 * listener.testRunFinished(_)
+  }
+
+  @Unroll
+  def "with parallel scheduler iterations and features should be executed sequentially if FORCE_SEQUENTIAL for unrolled method"() {
+    def listener = Mock(RunListener)
+    def jUnitCore = new JUnitCore()
+    jUnitCore.addListener(listener)
+
+    def clazz = SampleTestWithSequentialOnMethodLevel.class
+    when:
+    def runner = new EmbeddedSpecRunner()
+    runner.withNewContext {
+      jUnitCore.run(ParallelComputer.methods(), clazz);
+    }
+    then:
+    1 * listener.testRunStarted(_)
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test for x=1"))
+    1 * listener.testStarted(testDescription(clazz, "test simple"))
+    1 * listener.testStarted(testDescription(clazz, "test no unroll"))
+    0 * listener.testFailure(_)
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test for x=1"))
+    0 * listener.testFailure(_)
+    then:
+    1 * listener.testStarted(testDescription(clazz, "test for x=2"))
+    0 * listener.testFailure(_)
+    then:
+    1 * listener.testFinished(testDescription(clazz, "test for x=2"))
+    1 * listener.testFinished(testDescription(clazz, "test simple"))
+    1 * listener.testFinished(testDescription(clazz, "test no unroll"))
+    0 * listener.testFailure(_)
+    then:
+    1 * listener.testRunFinished(_)
+  }
+
+  private static Description testDescription(Class clazz, String testName) {
+    Description.createTestDescription(clazz, testName)
+  }
+
+}
+
+class SampleTest extends Specification {
+
+  @Unroll
+  def "test for x=#x"() {
+    when:
+    sleep 1000
+    then:
+    x == x
+    where:
+    x | _
+    1 | _
+    2 | _
+  }
+
+  def "test simple"() {
+    def x = 1;
+    when:
+    sleep 1000
+    then:
+    x == x
+  }
+
+  def "test no unroll"() {
+    when:
+    sleep 1000
+    then:
+    x == x
+    where:
+    x | _
+    1 | _
+    2 | _
+  }
+}
+
+class SampleTestWithTimeout extends Specification {
+
+  def setup() {
+    sleep 1000
+  }
+
+  @Unroll
+  def "test for x=#x"() {
+    when:
+    sleep 1000
+    then:
+    x == x
+    where:
+    x | _
+    1 | _
+    2 | _
+  }
+
+  def "test simple"() {
+    def x = 1;
+    when:
+    sleep 1000
+    then:
+    x == x
+  }
+
+  def "test no unroll"() {
+    when:
+    sleep 1000
+    then:
+    x == x
+    where:
+    x | _
+    1 | _
+    2 | _
+  }
+}
+
+@ConcurrentExecutionMode(ConcurrentExecutionMode.Mode.FORCE_SEQUENTIAL)
+class SampleTestWithSequentialOnClassLevel extends Specification {
+
+  @Unroll
+  def "test for x=#x"() {
+    when:
+    sleep 1000
+    then:
+    x == x
+    where:
+    x | _
+    1 | _
+    2 | _
+  }
+
+  def "test simple"() {
+    def x = 1;
+    when:
+    sleep 1000
+    then:
+    x == x
+  }
+
+  def "test no unroll"() {
+    when:
+    sleep 1000
+    then:
+    x == x
+    where:
+    x | _
+    1 | _
+    2 | _
+  }
+}
+
+class SampleTestWithSequentialOnMethodLevel extends Specification {
+
+  @ConcurrentExecutionMode(ConcurrentExecutionMode.Mode.FORCE_SEQUENTIAL)
+  @Unroll
+  def "test for x=#x"() {
+    when:
+    sleep 300
+    then:
+    x == x
+    where:
+    x | _
+    1 | _
+    2 | _
+  }
+
+  def "test simple"() {
+    def x = 1;
+    when:
+    sleep 1000
+    then:
+    x == x
+  }
+
+  def "test no unroll"() {
+    when:
+    sleep 1000
+    then:
+    x == x
+    where:
+    x | _
+    1 | _
+    2 | _
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/ClosingOfDataProviders.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/ClosingOfDataProviders.groovy
@@ -16,10 +16,14 @@
 
 package org.spockframework.runtime
 
+import org.junit.runners.model.RunnerScheduler
 import spock.lang.Specification
 
 class ClosingOfDataProviders extends Specification {
-  def runner = new ParameterizedSpecRunner(null, null)
+  def runner = new ParameterizedSpecRunner(
+          null,
+          null,
+          new Scheduler(new SequentialRunnerScheduler(), false))
 
   def "close one provider which potentially throws an exception"() {
     MyCloseable provider = Mock()

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/EstimatedNumberOfIterations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/EstimatedNumberOfIterations.groovy
@@ -16,10 +16,14 @@
 
 package org.spockframework.runtime
 
+import org.junit.runners.model.RunnerScheduler
 import spock.lang.Specification
 
 class EstimatedNumberOfIterations extends Specification {
-  def runner = new ParameterizedSpecRunner(null, null)
+  def runner =  new ParameterizedSpecRunner(
+          null,
+          null,
+          new Scheduler(new SequentialRunnerScheduler(), false))
 
   def "w/o data provider"() {
     expect: "estimation is 1"

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/FixtureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/FixtureMethods.groovy
@@ -22,16 +22,20 @@ import org.spockframework.compiler.InvalidSpecCompileException
 import spock.lang.Issue
 
 class FixtureMethods extends EmbeddedSpecification {
-  static List log
+  public static ThreadLocal<List> log = new ThreadLocal<>()
 
   def setup() {
-    log = []
+    log.set([])
+  }
+
+  def cleanup() {
+    log.remove();
   }
 
   def "are run in correct order"() {
     when:
     runner.runSpecBody """
-def getLog() { org.spockframework.smoke.FixtureMethods.log }
+def getLog() { org.spockframework.smoke.FixtureMethods.log.get() }
 
 def setup() { log << "s" }
 def cleanup() { log << "c" }
@@ -42,7 +46,7 @@ def feature() { expect: true }
     """
 
     then:
-    log == ["ss", "s", "c", "cs"]
+    log.get() == ["ss", "s", "c", "cs"]
   }
 
   def "are run in correct order across class hierarchy"() {
@@ -50,7 +54,7 @@ def feature() { expect: true }
     runner.runWithImports """
 @Ignore
 class Base extends Specification {
-  def getLog() { org.spockframework.smoke.FixtureMethods.log }
+  def getLog() { org.spockframework.smoke.FixtureMethods.log.get() }
 
   def setup() { log << "s1" }
   def cleanup() { log << "c1" }
@@ -59,7 +63,7 @@ class Base extends Specification {
 }
 
 class Derived extends Base {
-  def getLog() { org.spockframework.smoke.FixtureMethods.log }
+  def getLog() { org.spockframework.smoke.FixtureMethods.log.get() }
 
   def setup() { log << "s2" }
   def cleanup() { log << "c2" }
@@ -71,7 +75,7 @@ class Derived extends Base {
     """
 
     then:
-    log == ["ss1", "ss2", "s1", "s2", "c2", "c1", "cs2", "cs1"]
+    log.get() == ["ss1", "ss2", "s1", "s2", "c2", "c1", "cs2", "cs1"]
   }
 
   @Issue("http://issues.spockframework.org/detail?id=139")
@@ -111,6 +115,7 @@ def cleanupSpec() {
 
     when:
     runner.runSpecBody("""
+def getLog() { org.spockframework.smoke.FixtureMethods.log.get() }
 def setup() { throw new RuntimeException() }
 def feature() { expect: true }
 def cleanup() { log << "cleanup" }
@@ -118,7 +123,7 @@ def cleanup() { log << "cleanup" }
 
     then:
     thrown(RuntimeException)
-    log == ["cleanup"]
+    log.get() == ["cleanup"]
   }
 
   def "cleanup() is not run when field initializer fails"() {
@@ -135,7 +140,7 @@ def cleanup() { log << "cleanup" }
 
     then:
     thrown(RuntimeException)
-    log.empty
+    log.get().empty
   }
 
   static class BlowUp {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/FixtureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/FixtureMethods.groovy
@@ -126,6 +126,22 @@ def cleanup() { log << "cleanup" }
     log.get() == ["cleanup"]
   }
 
+  def "cleanupSpec() is run when setupSpec() fails"() {
+    runner.addClassMemberImport(FixtureMethods)
+
+    when:
+    runner.runSpecBody("""
+def getLog() { org.spockframework.smoke.FixtureMethods.log.get() }
+def setupSpec() { throw new RuntimeException() }
+def feature() { expect: true }
+def cleanupSpec() { log << "cleanupSpec" }
+    """)
+
+    then:
+    thrown(RuntimeException)
+    log.get() == ["cleanupSpec"]
+  }
+
   def "cleanup() is not run when field initializer fails"() {
     runner.addClassImport(BlowUp)
     runner.addClassMemberImport(FixtureMethods)

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ConditionallyIgnoreFeature.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ConditionallyIgnoreFeature.groovy
@@ -18,8 +18,10 @@ package org.spockframework.smoke.extension
 
 import spock.lang.*
 
+import java.util.concurrent.CopyOnWriteArrayList
+
 class ConditionallyIgnoreFeature extends Specification {
-  @Shared log = []
+  @Shared List log = new CopyOnWriteArrayList()
 
   @IgnoreIf({ 1 < 2 })
   def "should be ignored"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitFixtureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitFixtureMethods.groovy
@@ -20,13 +20,17 @@ import org.spockframework.EmbeddedSpecification
 import spock.lang.*
 
 class JUnitFixtureMethods extends EmbeddedSpecification {
-  static invocations = []
-  static RECORD_INVOCATION_METHOD = "static record(methodName) { JUnitFixtureMethods.invocations << methodName }"
+  public static ThreadLocal<List> invocations = new ThreadLocal<>()
+  static RECORD_INVOCATION_METHOD = "static record(methodName) { JUnitFixtureMethods.invocations.get() << methodName }"
 
   def setup() {
-    invocations.clear()
+    invocations.set(new ArrayList())
   }
-  
+
+  void cleanup() {
+    invocations.remove()
+  }
+
   def "lifecycle"() {
     when:
     runSpecBody """
@@ -34,20 +38,20 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
       def setupSpec() { record("setupSpec") }
       ${before()}
       def setup() { record("setup") }
-      
+
       def feature1() { expect: true }
       def feature2() { expect: true }
-      
+
       def cleanup() { record("cleanup") }
       ${after()}
       def cleanupSpec() { record("cleanupSpec") }
       ${afterClass()}
     """
-    
+
     then:
-    invocations == [
-        "beforeClass", "setupSpec", 
-        "before", "setup" , "cleanup", "after", 
+    invocations.get() == [
+        "beforeClass", "setupSpec",
+        "before", "setup" , "cleanup", "after",
         "before", "setup" , "cleanup", "after",
         "cleanupSpec", "afterClass"
     ]
@@ -59,14 +63,14 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
     runSpecBody """
       ${this."$fixtureType"("m1")}
       ${this."$fixtureType"("m2")}
-      
+
       def feature1() { expect: true }
     """
-    
+
     then:
-    invocations.contains("m1")
-    invocations.contains("m2")
-    
+    invocations.get().contains("m1")
+    invocations.get().contains("m2")
+
     where:
     fixtureType << ["beforeClass", "before", "after", "afterClass"]
   }
@@ -77,22 +81,22 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
     run """
       abstract class Parent extends Specification {
         $RECORD_INVOCATION_METHOD
-        
+
         ${this."$fixtureType"("parent")}
       }
-      
+
       class Child extends Parent {
         ${this."$fixtureType"("child")}
-        
+
         def feature1() { expect: true }
       }
     """
-    
+
     then:
-    invocations == order
-    
+    invocations.get() == order
+
     where:
-    fixtureType   | order 
+    fixtureType   | order
     "beforeClass" | ["parent", "child"]
     "before"      | ["parent", "child"]
     "after"       | ["child", "parent"]
@@ -117,7 +121,7 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
     """
 
     then:
-    invocations == order
+    invocations.get() == order
 
     where:
     fixtureType   | order
@@ -136,9 +140,9 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
       def feature() { when: mode = "after"; then: true }
       @BeforeClass @AfterClass static void sf() { record mode + "Class" }
     """
-    
+
     then:
-    invocations == ["beforeClass", "before", "after", "afterClass"]
+    invocations.get() == ["beforeClass", "before", "after", "afterClass"]
   }
 
   def "exceptions thrown by fixture methods are handled correctly"() {
@@ -167,7 +171,7 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
     "afterClass"  | "@AfterClass static"  | true        | 1
     "afterClass"  | "@AfterClass static"  | false       | 0
   }
-  
+
   protected beforeClass(name = "beforeClass") { "@BeforeClass static void $name() { record('$name') }" }
   protected before(name = "before") { "@Before void $name() { record('$name') }" }
   protected after(name = "after") { "@After void $name() { record('$name') } "}
@@ -177,17 +181,17 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
   protected before2(log) { "@Before void before() { record('$log') }" }
   protected after2(log) { "@After void after() { record('$log') } "}
   protected afterClass2(log) { "@AfterClass static void afterClass() { record('$log') } "}
-  
+
   protected addImports() {
     runner.addPackageImport(getClass().package)
     runner.addPackageImport(org.junit.Before.package)
   }
-  
+
   protected runSpecBody(String specBody) {
     addImports()
     runner.runSpecBody """
       $RECORD_INVOCATION_METHOD
-      
+
       $specBody
     """
   }
@@ -196,5 +200,5 @@ class JUnitFixtureMethods extends EmbeddedSpecification {
     addImports()
     runner.runWithImports(source)
   }
-  
+
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/junit/RulesAndInheritance.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/junit/RulesAndInheritance.groovy
@@ -19,6 +19,7 @@ import org.junit.rules.TestName
 
 import spock.lang.*
 
+@ConcurrentExecutionMode(ConcurrentExecutionMode.Mode.FORCE_SEQUENTIAL) // it should be executed in order to distinguish between base and derived feature
 @Issue("http://issues.spockframework.org/detail?id=98")
 class RulesAndInheritance extends RulesAndInheritanceBase {
   @Rule

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/junit/UseJUnitTestNameRule.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/junit/UseJUnitTestNameRule.groovy
@@ -10,7 +10,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */  
+ */
 
 package org.spockframework.smoke.junit
 
@@ -18,6 +18,7 @@ import spock.lang.*
 import org.junit.Rule
 import org.junit.rules.TestName
 
+@ConcurrentExecutionMode(ConcurrentExecutionMode.Mode.FORCE_SEQUENTIAL) // TestName rule does not support parallel execution
 @Issue("http://issues.spockframework.org/detail?id=108")
 class UseJUnitTestNameRule extends Specification {
   @Rule
@@ -31,7 +32,7 @@ class UseJUnitTestNameRule extends Specification {
   def "data-driven, not unrolled"() {
     expect:
     name.methodName == "data-driven, not unrolled"
-    
+
     where:
     i << (1..3)
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovySpiesThatAreGlobal.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovySpiesThatAreGlobal.groovy
@@ -14,6 +14,8 @@
 
 package org.spockframework.smoke.mock
 
+import spock.lang.ConcurrentExecutionMode
+
 import java.lang.reflect.Modifier
 
 import spock.lang.Specification

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/UnrolledFeatureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/UnrolledFeatureMethods.groovy
@@ -327,6 +327,32 @@ def "an actor (named #actor.getName()) age #actor.getAge()"() {
 
   }
 
+  def "duplicated generated names should become different"() {
+    def List<String> descriptions = new ArrayList<>()
+    when:
+    runner.runSpecBody("""
+@Unroll
+def "test #x"(int x) {
+  expect: true
+
+  where:
+    x | _
+    1 | _
+    1 | _
+    1 | _
+    2 | _
+    2 | _
+}
+    """)
+
+    then:
+     _ * listener.testStarted { descriptions.add(it.methodName) }
+     descriptions.size() == new HashSet(descriptions).size() // no duplicates
+
+  }
+
+
+
   static class Actor {
     Map details = [name: "fred", age: 30]
   }

--- a/spock-specs/src/test2.4/groovy/org/spockframework/smoke/traits/BasicTraitUsage.groovy
+++ b/spock-specs/src/test2.4/groovy/org/spockframework/smoke/traits/BasicTraitUsage.groovy
@@ -18,6 +18,7 @@ package org.spockframework.smoke.traits
 
 import spock.lang.*
 
+@ConcurrentExecutionMode(ConcurrentExecutionMode.Mode.FORCE_SEQUENTIAL)
 class BasicTraitUsage extends Specification implements MyTrait {
   boolean setupEvaluated
   @Shared


### PR DESCRIPTION
This pull-request based on #558.

Main idea is to make failure handling more explicit and keep abort logic and execution logiс together.

Instead of maintaining runStatus field, InvokeException is thrown and handled on top of current scope. And now it is easy to understand that failures in iterations does not affect each other and do not abort feature execution.

This PR is preparation for adding retry logic: instead immediately failure registration, failures can be collected and registered only when all attempts will fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/561)
<!-- Reviewable:end -->
