### PR TITLE
Allow additional parameters in feature methods

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
@@ -180,6 +180,7 @@ public class SpecInfoBuilder {
     provider.setParent(feature);
     provider.setLine(metadata.line());
     provider.setDataVariables(Arrays.asList(metadata.dataVariables()));
+    provider.setParameters(Arrays.asList(metadata.parameters()));
     provider.setDataProviderMethod(method);
     return provider;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollNameProvider.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollNameProvider.java
@@ -16,6 +16,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,7 +45,7 @@ public class UnrollNameProvider implements NameProvider<IterationInfo> {
     return nameFor(iterationInfo.getDataValues());
   }
 
-  String nameFor(Object... dataValues) {
+  String nameFor(Map<String, Object> dataValues) {
     StringBuffer result = new StringBuffer();
     expressionMatcher.reset();
 
@@ -59,7 +60,7 @@ public class UnrollNameProvider implements NameProvider<IterationInfo> {
     return result.toString();
   }
 
-  private String evaluateExpression(String expr, Object[] dataValues) {
+  private String evaluateExpression(String expr, Map<String, Object> dataValues) {
     String[] exprParts = expr.split("\\.");
     String firstPart = exprParts[0];
     Object result;
@@ -69,9 +70,11 @@ public class UnrollNameProvider implements NameProvider<IterationInfo> {
     } else if (firstPart.equals("iterationCount")) {
       result = String.valueOf(iterationCount);
     } else {
-      int index = feature.getDataVariables().indexOf(firstPart);
-      if (index < 0) return "#Error:" + expr;
-      result = dataValues[index];
+      if (dataValues.containsKey(firstPart)) {
+        result = dataValues.get(firstPart);
+      } else {
+        return "#Error:" + expr;
+      }
     }
 
     try {

--- a/spock-core/src/main/java/org/spockframework/runtime/model/DataProviderInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/DataProviderInfo.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class DataProviderInfo extends NodeInfo<FeatureInfo, AnnotatedElement> {
   private List<String> dataVariables;
   private MethodInfo dataProviderMethod;
+  private List<String> parameters;
 
   @Override
   public AnnotatedElement getReflection() {
@@ -31,5 +32,13 @@ public class DataProviderInfo extends NodeInfo<FeatureInfo, AnnotatedElement> {
 
   public void setDataProviderMethod(MethodInfo dataProviderMethod) {
     this.dataProviderMethod = dataProviderMethod;
+  }
+
+  public List<String> getParameters() {
+    return parameters;
+  }
+
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/DataProviderMetadata.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/DataProviderMetadata.java
@@ -10,7 +10,9 @@ import java.lang.annotation.*;
 public @interface DataProviderMetadata {
   String LINE = "line";
   String DATA_VARIABLES = "dataVariables";
-  
+  String PARAMETERS = "parameters";
+
   int line();
   String[] dataVariables();
+  String[] parameters();
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -57,7 +57,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   public void addParameterName(String parameterName) {
     parameterNames.add(parameterName);
   }
-  
+
   public List<String> getDataVariables() {
     return parameterNames; // currently the same
   }
@@ -109,7 +109,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   public boolean isReportIterations() {
     return reportIterations;
   }
-  
+
   public void setReportIterations(boolean flag) {
     reportIterations = flag;
   }
@@ -118,7 +118,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   public NameProvider<IterationInfo> getIterationNameProvider() {
     return iterationNameProvider;
   }
-  
+
   public void setIterationNameProvider(NameProvider<IterationInfo> provider) {
     iterationNameProvider = provider;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/IterationInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/IterationInfo.java
@@ -16,19 +16,21 @@ package org.spockframework.runtime.model;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Runtime information about an iteration of a feature method.
  */
 public class IterationInfo extends NodeInfo<FeatureInfo, AnnotatedElement> {
-  private final Object[] dataValues;
+  private final Map<String, Object> dataValues;
   private final int estimatedNumIterations;
   private final List<Runnable> cleanups = new ArrayList<Runnable>();
 
-  public IterationInfo(FeatureInfo feature, Object[] dataValues, int estimatedNumIterations) {
+  public IterationInfo(FeatureInfo feature, Map<String, Object> dataValues, int estimatedNumIterations) {
     setParent(feature);
-    this.dataValues = dataValues;
+    this.dataValues = new HashMap<String, Object>(dataValues);
     this.estimatedNumIterations = estimatedNumIterations;
   }
 
@@ -57,11 +59,11 @@ public class IterationInfo extends NodeInfo<FeatureInfo, AnnotatedElement> {
    * Return this iteration's data values for the ongoing execution of the
    * owning feature method. The names of the data values (in the same order)
    * are available through {@link FeatureInfo#getDataVariables}.
-   * 
+   *
    * @return this iteration's data values for the ongoing execution of the
    * owning feature method
    */
-  public Object[] getDataValues() {
+  public Map<String, Object> getDataValues() {
     return dataValues;
   }
 

--- a/spock-specs/src/test/groovy/org/spockframework/VerifyExecutionExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/VerifyExecutionExtension.groovy
@@ -62,15 +62,15 @@ class VerifyExecutionExtension extends AbstractAnnotationDrivenExtension<VerifyE
       }
     })
 
-    verifyMethod.featureMethod.addInterceptor(
-        new IMethodInterceptor() {
-          void intercept(IMethodInvocation invocation) {
-            if (invocation.method.reflection.parameterTypes.size() == 1) {
-              invocation.arguments = [executionLog]
-            }
-            invocation.proceed()
-          }
+    verifyMethod.addIterationInterceptor(new IMethodInterceptor() {
+      @Override
+      void intercept(IMethodInvocation invocation) throws Throwable {
+        def variables = verifyMethod.getDataVariables()
+        if (variables.size() == 1){
+          invocation.getIteration().getDataValues().put(variables.get(0), executionLog);
         }
-    )
+        invocation.proceed();
+      }
+    })
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/AsyncRunListenerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/AsyncRunListenerSpec.groovy
@@ -12,7 +12,7 @@ class AsyncRunListenerSpec extends Specification {
   def "replays events in correct order in a separate thread"() {
     def specInfo = new SpecInfoBuilder(getClass()).build()
     def featureInfo = specInfo.features[0]
-    def iterationInfo = new IterationInfo(featureInfo, [] as Object[], 1)
+    def iterationInfo = new IterationInfo(featureInfo, new HashMap<String, Object>(), 1)
     def errorInfo = new ErrorInfo(featureInfo.featureMethod, new Exception())
 
     when:

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/SafeIterationNameProviderSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/SafeIterationNameProviderSpec.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class SafeIterationNameProviderSpec extends Specification {
   def feature = new FeatureInfo()
-  def iteration = new IterationInfo(feature, [] as Object[], 3)
+  def iteration = new IterationInfo(feature, new HashMap<>(), 3)
   def other = Mock(NameProvider)
   def provider = new SafeIterationNameProvider(other)
 
@@ -35,32 +35,32 @@ class SafeIterationNameProviderSpec extends Specification {
   def "delegates to other provider"() {
     when:
     provider.getName(iteration)
-    
+
     then:
     1 * other.getName(iteration)
   }
-  
+
   def "returns default if there is no other provider"() {
-    provider = new SafeIterationNameProvider(null)  
-    
+    provider = new SafeIterationNameProvider(null)
+
     expect:
     provider.getName(iteration) == "feature"
   }
-  
+
   def "returns default if other provider returns nothing"() {
     other.getName(iteration) >> null
 
     expect:
     provider.getName(iteration) == "feature"
   }
-  
+
   def "returns default if other provider blows up"() {
     other.getName(iteration) >> { throw new RuntimeException() }
 
     expect:
     provider.getName(iteration) == "feature"
   }
-  
+
   def "iteration name defaults to feature name when iterations aren't reported"() {
     feature.reportIterations = false
 

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/extension/builtin/UnrollNameProviderSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/extension/builtin/UnrollNameProviderSpec.groovy
@@ -26,7 +26,7 @@ class UnrollNameProviderSpec extends Specification {
     def nameGenerator = new UnrollNameProvider(feature, "foo #dataVar bar")
 
     expect:
-    nameGenerator.nameFor(value) == name
+    nameGenerator.nameFor(Collections.singletonMap("dataVar", value)) == name
 
     where:
     value                   | name
@@ -40,7 +40,7 @@ class UnrollNameProviderSpec extends Specification {
     def nameGenerator = new UnrollNameProvider(feature, "foo #dataVar bar")
 
     expect:
-    nameGenerator.nameFor(value) == name
+    nameGenerator.nameFor(Collections.singletonMap("dataVar", value)) == name
 
     where:
     value                   | name

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/AdditionalParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/AdditionalParameters.groovy
@@ -1,0 +1,133 @@
+package org.spockframework.smoke.parameterization
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.SpockExecutionException
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.ExtensionAnnotation
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FeatureInfo
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+
+class AdditionalParameters extends EmbeddedSpecification {
+  void setup() {
+    runner.addClassImport(ProvideValues.class)
+    runner.addClassImport(ProvideNullValues.class)
+  }
+
+  def "should be possible to add missing parameters in runtime [no parametrization case]"() {
+    when:
+        runner.runSpecBody("""
+          @ProvideValues(["a", "b"])
+          def test(String a, String b){
+            expect:
+              a == "a"
+              b == "b"
+          }
+
+""")
+    then:
+        noExceptionThrown()
+  }
+
+  def "should be possible to add missing parameters in runtime [parametrization case]"() {
+    when:
+        runner.runSpecBody("""
+          @ProvideValues(["a", "c"])
+          def test(String a, String b, String c){
+            expect:
+              a == "a"
+              b == "b"
+              c == "c"
+            where:
+              b << "b"
+          }
+
+""")
+    then:
+        noExceptionThrown()
+  }
+
+  def "should report error if not all parameters was set"() {
+    when:
+        runner.runSpecBody("""
+          @ProvideValues(["b"])
+          def test(String a, String b, String c){
+            expect:
+              true
+            where:
+              a << "a"
+          }
+
+""")
+    then:
+        thrown(SpockExecutionException.class)
+  }
+
+  def "should be possible to set parameters to null"() {
+    when:
+        runner.runSpecBody("""
+          @ProvideNullValues(["b"])
+          def test(String a, String b){
+            expect:
+              a == null
+              b == null
+            where:
+              a << [null]
+          }
+
+""")
+    then:
+        noExceptionThrown()
+  }
+
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@ExtensionAnnotation(ProvideValuesExtension.class)
+public @interface ProvideValues {
+  String[] value();
+}
+
+public class ProvideValuesExtension extends AbstractAnnotationDrivenExtension<ProvideValues> {
+  @Override
+  void visitFeatureAnnotation(ProvideValues annotation, FeatureInfo feature) {
+    feature.addIterationInterceptor(new IMethodInterceptor() {
+      @Override
+      void intercept(IMethodInvocation invocation) throws Throwable {
+        for (String name : annotation.value()) {
+          invocation.getIteration().getDataValues().put(name, name);
+        }
+        invocation.proceed()
+      }
+    })
+  }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@ExtensionAnnotation(ProvideNullValuesExtension.class)
+public @interface ProvideNullValues {
+  String[] value();
+}
+
+public class ProvideNullValuesExtension extends AbstractAnnotationDrivenExtension<ProvideNullValues> {
+  @Override
+  void visitFeatureAnnotation(ProvideNullValues annotation, FeatureInfo feature) {
+    feature.addIterationInterceptor(new IMethodInterceptor() {
+      @Override
+      void intercept(IMethodInvocation invocation) throws Throwable {
+        for (String name : annotation.value()) {
+          invocation.getIteration().getDataValues().put(name, null);
+        }
+        invocation.proceed()
+      }
+    })
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -68,7 +68,7 @@ class MethodParameters extends EmbeddedSpecification {
     x << [1, 2]
     y << [1, 2]
   }
-  
+
   def "fewer parameters than data variables"() {
     when:
     compiler.compileSpecBody """
@@ -79,40 +79,6 @@ def foo(x) {
   where:
   x << [1, 2]
   y << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-  }
-
-
-  def "more parameters than data variables"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x, y, z) {
-  expect:
-  x == y
-
-  where:
-  x << [1, 2]
-  y << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-  }
-
-  def "parameter that is not a data variable"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x, a) {
-  expect:
-  x == x
-
-  where:
-  x << [1, 2]
 }
     """
 


### PR DESCRIPTION
With this PR it will be possible to declare additional parameters (that is not specified in where block) in feature methods. Values can be set via interceptors. 

Main usage scenario of this PR is to allow some kind of dependency injection: some parameters are set from `where` block and others set by interceptor (for example Spring beans can be injected or other contexts)

Additionally this PR allows to omit some of data variables from parameters list (it is usefull with #526 - intermediate parameters can be dropped)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/566)
<!-- Reviewable:end -->
