### PR TITLE
Use the type of the field instead of using Object as the return type when generating getters for shared fields.

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -103,7 +103,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     BlockStatement getterBlock = new BlockStatement();
     getter = new MethodNode(getterName, determineVisibilityForSharedFieldAccessor(field) | Opcodes.ACC_SYNTHETIC,
-        ClassHelper.DYNAMIC_TYPE, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, getterBlock);
+        field.getAst().getType(), Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, getterBlock);
 
     getterBlock.addStatement(
         new ReturnStatement(

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/SharedFields.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/SharedFields.groovy
@@ -61,4 +61,27 @@ class Foo extends Specification {
     then:
     noExceptionThrown()
   }
+
+  @Issue("https://github.com/spockframework/spock/issues/570")
+  def 'getters and setters generated for shared fields use the declared type of the field'() {
+    when:
+    runner.runWithImports '''
+class ImplementsInterface extends Specification implements HasValueProperty {
+  @Shared String value = "1"
+
+  def test() {
+    expect:
+    value == "1"
+  }
+}
+
+interface HasValueProperty {
+    String getValue()
+    void setValue(String value)
+}
+    '''
+
+    then:
+    noExceptionThrown()
+  }
 }


### PR DESCRIPTION
This pull request provides a fix for #570.

Please let me know if there is anything that this pull request is missing to get accepted, I'm happy to rework it to match your expectations.