### PR TITLE
Added support for Spring-Boot 1.4 @SpringBootTest annotation

### DIFF
--- a/spock-spring/boot-test/boot-test.gradle
+++ b/spock-spring/boot-test/boot-test.gradle
@@ -1,15 +1,15 @@
-def springVersion = "4.1.0.RELEASE"
-def bootVersion = "1.1.6.RELEASE"
+def bootVersion = "1.4.0.M2"
 
 dependencies {
-	compile "org.springframework:spring-core:$springVersion"
-	compile "org.springframework.boot:spring-boot:$bootVersion"
-	compile "org.springframework.boot:spring-boot-autoconfigure:$bootVersion"
+	compile "org.springframework.boot:spring-boot-starter-test:$bootVersion"
 
   testCompile project(":spock-core")
-  testCompile "org.springframework:spring-context:$springVersion"
-  testCompile "org.springframework:spring-test:$springVersion"
-
   testRuntime project(":spock-spring")
+}
+
+repositories {
+  maven {
+    url 'https://repo.spring.io/libs-milestone'
+  }
 }
 

--- a/spock-spring/boot-test/src/main/java/org/spockframework/boot/SimpleBootApp.java
+++ b/spock-spring/boot-test/src/main/java/org/spockframework/boot/SimpleBootApp.java
@@ -20,14 +20,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 import org.spockframework.boot.service.HelloWorldService;
 
-@Configuration
-@EnableAutoConfiguration
-@ComponentScan
+@SpringBootApplication
 public class SimpleBootApp implements CommandLineRunner {
 	@Autowired
 	private HelloWorldService helloWorldService;

--- a/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/SimpleBootAppTestAnnotationIntegrationSpec.groovy
+++ b/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/SimpleBootAppTestAnnotationIntegrationSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.boot
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import spock.lang.Specification
+
+/**
+ * Integration test similar to {@link SimpleBootAppIntegrationSpec} but using the {@link SpringBootTest} annotation.
+ *
+ * @author Kevin Wittek
+ */
+@SpringBootTest
+class SimpleBootAppTestAnnotationIntegrationSpec extends Specification {
+  @Autowired
+  ApplicationContext context
+
+  def "test context loads"() {
+    expect:
+    context != null
+    context.containsBean("helloWorldService")
+    context.containsBean("simpleBootApp")
+  }
+}

--- a/spock-spring/src/main/java/org/spockframework/spring/SpringExtension.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringExtension.java
@@ -37,6 +37,10 @@ public class SpringExtension extends AbstractGlobalExtension {
   private static final Class<? extends Annotation> contextHierarchyClass =
       (Class) ReflectionUtil.loadClassIfAvailable("org.springframework.test.context.ContextHierarchy");
 
+  @SuppressWarnings("unchecked")
+  private static final Class<? extends Annotation> springBootTestClass =
+    (Class) ReflectionUtil.loadClassIfAvailable("org.springframework.boot.test.context.SpringBootTest");
+
   // since Spring 4.0
   private static final Method findAnnotationDescriptorForTypesMethod;
 
@@ -57,7 +61,7 @@ public class SpringExtension extends AbstractGlobalExtension {
 
     SpringTestContextManager manager = new SpringTestContextManager(spec.getReflection());
     final SpringInterceptor interceptor = new SpringInterceptor(manager);
-    
+
     spec.addListener(new AbstractRunListener() {
       public void error(ErrorInfo error) {
         interceptor.error(error);
@@ -73,6 +77,7 @@ public class SpringExtension extends AbstractGlobalExtension {
   private boolean isSpringSpec(SpecInfo spec) {
     if (spec.isAnnotationPresent(ContextConfiguration.class)) return true;
     if (contextHierarchyClass != null && spec.isAnnotationPresent(contextHierarchyClass)) return true;
+    if (springBootTestClass != null && spec.isAnnotationPresent(springBootTestClass)) return true;
     return findAnnotationDescriptorForTypesMethod != null
         && ReflectionUtil.invokeMethod(
             null, findAnnotationDescriptorForTypesMethod, spec.getReflection(),


### PR DESCRIPTION
See #581 for the issue.

Spring-Boot 1.4 will introduce a new annotation for test classes called @SpringBootTest to avoid some of the integration test boilerplate annotations.

Currently the spock-spring plugin does not recognize this annotation in order to identify this class as a Spring test class and instead relies on other annotations like @ContextHierarchy or @ContextConfiguration which do not need to be present if @SpringBootTest used.

I've introduced a check for the `@SpringBootTest` in the `SpringExtension` class similar to the other checks.

I've also added a new test for this annotation and cleaned up the `boot-test.gradle` file to include only the needed dependencies.