### PR TITLE
fix MethodRule execution

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/MethodRuleInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/MethodRuleInterceptor.java
@@ -41,7 +41,7 @@ public class MethodRuleInterceptor extends AbstractRuleInterceptor {
   }
 
   private FrameworkMethod createFrameworkMethod(final IMethodInvocation invocation) {
-    return new FrameworkMethod(invocation.getMethod().getReflection()) {
+    return new FrameworkMethod(invocation.getIteration().getParent().getFeatureMethod().getReflection()) {
       @Override
       public String getName() {
         return invocation.getIteration().getDescription().getMethodName();

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RuleExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RuleExtension.java
@@ -52,7 +52,7 @@ public class RuleExtension extends AbstractRuleExtension {
     static void install(SpecInfo spec, List<FieldInfo> ruleFields) {
       MethodRuleInterceptor interceptor = new MethodRuleInterceptor(ruleFields);
       for (FeatureInfo feature : spec.getAllFeatures()) {
-        feature.getFeatureMethod().addInterceptor(interceptor);
+        feature.addIterationInterceptor(interceptor);
       }
     }
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitMethodRuleOrder.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitMethodRuleOrder.groovy
@@ -22,15 +22,24 @@ import spock.lang.Specification
 
 class JUnitMethodRuleOrder extends Specification {
   List log = []
-  @Rule LoggingRule rule1 = new LoggingRule(log: log, msg: "rule1")
-  @Rule LoggingRule rule2 = new LoggingRule(log: log, msg: "rule2")
+  @Rule LoggingRule rule1 = new LoggingRule(log: log, msg: "testRule1")
+  @Rule LoggingRule rule2 = new LoggingRule(log: log, msg: "testRule2")
+
+  def setup() {
+    // expect: setup is called during base.evaluate()
+    assert log == ["testRule2: before", "testRule1: before"]
+  }
 
   def "rules declared later wrap around rules declared earlier"() {
     expect:
-    log == ["rule2", "rule1"]
+    log == ["testRule2: before", "testRule1: before"]
   }
 
-  @SuppressWarnings("deprecation")
+  def cleanup() {
+    // expect: cleanup is called before base.evaluate() leaves
+    assert log == ["testRule2: before", "testRule1: before"]
+  }
+
   static class LoggingRule implements MethodRule {
     List log
     String msg
@@ -39,8 +48,9 @@ class JUnitMethodRuleOrder extends Specification {
       new Statement() {
         @Override
         void evaluate() {
-          log << msg
+          log << "$msg: before"
           base.evaluate()
+          log << "$msg: after"
         }
       }
     }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitTestRuleOrder.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitTestRuleOrder.groovy
@@ -22,12 +22,22 @@ import spock.lang.Specification
 
 class JUnitTestRuleOrder extends Specification {
   List log = []
-  @Rule LoggingRule rule1 = new LoggingRule(log: log, msg: "rule1")
-  @Rule LoggingRule rule2 = new LoggingRule(log: log, msg: "rule2")
+  @Rule LoggingRule rule1 = new LoggingRule(log: log, msg: "testRule1")
+  @Rule LoggingRule rule2 = new LoggingRule(log: log, msg: "testRule2")
+
+  def setup() {
+    // expect: setup is called during base.evaluate()
+    assert log == ["testRule2: before", "testRule1: before"]
+  }
 
   def "rules declared later wrap around rules declared earlier"() {
     expect:
-    log == ["rule2", "rule1"]
+    log == ["testRule2: before", "testRule1: before"]
+  }
+
+  def cleanup() {
+    // expect: cleanup is called before base.evaluate() leaves
+    assert log == ["testRule2: before", "testRule1: before"]
   }
 
   static class LoggingRule implements TestRule {
@@ -38,8 +48,9 @@ class JUnitTestRuleOrder extends Specification {
       new Statement() {
         @Override
         void evaluate() {
-          log << msg
+          log << "$msg: before"
           base.evaluate()
+          log << "$msg: after"
         }
       }
     }


### PR DESCRIPTION
MethodRules did not wrap setup() and cleanup(). Only the feature method
was wrapped. 

Since I don't know the Spock codebase well enough, I was only able to create a testcase to show the bug. After that, I debugged the code and tried to watch for the difference between TestRule and MethodRule. 

I found the RuleExtension with it's difference. Changing the MethodRule extension to do the same as the TestRule extension resulted in a NullPointerException, since in that case `invocation.getMethod().getReflection()` is null.

Again, using the debugger I found `invocation.getIteration().getParent().getFeatureMethod().getReflection()`. But I am not sure, if this is a valid fix. 

Fixes #584