### PR TITLE
Automatic releasing from Travis to Maven Central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - $HOME/.gradle
 
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk8
 
@@ -17,6 +16,7 @@ env:
     - VARIANT=2.3
     - VARIANT=2.4
   global:
+    - SONATYPE_OSS_USERNAME=pniederw
     # SIGNING_PASSWORD
     - secure: "GBvPdDAaMfr0iAYHzVxhMIBVHFanEPY+69CbEFijbZjhv8h0FPvuLos2p1K5/hbmNkQ1Hd2+CHsm3ErvXQHXtpXn0HmKvzSP7pnPk83iRNVGPieasvfnKiSohZeEplkAK6kbK8sZbjJRUFqUZtwyPtWfs244rCOo++D3KtfggzQ="
     # SONATYPE_OSS_PASSWORD
@@ -33,14 +33,12 @@ matrix:
     # See travisCiBuild task for mandatory combinations
     - jdk: oraclejdk8
       env: VARIANT=2.3
-    - jdk: openjdk7
-      env: VARIANT=2.0
-    - jdk: openjdk7
-      env: VARIANT=2.4
+
+before_install: "export TRAVIS_COMMIT_MSG=$(git log --format=%B -n 1 $TRAVIS_COMMIT)"
 
 install: true
 
-script: ./gradlew travisCiBuild -Dvariant=$VARIANT
+script: ./gradlew prepareForTravisCiBuild -Dvariant=$VARIANT -i && ./gradlew travisCiBuild -Dvariant=$VARIANT
 
 notifications:
   slack:

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,15 @@ buildscript {
 
   dependencies {
     classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.5.2"
+    classpath 'pl.allegro.tech.build:axion-release-plugin:1.3.3'
+    classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
   }
 }
 
 apply plugin: "base"
 apply plugin: "org.asciidoctor.convert"
+apply plugin: 'pl.allegro.tech.build.axion-release'
+apply plugin: 'io.codearte.nexus-staging'
 
 description = "Spock Framework"
 
@@ -32,12 +36,10 @@ ext {
   } else {
     throw new InvalidUserDataException("Unknown variant: $variant. Choose one of: $variants")
   }
-  javaVersions = [1.6, 1.7, 1.8]
+  javaVersions = [1.7, 1.8]
   javaVersion = System.getProperty("java.specification.version") as BigDecimal
-  baseVersion = "1.1"
-  snapshotVersion = true
-  fullVersion = "$baseVersion-groovy-$variant" + (snapshotVersion ? "-SNAPSHOT" : "")
-  variantLessVersion = baseVersion + (snapshotVersion ? "-SNAPSHOT" : "")
+  targetJavaVersion = "1.6"
+  releaseTriggeringCommand = "[#DO_RELEASE]"
   libs = [
     jetbrainsAnnotations: "org.jetbrains:annotations:13.0",
     ant: "org.apache.ant:ant:1.9.4",
@@ -49,6 +51,30 @@ ext {
     log4j: "log4j:log4j:1.2.17",
     objenesis: "org.objenesis:objenesis:2.1"
   ]
+}
+
+scmVersion {
+  tag {
+    prefix = 'release'
+    versionSeparator = '/'
+  }
+  createReleaseCommit = true
+  releaseCommitMessage { version, position -> "Release version: ${version}\n\n[ci skip]" }
+  versionIncrementer 'incrementPrerelease'
+}
+
+String calculateFullVersion(String baseVersion) {
+  //TODO: Replace with a smart regexp like (.*)(-SNAPSHOT|) -> {1}-groovy-2.3{2}
+  if (baseVersion.endsWith('-SNAPSHOT')) {
+    return baseVersion - '-SNAPSHOT' + "-groovy-$variant-SNAPSHOT"
+  }
+  return baseVersion + "-groovy-$variant"
+}
+
+ext {
+  baseVersion = scmVersion.version
+  fullVersion = calculateFullVersion(baseVersion)
+  snapshotVersion = baseVersion.endsWith('-SNAPSHOT')
 }
 
 allprojects {
@@ -72,8 +98,8 @@ subprojects {
   apply plugin: "groovy"
   apply plugin: "signing"
 
-  sourceCompatibility = javaVersions.min()
-  targetCompatibility = javaVersions.min()
+  sourceCompatibility = targetJavaVersion
+  targetCompatibility = targetJavaVersion
 
   sourceSets.all { ss ->
     for (v in variants.findAll { it <= variant } ) {
@@ -140,6 +166,19 @@ subprojects {
   }
 }
 
+if (gradle.startParameter.taskNames == ["prepareForTravisCiBuild"]) {
+  gradle.startParameter.taskNames = ["currentVersion"]
+  if (System.getenv("TRAVIS_PULL_REQUEST") == "false" && System.getenv("TRAVIS_BRANCH") == "master") {
+    logger.info("TRAVIS_COMMIT: ${System.getenv("TRAVIS_COMMIT")}, TRAVIS_COMMIT_MSG: ${System.getenv("TRAVIS_COMMIT_MSG")}")
+    if (System.getenv("TRAVIS_COMMIT_MSG")?.contains(releaseTriggeringCommand)) {
+      if (javaVersion == javaVersions.min() && variant == variants.max()) {
+        project.ext["release.disableRemoteCheck"] = true	//TODO: Switch to setting in task properties
+        gradle.startParameter.taskNames = ["createRelease"]
+      }
+    }
+  }
+}
+
 if (gradle.startParameter.taskNames == ["travisCiBuild"]) {
   gradle.startParameter.taskNames = ["build"]
   subprojects {
@@ -147,16 +186,19 @@ if (gradle.startParameter.taskNames == ["travisCiBuild"]) {
       maxParallelForks = 2
     }
   }
-  if (System.getenv("TRAVIS_PULL_REQUEST") == "false") {
+  if (System.getenv("TRAVIS_PULL_REQUEST") == "false" && System.getenv("TRAVIS_BRANCH") == "master") {
     if (javaVersion == javaVersions.min()) {
       gradle.startParameter.taskNames += ["uploadArchives"]
+      if (variant == variants.max()) {
+        if (!snapshotVersion) {
+          gradle.startParameter.taskNames += ["closeRepository", "tagRelease", "promoteRepository"]
+        }
+      }
     }
     if (javaVersion == javaVersions.max()) {
       if (variant == variants.max()) {
+        //TODO: Would it be a problem to do it with javaVersions.min()? Should Javadocs for snapshot published?
         gradle.startParameter.taskNames += ["publishJavadoc", "publishDocs"]
-        if (!snapshotVersion) {
-          gradle.startParameter.taskNames += ["tagRelease"]
-        }
       }
     }
   }
@@ -201,12 +243,12 @@ task publishJavadoc(type: Exec) {
   git config user.name "Spock Framework Robot"
   git fetch origin +gh-pages:gh-pages
   git checkout gh-pages
-  rm -rf javadoc/$variantLessVersion
-  mkdir -p javadoc/$variantLessVersion
-  cp -r build/javadoc/$variantLessVersion javadoc/
+  rm -rf javadoc/$baseVersion
+  mkdir -p javadoc/$baseVersion
+  cp -r build/javadoc/$baseVersion javadoc/
   git add javadoc
-  git commit -qm "Publish javadoc/$variantLessVersion"
-  git push -q "https://${System.getenv("GITHUB_TOKEN")}@github.com/spockframework/spock.git" gh-pages > /dev/null 2>&1
+  git commit -qm "Publish javadoc/$baseVersion"
+  git push -q "https://\$GITHUB_TOKEN@github.com/spockframework/spock.git" gh-pages > /dev/null 2>&1
   git checkout master
 """
 }
@@ -218,12 +260,12 @@ task publishDocs(type: Exec) {
   git config user.name "Spock Framework Robot"
   git fetch origin +gh-pages:gh-pages
   git checkout gh-pages
-  rm -rf docs/$variantLessVersion
-  mkdir -p docs/$variantLessVersion
-  cp -r build/asciidoc/html5/* docs/$variantLessVersion
+  rm -rf docs/$baseVersion
+  mkdir -p docs/$baseVersion
+  cp -r build/asciidoc/html5/* docs/$baseVersion
   git add docs
-  git commit -qm "Publish docs/$variantLessVersion"
-  git push -q "https://${System.getenv("GITHUB_TOKEN")}@github.com/spockframework/spock.git" gh-pages > /dev/null 2>&1
+  git commit -qm "Publish docs/$baseVersion"
+  git push -q "https://\$GITHUB_TOKEN@github.com/spockframework/spock.git" gh-pages > /dev/null 2>&1
   git checkout master
 """
 }
@@ -232,15 +274,13 @@ task tagRelease(type: Exec) {
 """
   git config user.email "dev@forum.spockframework.org"
   git config user.name "Spock Framework Robot"
-  git checkout master
-  git tag spock-$baseVersion
-  git push -q "https://${System.getenv("GITHUB_TOKEN")}@github.com/spockframework/spock.git" spock-$baseVersion > /dev/null 2>&1
+  git push -q "https://\$GITHUB_TOKEN@github.com/spockframework/spock.git" HEAD:refs/heads/master --follow-tags > /dev/null 2>&1
 """
 }
 
 task javadoc(type: Javadoc) {
-  title "Spock Framework API Documentation ($variantLessVersion)"
-  destinationDir file("build/javadoc/$variantLessVersion")
+  title "Spock Framework API Documentation ($baseVersion)"
+  destinationDir file("build/javadoc/$baseVersion")
   source subprojects.javadoc.source
   classpath = files(subprojects.javadoc.classpath)
 }
@@ -248,9 +288,9 @@ task javadoc(type: Javadoc) {
 configureJavadoc(javadoc)
 
 task groovydoc(type: Groovydoc) {
-  docTitle "Spock Framework API Documentation ($variantLessVersion)"
-  windowTitle "Spock Framework API Documentation ($variantLessVersion)"
-  destinationDir file("build/groovydoc/$variantLessVersion")
+  docTitle "Spock Framework API Documentation ($baseVersion)"
+  windowTitle "Spock Framework API Documentation ($baseVersion)"
+  destinationDir file("build/groovydoc/$baseVersion")
   source subprojects.groovydoc.source
   classpath = files(subprojects.groovydoc.classpath)
   groovyClasspath = project(":spock-core").groovydoc.groovyClasspath
@@ -286,4 +326,6 @@ def configureGroovydoc(task) {
   }
 }
 
+tagRelease.mustRunAfter closeRepository
+promoteRepository.mustRunAfter tagRelease
 

--- a/gradle/publishMaven.gradle
+++ b/gradle/publishMaven.gradle
@@ -51,10 +51,10 @@ install {
 uploadArchives {
   deployers << repositories.mavenDeployer {
     snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-      authentication(userName: "pniederw", password: System.getenv("SONATYPE_OSS_PASSWORD"))
+      authentication(userName: System.getenv("SONATYPE_OSS_USERNAME"), password: System.getenv("SONATYPE_OSS_PASSWORD"))
     }
     repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-      authentication(userName: "pniederw", password: System.getenv("SONATYPE_OSS_PASSWORD"))
+      authentication(userName: System.getenv("SONATYPE_OSS_USERNAME"), password: System.getenv("SONATYPE_OSS_PASSWORD"))
     }
   }
 }
@@ -90,3 +90,11 @@ modifyPom { pom ->
 }
 
 deployers*.beforeDeployment { signing.signPom(it) }
+
+nexusStaging {
+    packageGroup = 'org.spockframework'
+    numberOfRetries = 20
+    username = hasProperty('nexusUsername') ? getProperty('nexusUsername') : System.env.SONATYPE_OSS_USERNAME
+    password = hasProperty('nexusPassword') ? getProperty('nexusPassword') : System.env.SONATYPE_OSS_PASSWORD
+}
+


### PR DESCRIPTION
# Automatic releasing from Travis to Maven Central mechanism - a proposal

## Rationale

There have been many very interesting features implemented in the PRs for the previous 2 years. Unfortunately most of them have been kept in a freeze what is very frustrating for their authors (what in the end limit the number of contributions to Spock). Luckily the situation seems to be changing very recently - PRs have started to be merged. This PR is a complement to that process.

Automatic releasing from Travis makes it possible to have the feature available in **released version** just minutes after being merge into master. Currently the versions are marked as `beta`, but the artifacts are properly versioned, released to Maven Central and will stay there until the end of time (not like snapshots) - with an ability revert to the previous working version in case of problems . Therefore the group of early adopters become wider and wider. IMHO it is crucial to get Spock Framework development back on track.

## Usage

To trigger the release process a commit to master branch with `[#DO_RELEASE]` command in the message is required. It can be an artificial commit, like:

```
git commit -m "Trigger release" -m "[#DO_RELEASE]" --allow-empty
```

Or the command can be added to a merge commit in GitHub UI.

## Limitations and corner cases

The process has some limitation and (while usually working with my POC project) has been submitted here to get feedback and raise a discussion. The releasing mechanism has been adjusted to existing Spock build configuration and specific requirements (like variants for different Groovy versions).

### Limitations

1. Only Groovy 2.4 variant is released - this would be very tricky to work with Nexus from different Travis builds. Other variants are still released as snapshots.
2. Spock is released with Java 7 (instead 6). While the target version is still 1.6 some Axion dependencies (namely JGit) support only Java 7+ at runtime.

### Corner cases

Why should I scary you :). There are some, but all should be able to solve manually when accidentally happen. I will update this point later. Some of them might become obsolete before my PR would be merged ;).

## Technicalities

 - [Axion plugin](https://github.com/allegro/axion-release-plugin/) by Adam Dubiel is used to manage versioning which is now based on Git tags
 - my [Nexus Stating plugin](https://github.com/Codearte/gradle-nexus-staging-plugin/) is used to automatically promote artifacts to Maven Central from a Gradle build
 - Gradle logic (and sometimes hacks) to glue everything together

## Further work

Code could be somehow refactored. However for a time being I wanted to reduce an impact on existing mechanisms.