### PR TITLE
Mark the new verifyAll method as @Beta

### DIFF
--- a/spock-core/src/main/java/spock/lang/Specification.java
+++ b/spock-core/src/main/java/spock/lang/Specification.java
@@ -218,6 +218,7 @@ public abstract class Specification extends MockingApi {
     with(target, closure);
   }
 
+  @Beta
   public void verifyAll(Closure closure){
     GroovyRuntimeUtil.invokeClosure(closure);
   }


### PR DESCRIPTION
I think it would be good to make the all new things as `@Beta` to allow to get feedback from people using it in production.