### PR TITLE
Upload artifacts only from master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ if (gradle.startParameter.taskNames == ["travisCiBuild"]) {
       maxParallelForks = 2
     }
   }
-  if (System.getenv("TRAVIS_PULL_REQUEST") == "false") {
+  if (System.getenv("TRAVIS_PULL_REQUEST") == "false" && System.getenv("TRAVIS_BRANCH") == "master") {
     if (javaVersion == javaVersions.min()) {
       gradle.startParameter.taskNames += ["uploadArchives"]
     }


### PR DESCRIPTION
To prevent snapshot version upload from branches created by the committers
in the project repo directly.