### PR TITLE
Fixed #581 by adding complete Spring-Boot 1.4 support

### DIFF
--- a/spock-spring/boot-test/boot-test.gradle
+++ b/spock-spring/boot-test/boot-test.gradle
@@ -1,15 +1,34 @@
-def bootVersion = "1.4.0.M2"
+buildscript {
+  ext {
+    springBootVersion = '1.4.0.M3'
+  }
+  repositories {
+    mavenCentral()
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
+  }
+  dependencies {
+    classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
+  }
+}
+
+
+apply plugin: 'spring-boot'
 
 dependencies {
-	compile "org.springframework.boot:spring-boot-starter-test:$bootVersion"
+  compile "org.springframework.boot:spring-boot-starter-data-jpa"
+  compile "org.springframework.boot:spring-boot-starter-web"
 
+  testCompile "org.springframework.boot:spring-boot-starter-test"
   testCompile project(":spock-core")
+
+  runtime "com.h2database:h2"
+
   testRuntime project(":spock-spring")
 }
 
 repositories {
-  maven {
-    url 'https://repo.spring.io/libs-milestone'
-  }
+  mavenCentral()
+  maven { url "https://repo.spring.io/snapshot" }
+  maven { url "https://repo.spring.io/milestone" }
 }
-

--- a/spock-spring/boot-test/boot-test.gradle
+++ b/spock-spring/boot-test/boot-test.gradle
@@ -15,9 +15,19 @@ buildscript {
 
 apply plugin: 'spring-boot'
 
+
+
+ext['tomcat.version'] = '7.0.59' // use Tomcat 7 to ensure Java 6 compatibility
 dependencies {
-  compile "org.springframework.boot:spring-boot-starter-data-jpa"
+  compile("org.springframework.boot:spring-boot-starter-data-jpa") {
+    // for Java 6 compatibility, see http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#how-to-use-java-6-jta-api
+    exclude group: "javax.transaction", module: "javax.transaction-api"
+  }
+
+  compile "org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.0.Final"
+
   compile "org.springframework.boot:spring-boot-starter-web"
+
 
   testCompile "org.springframework.boot:spring-boot-starter-test"
   testCompile project(":spock-core")
@@ -33,13 +43,3 @@ repositories {
   maven { url "https://repo.spring.io/milestone" }
 }
 
-// use Tomcat 7 to ensure Java 6 compatibility
-configurations.all {
-  resolutionStrategy {
-    eachDependency {
-      if (it.requested.group == 'org.apache.tomcat.embed') {
-        it.useVersion '7.0.56'
-      }
-    }
-  }
-}

--- a/spock-spring/boot-test/boot-test.gradle
+++ b/spock-spring/boot-test/boot-test.gradle
@@ -32,3 +32,14 @@ repositories {
   maven { url "https://repo.spring.io/snapshot" }
   maven { url "https://repo.spring.io/milestone" }
 }
+
+// use Tomcat 7 to ensure Java 6 compatibility
+configurations.all {
+  resolutionStrategy {
+    eachDependency {
+      if (it.requested.group == 'org.apache.tomcat.embed') {
+        it.useVersion '7.0.56'
+      }
+    }
+  }
+}

--- a/spock-spring/boot-test/src/main/java/org/spockframework/boot/jpa/Book.java
+++ b/spock-spring/boot-test/src/main/java/org/spockframework/boot/jpa/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,29 @@
  * limitations under the License.
  */
 
-package org.spockframework.boot;
 
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+package org.spockframework.boot.jpa;
 
-@SpringBootApplication
-public class SimpleBootApp implements CommandLineRunner {
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 
-	@Override
-	public void run(String... args) {
-    System.out.println("Hello World");
+/**
+ * JPA example entity class.
+ */
+@Entity
+public class Book {
+
+  @Id
+  @GeneratedValue
+  private Long id;
+  private String title;
+
+  protected Book() {
+    // no-args JPA constructor
   }
 
-	public static void main(String[] args) throws Exception {
-		SpringApplication.run(SimpleBootApp.class, args);
-	}
+  public Book(String title) {
+    this.title = title;
+  }
 }

--- a/spock-spring/boot-test/src/main/java/org/spockframework/boot/jpa/BookRepository.java
+++ b/spock-spring/boot-test/src/main/java/org/spockframework/boot/jpa/BookRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,13 @@
  * limitations under the License.
  */
 
-package org.spockframework.boot;
 
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+package org.spockframework.boot.jpa;
 
-@SpringBootApplication
-public class SimpleBootApp implements CommandLineRunner {
+import org.springframework.data.repository.CrudRepository;
 
-	@Override
-	public void run(String... args) {
-    System.out.println("Hello World");
-  }
-
-	public static void main(String[] args) throws Exception {
-		SpringApplication.run(SimpleBootApp.class, args);
-	}
+/**
+ * Spring-Data repository for {@link Book} entities.
+ */
+public interface BookRepository extends CrudRepository<Book, Long> {
 }

--- a/spock-spring/boot-test/src/main/java/org/spockframework/boot/web/HelloWorldController.java
+++ b/spock-spring/boot-test/src/main/java/org/spockframework/boot/web/HelloWorldController.java
@@ -1,0 +1,17 @@
+package org.spockframework.boot.web;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Spring-MVC controller class.
+ */
+@RestController
+public class HelloWorldController {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "hello world";
+  }
+
+}

--- a/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/DataJpaTestIntegrationSpec.groovy
+++ b/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/DataJpaTestIntegrationSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.spockframework.boot
+
+import org.spockframework.boot.jpa.Book
+import org.spockframework.boot.jpa.BookRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+/**
+ * Integration tests for ensuring compatibility with Spring-Boot's {@link DataJpaTest} annotation.
+ */
+@DataJpaTest
+class DataJpaTestIntegrationSpec extends Specification {
+
+  @Autowired
+  TestEntityManager entityManager
+
+  @Autowired
+  BookRepository bookRepository
+
+  def "spring context loads for data jpa slice"() {
+    given: "some existing books"
+    entityManager.persist(new Book("Moby Dick"))
+    entityManager.persist(new Book("Testing Spring with Spock"))
+
+    expect: "the correct count is inside the repository"
+    bookRepository.count() == 2L
+  }
+
+
+}

--- a/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/SpringBootTestAnnotationIntegrationSpec.groovy
+++ b/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/SpringBootTestAnnotationIntegrationSpec.groovy
@@ -23,11 +23,9 @@ import spock.lang.Specification
 
 /**
  * Integration test similar to {@link SimpleBootAppIntegrationSpec} but using the {@link SpringBootTest} annotation.
- *
- * @author Kevin Wittek
  */
 @SpringBootTest
-class SimpleBootAppTestAnnotationIntegrationSpec extends Specification {
+class SpringBootTestAnnotationIntegrationSpec extends Specification {
   @Autowired
   ApplicationContext context
 

--- a/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/WebMvcTestIntegrationSpec.groovy
+++ b/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/WebMvcTestIntegrationSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.boot
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import spock.lang.Specification
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * Integration tests for ensuring compatibility with Spring-Boot's {@link WebMvcTest} annotation.
+ */
+@WebMvcTest
+class WebMvcTestIntegrationSpec extends Specification {
+
+  @Autowired
+  MockMvc mvc
+
+  def "spring context loads for web mvc slice"() {
+
+    expect: "controller is available"
+    mvc.perform(MockMvcRequestBuilders.get("/"))
+      .andExpect(status().isOk())
+      .andExpect(content().string("hello world"))
+  }
+
+}


### PR DESCRIPTION
I've added more robust support for the current Spring-Boot 1.4 test annotations (#581) by checking for annotations on the spec, which class itself contains an `@BootstrapWith` annotation. 
This works for `@SpringBootTest `, `@DataJpaTest` and `@WebMvcTest`. 

I've also refactored the `SpringExtension` class a bit to reflect which check determines the presence of Spring-Boot. It might be possible to clean up this class even more, but I'm not entirely sure if some checks are needed for backwards compatibility with older Spring versions.
