### PR TITLE
Fix broken hyperlink

### DIFF
--- a/docs/getting_started.adoc
+++ b/docs/getting_started.adoc
@@ -10,7 +10,7 @@ So why not run http://webconsole.spockframework.org/edit/9001[Hello, Spock!] rig
 
 == Spock Example Project
 
-To try Spock in your local environment, clone or download/unzip the https://github.com/spockframework/spock-example
-[Spock Example Project]. It comes with fully working Ant, Gradle, and Maven builds that require no further setup.
-The Gradle build even bootstraps Gradle itself and gets you up and running in Eclipse or IDEA with a single command.
-See the README for detailed instructions.
+To try Spock in your local environment, clone or download/unzip the
+https://github.com/spockframework/spock-example[Spock Example Project]. It comes with fully working Ant, Gradle, and
+Maven builds that require no further setup. The Gradle build even bootstraps Gradle itself and gets you up and
+running in Eclipse or IDEA with a single command. See the README for detailed instructions.


### PR DESCRIPTION
There is a line break between the URI and the caption of the link. This breaks the link in Asciidoctor and in the Github preview. This commit rearranges the line breaks so that this issue is resolved.