### PR TITLE
Fix to avoid Spring BeanIsAbstractException at attaching mocks in SpringMockTestExecutionListener

### DIFF
--- a/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.spockframework.mock.ISpockMockObject;
 import org.spockframework.mock.MockUtil;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
@@ -40,6 +42,10 @@ public class SpringMockTestExecutionListener implements TestExecutionListener {
       List<Object> mockedBeans = new ArrayList<Object>();
 
       for (String beanName : mockBeanNames) {
+        BeanDefinition beanDefinition = ((BeanDefinitionRegistry)applicationContext).getBeanDefinition(beanName);
+        if(beanDefinition.isAbstract()){
+            continue;
+        }
         Object bean = applicationContext.getBean(beanName);
         if (mockUtil.isMock(bean)) {
           mockUtil.attachMock(bean, specification);


### PR DESCRIPTION
If the application contexts has some bean definitions that are abstract, currently the method 
`applicationContext.getBean(beanName)` throws the exception `org.springframework.beans.factory.BeanIsAbstractException` (Error creating bean with name '...': Bean definition is abstract).
So it is needed to check if the beanDefinition is abstract before getting the bean.