### PR TITLE
Added support for mock class creation using Byte Buddy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ ext {
     jetbrainsAnnotations: "org.jetbrains:annotations:13.0",
     ant: "org.apache.ant:ant:1.9.7",
     asm: "org.ow2.asm:asm:5.1",
+    bytebuddy: "net.bytebuddy:byte-buddy:1.4.26",
     cglib: "cglib:cglib-nodep:3.2.2",
     groovy: "org.codehaus.groovy:groovy-all:$groovyVersion",
     h2database: "com.h2database:h2:1.3.176",
@@ -139,6 +140,20 @@ subprojects {
   artifacts {
     archives sourcesJar, javadocJar
   }
+
+  task testCglib(type: Test) {
+    systemProperty("org.spockframework.mock.ignoreByteBuddy", "true")
+    testClassesDir = sourceSets.test.output.classesDir
+    classpath = sourceSets.test.runtimeClasspath
+  }
+
+  if (gradle.startParameter.taskNames.contains("travisCiBuild")
+    || gradle.startParameter.taskNames.contains("shippableCiBuild")
+    || gradle.startParameter.taskNames.contains("appveyorCiBuild")) {
+    check.dependsOn testCglib
+  }
+
+  testCglib.mustRunAfter test
 
   tasks.withType(Test) {
     reports {

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -17,6 +17,7 @@ dependencies {
   compile libs.jetbrainsAnnotations, optional
   compile libs.ant, optional
   compile libs.asm, optional
+  compile libs.bytebuddy, optional
   compile libs.cglib, optional
   compile libs.objenesis, optional
 }
@@ -30,6 +31,11 @@ jar {
         'org.objenesis;version="[1,2)";resolution:=optional', 
         'org.apache.tools.ant;version="[1,2)";resolution:=optional', 
         'org.apache.tools.ant.types;version="[1,2)";resolution:=optional',
+        'net.bytebuddy;version="[1.4.17,1)";resolution:=optional',
+        'net.bytebuddy.dynamic;version="[1.4.17,1)";resolution:=optional',
+        'net.bytebuddy.implementation;version="[1.4.17,1)";resolution:=optional',
+        'net.bytebuddy.implementation.bind.annotation;version="[1.4.17,1)";resolution:=optional',
+        'net.bytebuddy.description.modifier;version="[1.4.17,1)";resolution:=optional',
         'net.sf.cglib.proxy;version="[2.2,2)";resolution:=optional', 
         'org.apache.tools.ant.types.selectors;version="[1.7,2)";resolution:=optional',
         'groovy.lang;version="[1.8,3)"', 'org.codehaus.groovy.*;version="[1.8,3)"', 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyClassCache.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyClassCache.java
@@ -1,0 +1,151 @@
+package org.spockframework.mock.runtime;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class ByteBuddyClassCache extends ReferenceQueue<ClassLoader> {
+
+  private static final ClassLoader MARKER = new URLClassLoader(new URL[0], null); // null cannot be stored in concurrent maps.
+
+  private final boolean weakKey;
+
+  final ConcurrentMap<Key, ConcurrentMap<MockKey, Reference<Class<?>>>> cache = new ConcurrentHashMap<Key, ConcurrentMap<MockKey, Reference<Class<?>>>>();
+
+  public ByteBuddyClassCache(boolean weakKey) {
+    this.weakKey = weakKey;
+  }
+
+  public Class<?> find(ClassLoader classLoader, Class<?> type, Collection<? extends Class<?>> interfaces) {
+    if (classLoader == null) {
+      classLoader = MARKER;
+    }
+    Map<MockKey, Reference<Class<?>>> value = cache.get(new LookupKey(classLoader));
+    if (value == null) {
+      return null;
+    }
+    Reference<Class<?>> reference = value.get(MockKey.of(type, interfaces));
+    if (reference == null) {
+      return null;
+    } else {
+      return reference.get();
+    }
+  }
+
+  public void insert(ClassLoader classLoader, Class<?> type, Collection<? extends Class<?>> interfaces, Class<?> enhancedType) {
+    if (classLoader == null) {
+      classLoader = MARKER;
+    }
+    ConcurrentMap<MockKey, Reference<Class<?>>> value = cache.get(new LookupKey(classLoader));
+    if (value == null) {
+      value = new ConcurrentHashMap<MockKey, Reference<Class<?>>>();
+      cache.put(new WeakKey(classLoader, this), value);
+    }
+    value.put(MockKey.of(type, interfaces), weakKey ? new WeakReference<Class<?>>(enhancedType) : new SoftReference<Class<?>>(enhancedType));
+  }
+
+  private interface Key {
+
+    ClassLoader get();
+  }
+
+  private static class LookupKey implements Key {
+
+    private final ClassLoader value;
+
+    private final int hashCode;
+
+    public LookupKey(ClassLoader value) {
+      this.value = value;
+      hashCode = System.identityHashCode(value);
+    }
+
+    @Override
+    public ClassLoader get() {
+      return value;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+      if (this == object) return true;
+      if (!(object instanceof Key)) return false;
+      return value == ((Key) object).get();
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+  }
+
+  private static class WeakKey extends WeakReference<ClassLoader> implements Key {
+
+    private final int hashCode;
+
+    public WeakKey(ClassLoader referent, ReferenceQueue<ClassLoader> q) {
+      super(referent, q);
+      hashCode = System.identityHashCode(referent);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+      if (this == object) return true;
+      if (!(object instanceof Key)) return false;
+      return get() == ((Key) object).get();
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+  }
+
+  // should be stored as a weak or soft reference
+  private static class MockKey<T> {
+    private final String mockedType;
+    private final Set<String> types;
+
+    private MockKey(Class<T> mockedType, Collection<? extends Class<?>> interfaces) {
+      this.mockedType = mockedType.getName();
+      if (interfaces.isEmpty()) { // Optimize memory footprint for the common case.
+        types = Collections.emptySet();
+      } else {
+        types = new HashSet<String>();
+        for (Class<?> anInterface : interfaces) {
+          types.add(anInterface.getName());
+        }
+        types.add(this.mockedType);
+      }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) return true;
+      if (other == null || getClass() != other.getClass()) return false;
+
+      MockKey mockKey = (MockKey<?>) other;
+
+      if (!mockedType.equals(mockKey.mockedType)) return false;
+      if (!types.equals(mockKey.types)) return false;
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = mockedType.hashCode();
+      result = 31 * result + types.hashCode();
+      return result;
+    }
+
+    public static <T> MockKey<T> of(Class<T> mockedType, Collection<? extends Class<?>> interfaces) {
+      return new MockKey<T>(mockedType, interfaces);
+    }
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyInterceptorAdapter.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyInterceptorAdapter.java
@@ -1,0 +1,44 @@
+package org.spockframework.mock.runtime;
+
+import net.bytebuddy.implementation.bind.annotation.*;
+
+import java.lang.reflect.Method;
+
+public class ByteBuddyInterceptorAdapter {
+
+  @RuntimeType
+  public static Object interceptAbstract(@FieldValue("$spock_interceptor") IProxyBasedMockInterceptor proxyBasedMockInterceptor,
+                                         @This Object self,
+                                         @AllArguments Object[] arguments,
+                                         @Origin Method method,
+                                         @StubValue Object stubValue) throws Exception {
+    Object returnValue;
+    if (proxyBasedMockInterceptor == null) {
+      returnValue = null; // Call before interceptor was set (constructor).
+    } else {
+      returnValue = proxyBasedMockInterceptor.intercept(self, method, arguments, new ByteBuddyMethodInvoker(null));
+    }
+    return returnValue == null ? stubValue : returnValue;
+  }
+
+  @RuntimeType
+  public static Object interceptNonAbstract(@FieldValue("$spock_interceptor") IProxyBasedMockInterceptor proxyBasedMockInterceptor,
+                                            @Morph ByteBuddyInvoker invoker,
+                                            @This Object self,
+                                            @AllArguments Object[] arguments,
+                                            @Origin Method method,
+                                            @StubValue Object stubValue) throws Exception {
+    Object returnValue;
+    if (proxyBasedMockInterceptor == null) {
+      returnValue = invoker.call(arguments); // Call before interceptor was set (constructor).
+    } else {
+      returnValue = proxyBasedMockInterceptor.intercept(self, method, arguments, new ByteBuddyMethodInvoker(invoker));
+    }
+    return returnValue == null ? stubValue : returnValue;
+  }
+
+  public interface InterceptorAccess {
+
+    void $spock_set(IProxyBasedMockInterceptor proxyBasedMockInterceptor);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyInvoker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyInvoker.java
@@ -1,0 +1,6 @@
+package org.spockframework.mock.runtime;
+
+public interface ByteBuddyInvoker {
+
+  Object call(Object[] arguments);
+}

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMethodInvoker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMethodInvoker.java
@@ -1,0 +1,28 @@
+package org.spockframework.mock.runtime;
+
+import org.spockframework.mock.IMockInvocation;
+import org.spockframework.mock.IResponseGenerator;
+import org.spockframework.util.ExceptionUtil;
+
+public class ByteBuddyMethodInvoker implements IResponseGenerator {
+
+  private final ByteBuddyInvoker superCall;
+
+  public ByteBuddyMethodInvoker(ByteBuddyInvoker superCall) {
+    this.superCall = superCall;
+  }
+
+  @Override
+  public Object respond(IMockInvocation invocation) {
+    if (superCall == null) {
+      throw new IllegalStateException("Cannot invoke abstract method " + invocation.getMethod());
+    }
+    try {
+      return superCall.call(invocation.getArguments().toArray());
+    } catch (Throwable t) {
+      // Byte Buddy doesn't wrap exceptions in InvocationTargetException, so no need to unwrap
+      ExceptionUtil.sneakyThrow(t);
+      return null; // unreachable
+    }
+  }
+}

--- a/spock-report/report.gradle
+++ b/spock-report/report.gradle
@@ -16,6 +16,11 @@ test {
   exclude "org/spockframework/report/sample/FightOrFlightSpec.class"
 }
 
+testCglib {
+  exclude "org/spockframework/report/sample/FightOrFlightStory.class"
+  exclude "org/spockframework/report/sample/FightOrFlightSpec.class"
+}
+
 ext.spockLogFileDir = file("$buildDir/spock/logFiles")
 ext.spockLogFileName = "spock-log"
 

--- a/spock-specs/specs.gradle
+++ b/spock-specs/specs.gradle
@@ -13,6 +13,7 @@ dependencies {
   testCompile project(":spock-core")
 
   testRuntime libs.asm
+  testRuntime libs.bytebuddy
   testRuntime libs.cglib
   testRuntime libs.objenesis
   testRuntime libs.h2database

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MockProxyCaching.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MockProxyCaching.groovy
@@ -16,7 +16,6 @@ package org.spockframework.smoke.mock
 
 import java.lang.reflect.Proxy
 import spock.lang.Specification
-import net.sf.cglib.proxy.Factory
 
 class MockProxyCaching extends Specification {
   def "dynamic proxy classes are cached"() {
@@ -29,13 +28,11 @@ class MockProxyCaching extends Specification {
     list1.getClass() == list2.getClass()
   }
 
-  def "CGLIB proxy classes are cached"() {
+  def "Byte Buddy or CGLIB proxy classes are cached"() {
     def list1 = Mock(ArrayList)
     def list2 = Mock(ArrayList)
 
     expect:
-    list1 instanceof Factory
-    list2 instanceof Factory
     list1.getClass() == list2.getClass()
   }
 }


### PR DESCRIPTION
Adds support for generating classes using Byte Buddy instead of cglib when Byte Buddy is found on the class path. (Other than on *AppVeyor*, running `:spock-specs:test` works fine on my machine.)