### PR TITLE
Change boot-test to only execute when Java 7 or higher is available

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,15 @@
 include "spock-core"
 include "spock-specs"
 include "spock-spring"
-include "spock-spring:boot-test"
 include "spock-guice"
 include "spock-tapestry"
 include "spock-unitils"
 include "spock-report"
 include "spock-gradle"
+
+if (JavaVersion.current().java7Compatible) {
+  include "spock-spring:boot-test"
+}
 
 rootProject.name = "spock"
 nameBuildScriptsAfterProjectNames(rootProject.children)

--- a/spock-spring/boot-test/boot-test.gradle
+++ b/spock-spring/boot-test/boot-test.gradle
@@ -17,17 +17,9 @@ apply plugin: 'spring-boot'
 
 
 
-ext['tomcat.version'] = '7.0.59' // use Tomcat 7 to ensure Java 6 compatibility
 dependencies {
-  compile("org.springframework.boot:spring-boot-starter-data-jpa") {
-    // for Java 6 compatibility, see http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#how-to-use-java-6-jta-api
-    exclude group: "javax.transaction", module: "javax.transaction-api"
-  }
-
-  compile "org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.0.Final"
-
+  compile "org.springframework.boot:spring-boot-starter-data-jpa"
   compile "org.springframework.boot:spring-boot-starter-web"
-
 
   testCompile "org.springframework.boot:spring-boot-starter-test"
   testCompile project(":spock-core")


### PR DESCRIPTION
Since 1.4.0.RELEASE the spring-boot-gradle plugin requires at least
Java 7 so we decided to follow this version requirement for this
subproject.