### PR TITLE
Fix NPE for install task if SIGNING_PASSWORD is null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,10 @@ subprojects {
   }
 
   ext."signing.keyId" = "2EA0A67F"
-  ext."signing.password" = System.getenv("SIGNING_PASSWORD")
+  if (System.getenv("SIGNING_PASSWORD")) {
+    // if the password property is set, even if its null null, the SigningExtension will try to load the key
+    ext."signing.password" = System.getenv("SIGNING_PASSWORD")
+  }
   ext."signing.secretKeyRingFile" = "$rootDir/config/code-signing-secring.gpg"
 
   configureJavadoc(javadoc)


### PR DESCRIPTION
The SingningExtension will try to load the key if the signing.password
property is set, even if no actual signing is required. This happens
as soon as the property is present regardless of its value.