### PR TITLE
Refactor handling of Exceptions in assertions

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/ConditionFailedWithExceptionError.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ConditionFailedWithExceptionError.java
@@ -1,0 +1,17 @@
+package org.spockframework.runtime;
+
+/**
+ * Indicates that an Exception was thrown while the condition was evaluated.
+ *
+ * @since 1.1
+ */
+public class ConditionFailedWithExceptionError extends ConditionNotSatisfiedError {
+  public ConditionFailedWithExceptionError(Condition condition, Throwable cause) {
+    super(condition, cause);
+  }
+
+  @Override
+  public String getMessage() {
+    return "Condition failed with Exception:\n\n" + getCondition().getRendering();
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockRuntime.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockRuntime.java
@@ -16,11 +16,13 @@
 
 package org.spockframework.runtime;
 
-import java.util.*;
-
 import org.spockframework.runtime.model.ExpressionInfo;
 import org.spockframework.runtime.model.TextPosition;
-import org.spockframework.util.*;
+import org.spockframework.util.CollectionUtil;
+import org.spockframework.util.Nullable;
+
+import java.util.List;
+import java.util.ListIterator;
 
 /**
  * @author Peter Niederwieser
@@ -52,7 +54,7 @@ public abstract class SpockRuntime {
         errorCollector.collectOrThrow(spockException); // this is our exception - it already has good message
         return;
       }
-    final ConditionNotSatisfiedError conditionNotSatisfiedError = new ConditionNotSatisfiedError(
+    final ConditionFailedWithExceptionError conditionNotSatisfiedError = new ConditionFailedWithExceptionError(
         new Condition(
             getValues(recorder),
             text,

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/FailsWithInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/FailsWithInterceptor.java
@@ -16,10 +16,10 @@
 
 package org.spockframework.runtime.extension.builtin;
 
+import org.spockframework.runtime.ConditionFailedWithExceptionError;
 import org.spockframework.runtime.WrongExceptionThrownError;
 import org.spockframework.runtime.extension.IMethodInterceptor;
 import org.spockframework.runtime.extension.IMethodInvocation;
-
 import spock.lang.FailsWith;
 
 /**
@@ -37,10 +37,15 @@ public class FailsWithInterceptor implements IMethodInterceptor {
     try {
       invocation.proceed();
     } catch (Throwable t) {
-      if (failsWith.value().isInstance(t)) return;
+      if (checkException(t)) return;
       throw new WrongExceptionThrownError(failsWith.value(), t);
     }
-    
+
     throw new WrongExceptionThrownError(failsWith.value(), null);
+  }
+
+  private boolean checkException(Throwable t) {
+    return failsWith.value().isInstance(t)
+      || (t instanceof ConditionFailedWithExceptionError && failsWith.value().isInstance(t.getCause()));
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionsInConditions.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionsInConditions.groovy
@@ -1,12 +1,8 @@
 package org.spockframework.smoke.condition
 
-import junit.framework.Assert
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.runtime.ConditionNotSatisfiedError
 import org.spockframework.runtime.SpockException
-import spock.lang.FailsWith
-import spock.lang.Specification
-
 
 class ExceptionsInConditions extends EmbeddedSpecification {
   def "null pointer exception in condition"() {
@@ -146,7 +142,7 @@ class ExceptionsInConditions extends EmbeddedSpecification {
     then:
     ConditionNotSatisfiedError e = thrown()
     e.getMessage() == """\
-      Condition not satisfied:
+      Condition failed with Exception:
 
       map.get("key").b.c.d.e()
       |   |          |

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/FailsWithExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/FailsWithExtension.groovy
@@ -16,10 +16,11 @@
 
 package org.spockframework.smoke.extension
 
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.ConditionFailedWithExceptionError
+import org.spockframework.runtime.InvalidSpecException
 import spock.lang.FailsWith
 import spock.lang.Specification
-import org.spockframework.EmbeddedSpecification
-import org.spockframework.runtime.InvalidSpecException
 
 /**
  *
@@ -42,6 +43,25 @@ class FailsWithOnMethod extends Specification {
 
   def ex3() {
     expect: true
+  }
+
+
+  @FailsWith(ConditionFailedWithExceptionError)
+  def "can handle ConditionFailedWithExceptionError"() {
+    when:
+    def a = [b:null]
+
+    then:
+    a.b.c.size()
+  }
+
+  @FailsWith(NullPointerException)
+  def "can handle cause of ConditionFailedWithExceptionError"() {
+    when:
+    def a = [b:null]
+
+    then:
+    a.b.c.size()
   }
 }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ReportLogExtensionSpec.groovy
@@ -167,7 +167,7 @@ loadLogFile([{
                 "err1\\n"
             ],
             "exceptions": [
-                "Condition not satisfied:\\n\\nthrowException()\\n|\\njava.io.IOException: ouch\\n\\n\\tat apackage.MySpec.some feature(scriptXXXXXXXXXXXXXXXXXXXXXXX.groovy:XX)\\nCaused by: java.io.IOException: ouch\\n\\tat DeclaringClass.methodName(filename:XX)\\n"
+                "Condition failed with Exception:\\n\\nthrowException()\\n|\\njava.io.IOException: ouch\\n\\n\\tat apackage.MySpec.some feature(scriptXXXXXXXXXXXXXXXXXXXXXXX.groovy:XX)\\nCaused by: java.io.IOException: ouch\\n\\tat DeclaringClass.methodName(filename:XX)\\n"
             ],
             "end": 1360051647586,
             "result": "failed",


### PR DESCRIPTION
Introduce `ConditionFailedWithExceptionError` as new subclass
of `ConditionNotSatisfiedError` it is thrown if an exception
occurred during evaluation of an assertion. `@FailsWith`
now handles this special case by looking also at the cause
of `ConditionFailedWithExceptionError`.