### PR TITLE
Report both test and cleanup exceptions for feature

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/smoke/CleanupBlocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/CleanupBlocks.groovy
@@ -21,8 +21,16 @@ import spock.lang.Specification
 import spock.lang.Issue
 import org.spockframework.EmbeddedSpecification
 import org.codehaus.groovy.runtime.typehandling.GroovyCastException
+import org.junit.runner.Result
+import org.junit.runners.model.MultipleFailureException
 
 class CleanupBlocks extends EmbeddedSpecification {
+  static List log
+
+  def setup() {
+    log = []
+  }
+
   def "basic usage"() {
     def x
     setup: x = 1
@@ -56,14 +64,49 @@ class CleanupBlocks extends EmbeddedSpecification {
     if (a == 0) throw new IllegalArgumentException()
   }
 
-  @FailsWith(IllegalArgumentException)
   def "is executed if exception is thrown"() {
-    def a = 1
-    throw new Exception()
+    when:
+    runner.runSpecBody """
+def getLog() { org.spockframework.smoke.CleanupBlocks.log }
 
-    cleanup:
-    a = 0
-    if (a == 0) throw new IllegalArgumentException()
+def feature() {
+  log << "feature"
+  throw new IllegalArgumentException()
+
+  cleanup:
+  log << "cleanup"
+}
+"""
+
+    then:
+    thrown(IllegalArgumentException)
+    log == ["feature", "cleanup"]
+  }
+
+  @Issue('https://github.com/spockframework/spock/issues/142')
+  def "feature exception and cleanup exception are both reported"() {
+    // turn off throwing the first failure so all failures can be inspected
+    runner.throwFailure = false
+
+    when:
+    Result result = runner.runSpecBody """
+def getLog() { org.spockframework.smoke.CleanupBlocks.log }
+
+def feature() {
+  log << "feature"
+  throw new IllegalArgumentException("feature")
+
+  cleanup:
+  log << "cleanup"
+  throw new IllegalArgumentException("cleanup")
+}
+"""
+
+    then:
+    List<Throwable> failures = result.getFailures()
+    failures[0].message == "feature"
+    failures[1].message == "cleanup"
+    log == ["feature", "cleanup"]
   }
 
   @FailsWith(IllegalArgumentException)


### PR DESCRIPTION
Fixes #142 

If a feature's test blocks (setup, when/then, etc.) and cleanup block
both throw Exceptions, only the Exception from the cleanup block will be
reported. This can make it difficult to determine why the test failed.

Now both Exceptions are captured and reported to JUnit using a
MultipleFailureException.

At a pseudo code level, I changed the AST transformation from:

```
try {
  // feature statements (setup, when/then, expect, etc. blocks)
} finally {
  // feature cleanup statements (cleanup block)
}
```

to

```
Throwable $spock_feature_throwable, $spock_cleanup_throwable

try {
  // feature statements (setup, when/then, expect, etc. blocks)
} catch (Throwable exc) {
  $spock_feature_throwable = exc
} finally {
  try {
    // feature cleanup statements (cleanup block)
  } catch (Throwable exc) {
    $spock_cleanup_throwable = exc
  }
}

if ($spock_feature_throwable != null && $spock_cleanup_throwable != null) {
  throw new MultipleFailureException([$spock_feature_throwable, $spock_cleanup_throwable])
} else if ($spock_feature_throwable != null) {
  throw $spock_feature_throwable
} else if ($spock_cleanup_throwable != null) {
  throw $spock_cleanup_throwable
}
```
