### PR TITLE
Update to Byte Buddy 1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
     jetbrainsAnnotations: "org.jetbrains:annotations:13.0",
     ant: "org.apache.ant:ant:1.9.7",
     asm: "org.ow2.asm:asm:5.1",
-    bytebuddy: "net.bytebuddy:byte-buddy:1.4.26",
+    bytebuddy: "net.bytebuddy:byte-buddy:1.5.9",
     cglib: "cglib:cglib-nodep:3.2.2",
     groovy: "org.codehaus.groovy:groovy-all:$groovyVersion",
     h2database: "com.h2database:h2:1.3.176",

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -27,18 +27,18 @@ jar {
     name = 'spock-core'
     instruction 'Export-Package', 'org.spockframework.*', 'spock.*'
     instruction 'Embed-Dependency', 'groovy;inline=false', 'junit;inline=false'
-    instruction 'Import-Package', 
-        'org.objenesis;version="[1,2)";resolution:=optional', 
-        'org.apache.tools.ant;version="[1,2)";resolution:=optional', 
+    instruction 'Import-Package',
+        'org.objenesis;version="[1,2)";resolution:=optional',
+        'org.apache.tools.ant;version="[1,2)";resolution:=optional',
         'org.apache.tools.ant.types;version="[1,2)";resolution:=optional',
-        'net.bytebuddy;version="[1.4.17,1)";resolution:=optional',
-        'net.bytebuddy.dynamic;version="[1.4.17,1)";resolution:=optional',
-        'net.bytebuddy.implementation;version="[1.4.17,1)";resolution:=optional',
-        'net.bytebuddy.implementation.bind.annotation;version="[1.4.17,1)";resolution:=optional',
-        'net.bytebuddy.description.modifier;version="[1.4.17,1)";resolution:=optional',
-        'net.sf.cglib.proxy;version="[2.2,2)";resolution:=optional', 
+        'net.bytebuddy;version="[1.5.0,1)";resolution:=optional',
+        'net.bytebuddy.dynamic;version="[1.5.0,1)";resolution:=optional',
+        'net.bytebuddy.implementation;version="[1.5.0,1)";resolution:=optional',
+        'net.bytebuddy.implementation.bind.annotation;version="[1.5.0,1)";resolution:=optional',
+        'net.bytebuddy.description.modifier;version="[1.5.0,1)";resolution:=optional',
+        'net.sf.cglib.proxy;version="[2.2,2)";resolution:=optional',
         'org.apache.tools.ant.types.selectors;version="[1.7,2)";resolution:=optional',
-        'groovy.lang;version="[1.8,3)"', 'org.codehaus.groovy.*;version="[1.8,3)"', 
+        'groovy.lang;version="[1.8,3)"', 'org.codehaus.groovy.*;version="[1.8,3)"',
         'org.junit.runner;version="[4,7)"'
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ProxyBasedMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ProxyBasedMockFactory.java
@@ -67,7 +67,7 @@ public class ProxyBasedMockFactory {
           constructorArgs, mockInterceptor, classLoader, useObjenesis);
     } else {
       throw new CannotCreateMockException(mockType,
-          ". Mocking of non-interface types requires a code generation library. Please put byte-buddy-1.4.0 or cglib-nodep-3.2 or higher on the class path."
+          ". Mocking of non-interface types requires a code generation library. Please put byte-buddy-1.5.0 or cglib-nodep-3.2 or higher on the class path."
       );
     }
 
@@ -120,9 +120,10 @@ public class ProxyBasedMockFactory {
               .implement(ISpockMockObject.class)
               .method(any())
                 .intercept(MethodDelegation.to(ByteBuddyInterceptorAdapter.class).appendParameterBinder(Morph.Binder.install(ByteBuddyInvoker.class)))
-                .transform(Transformer.ForMethod.withModifiers(SynchronizationState.PLAIN)) // Overridden methods should not be declared synchronized.
+                .transform(Transformer.ForMethod.withModifiers(SynchronizationState.PLAIN, Visibility.PUBLIC)) // Overridden methods should be public and non-synchronized.
               .implement(ByteBuddyInterceptorAdapter.InterceptorAccess.class)
-                .intercept(FieldAccessor.ofField("$spock_interceptor").defineAs(IProxyBasedMockInterceptor.class, Visibility.PRIVATE))
+                .intercept(FieldAccessor.ofField("$spock_interceptor"))
+                .defineField("$spock_interceptor", IProxyBasedMockInterceptor.class, Visibility.PRIVATE)
               .make()
               .load(classLoader)
               .getLoaded();


### PR DESCRIPTION
This makes sure that if methods that are declared by super classes and by interfaces are always public. Java defines that a class always inherits from its super class first and only from interfaces if a method is not declared by a class. If the class method defines a visibility less than public, the method would not be visible.
