### PR TITLE
Reduce cache rebuilding on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false # run on container-based infrastructure
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -fr $HOME/.gradle/caches/*/scripts/
+  - rm -fr $HOME/.gradle/caches/*/scripts-remapped/
 cache:
   directories:
     - $HOME/.gradle/caches/


### PR DESCRIPTION
Those directories seem to cause cache rebuilding everytime (~15-20 seconds extra build time). To be verified looking at the PR builds that Gradle needs less time to recompile those scripts.