### PR TITLE
Add support for scoped beans

### DIFF
--- a/spock-spring/boot-test/src/main/java/org/spockframework/boot/service/ScopedHelloWorldService.java
+++ b/spock-spring/boot-test/src/main/java/org/spockframework/boot/service/ScopedHelloWorldService.java
@@ -1,0 +1,19 @@
+package org.spockframework.boot.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@RequestScope(proxyMode = ScopedProxyMode.TARGET_CLASS)
+@Component
+public class ScopedHelloWorldService {
+
+  @Value("${name:World Scope!}")
+  private String name;
+
+  public String getHelloMessage() {
+    return "Hello " + this.name;
+  }
+
+}

--- a/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/SimpleBootAppIntegrationSpec.groovy
+++ b/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/SimpleBootAppIntegrationSpec.groovy
@@ -40,5 +40,6 @@ class SimpleBootAppIntegrationSpec extends Specification {
     context != null
     context.containsBean("helloWorldService")
     context.containsBean("simpleBootApp")
+    context.containsBean("scopedHelloWorldService")
   }
 }

--- a/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/SpringBootTestAnnotationIntegrationSpec.groovy
+++ b/spock-spring/boot-test/src/test/groovy/org/spockframework/boot/SpringBootTestAnnotationIntegrationSpec.groovy
@@ -34,5 +34,6 @@ class SpringBootTestAnnotationIntegrationSpec extends Specification {
     context != null
     context.containsBean("helloWorldService")
     context.containsBean("simpleBootApp")
+    context.containsBean("scopedHelloWorldService")
   }
 }

--- a/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.spockframework.mock.ISpockMockObject;
 import org.spockframework.mock.MockUtil;
+import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.ApplicationContext;
@@ -43,7 +44,7 @@ public class SpringMockTestExecutionListener implements TestExecutionListener {
 
       for (String beanName : mockBeanNames) {
         BeanDefinition beanDefinition = ((BeanDefinitionRegistry)applicationContext).getBeanDefinition(beanName);
-        if(beanDefinition.isAbstract()){
+        if(beanDefinition.isAbstract() || beanName.startsWith("scopedTarget.")){
             continue;
         }
         Object bean = applicationContext.getBean(beanName);


### PR DESCRIPTION
Test framework should not try to access a scopedTarget bean directly.
