### PR TITLE
Prevent Muliple Addition Of Global Extension

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/ExtensionClassesLoader.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ExtensionClassesLoader.java
@@ -33,11 +33,11 @@ public class ExtensionClassesLoader {
   }
 
   public List<Class<?>> loadClasses(String descriptorPath) {
-    List<Class<?>> extClasses = new ArrayList<Class<?>>();
+    Set<Class<?>> extClasses = new HashSet<Class<?>>();
     for (URL url : locateDescriptors(descriptorPath))
       for (String className : readDescriptor(url))
         extClasses.add(loadExtensionClass(className));
-    return extClasses;
+    return new ArrayList<Class<?>>(extClasses);
   }
 
   private List<URL> locateDescriptors(String descriptorPath) {


### PR DESCRIPTION
I just had the case that I built a Gradle project with IntelliJ IDEA. The /META-INF/services/org.spockframework.runtime.extension.IGlobalExtension file was then at build/resources/test/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension and classes/test/gradle-semantic-build-versioning/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension which were also both in the class path and so the class was two times in the list and thus was instantiated two times.

This could also happen when having two versions of a JAR with the same global extension in the class path for example. 

I cannot imagine a valid use-case for this behaviour, so I introduced the Set here that will prevent this from happening.
