### PR TITLE
Mock support: Ignore Spring beans with scope other then 'singleton' or 'prototype'

### DIFF
--- a/spock-spring/boot-test/src/main/java/org/spockframework/boot/web/HelloWorldRequestScopeController.java
+++ b/spock-spring/boot-test/src/main/java/org/spockframework/boot/web/HelloWorldRequestScopeController.java
@@ -1,0 +1,28 @@
+package org.spockframework.boot.web;
+
+import org.spockframework.boot.service.HelloWorldService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Spring-MVC controller class.
+ */
+@Scope("request")
+@RestController
+public class HelloWorldRequestScopeController {
+
+  private HelloWorldService service;
+
+  @Autowired
+  public HelloWorldRequestScopeController(HelloWorldService service) {
+    this.service = service;
+  }
+
+  @RequestMapping("/hello-from-request-scope")
+  public String hello() {
+    return service.getHelloMessage();
+  }
+
+}

--- a/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
@@ -43,8 +43,11 @@ public class SpringMockTestExecutionListener implements TestExecutionListener {
       List<Object> mockedBeans = new ArrayList<Object>();
 
       for (String beanName : mockBeanNames) {
+        if (beanName.startsWith("scopedTarget.")) {
+          continue;
+        }
         BeanDefinition beanDefinition = ((BeanDefinitionRegistry)applicationContext).getBeanDefinition(beanName);
-        if(beanDefinition.isAbstract() || beanName.startsWith("scopedTarget.")){
+        if (beanDefinition.isAbstract() || !isSupportedBeanScope(beanDefinition)) {
             continue;
         }
         Object bean = applicationContext.getBean(beanName);
@@ -59,6 +62,10 @@ public class SpringMockTestExecutionListener implements TestExecutionListener {
     } else {
       throw new IllegalArgumentException("SpringMockTestExecutionListener is only applicable for spock specifications.");
     }
+  }
+
+  private boolean isSupportedBeanScope(BeanDefinition beanDefinition) {
+    return beanDefinition.isPrototype() || beanDefinition.isSingleton();
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Preventing "Scope 'request' is not active for the current thread" errors