### PR TITLE
Redundant `static` and `public` modifiers

### DIFF
--- a/spock-core/src/main/groovy/spock/util/matcher/IsCloseTo.groovy
+++ b/spock-core/src/main/groovy/spock/util/matcher/IsCloseTo.groovy
@@ -24,7 +24,7 @@ import org.hamcrest.Description
  * <tt>Number</tt>s (in particular <tt>BigDecimal</tt>s). Otherwise almost
  * identical to that class.
  */
-public class IsCloseTo extends TypeSafeMatcher<Number> {
+class IsCloseTo extends TypeSafeMatcher<Number> {
   private final Number value
   private final Number epsilon
 

--- a/spock-core/src/main/java/org/spockframework/mock/IMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IMockFactory.java
@@ -17,7 +17,7 @@ package org.spockframework.mock;
 import spock.lang.Specification;
 
 public interface IMockFactory {
-  public boolean canCreate(IMockConfiguration configuration);
-  public Object create(IMockConfiguration configuration, Specification specification);
-  public Object createDetached(IMockConfiguration configuration, ClassLoader classLoader);
+  boolean canCreate(IMockConfiguration configuration);
+  Object create(IMockConfiguration configuration, Specification specification);
+  Object createDetached(IMockConfiguration configuration, ClassLoader classLoader);
 }

--- a/spock-core/src/main/java/org/spockframework/util/IMultiset.java
+++ b/spock-core/src/main/java/org/spockframework/util/IMultiset.java
@@ -31,7 +31,7 @@ import java.util.*;
  */
 @NotThreadSafe
 public interface IMultiset<E> extends Collection<E> {
-  public int count(E element);
+  int count(E element);
 
-  public Set<Map.Entry<E, Integer>> entrySet();
+  Set<Map.Entry<E, Integer>> entrySet();
 }

--- a/spock-guice/src/test/groovy/org/spockframework/guice/IService1.groovy
+++ b/spock-guice/src/test/groovy/org/spockframework/guice/IService1.groovy
@@ -16,6 +16,6 @@ package org.spockframework.guice
  * limitations under the License.
  */
 
-public interface IService1 {
+interface IService1 {
   String generateString()
 }

--- a/spock-guice/src/test/groovy/org/spockframework/guice/IService2.groovy
+++ b/spock-guice/src/test/groovy/org/spockframework/guice/IService2.groovy
@@ -14,6 +14,6 @@
 
 package org.spockframework.guice
 
-public interface IService2 {
-  public String generateQuickBrownFox();
+interface IService2 {
+  String generateQuickBrownFox();
 }

--- a/spock-guice/src/test/groovy/org/spockframework/guice/Service2.groovy
+++ b/spock-guice/src/test/groovy/org/spockframework/guice/Service2.groovy
@@ -15,8 +15,8 @@
 
 package org.spockframework.guice
 
-public class Service2 implements IService2 {
-  public String generateQuickBrownFox() {
+class Service2 implements IService2 {
+  String generateQuickBrownFox() {
     return "The quick brown fox jumps over the lazy dog.";
   }
 }

--- a/spock-specs/src/test.java1.8/java/org/spockframework/smoke/mock/IDeposit.java
+++ b/spock-specs/src/test.java1.8/java/org/spockframework/smoke/mock/IDeposit.java
@@ -20,7 +20,7 @@ package org.spockframework.smoke.mock;
  * A bank deposit with <a href="https://en.wikipedia.org/wiki/Compound_interest">compound interest</a>.
  */
 public interface IDeposit {
-  public static class DepositException extends Exception {
+  class DepositException extends Exception {
     public DepositException(String message) {
       super(message);
     }

--- a/spock-specs/src/test/groovy/org/spockframework/junit/JUnitRuleBehavior.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/junit/JUnitRuleBehavior.groovy
@@ -19,7 +19,7 @@ class JUnitRuleBehavior extends Base {
 
   abstract static class Base {
     @Test
-    public void ruleInDerivedClassAffectsTestInBaseClass() {
+    void ruleInDerivedClassAffectsTestInBaseClass() {
       assert this.started
     }
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/GroovyCallChain.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/GroovyCallChain.groovy
@@ -21,8 +21,8 @@ package org.spockframework.smoke
  *
  * @author Peter Niederwieser
  */
-public class GroovyCallChain {
-  public void a() {
+class GroovyCallChain {
+  void a() {
     b();
   }
 
@@ -34,13 +34,13 @@ public class GroovyCallChain {
   static void c(String foo, String bar) {
     throw new CallChainException();
   }
-    
+
   class Inner {
       def inner() {
         new StaticInner().staticInner()
       }
   }
-    
+
   static class StaticInner {
       def staticInner() {
         c("foo", "bar")

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/Fast.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/Fast.groovy
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */  
+ */
 package org.spockframework.smoke.extension
 
 import java.lang.annotation.Target
@@ -22,4 +22,4 @@ import java.lang.annotation.RetentionPolicy
 
 @Target([ElementType.TYPE, ElementType.METHOD])
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Fast {}
+@interface Fast {}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/Slow.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/Slow.groovy
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */  
+ */
 package org.spockframework.smoke.extension
 
 import java.lang.annotation.Target
@@ -22,4 +22,4 @@ import java.lang.annotation.RetentionPolicy
 
 @Target([ElementType.TYPE, ElementType.METHOD])
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Slow {}
+@interface Slow {}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitCompliance.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/junit/JUnitCompliance.groovy
@@ -22,7 +22,7 @@ import org.spockframework.EmbeddedSpecification
 import spock.lang.Issue
 import spock.util.EmbeddedSpecCompiler
 
-public class JUnitCompliance extends EmbeddedSpecification {
+class JUnitCompliance extends EmbeddedSpecification {
   @Issue("http://issues.spockframework.org/detail?id=13")
   def "failing setupSpec method"() {
     runner.throwFailure = false

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocksForGroovyClasses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocksForGroovyClasses.groovy
@@ -19,7 +19,7 @@ import org.spockframework.mock.FinalMethodsJavaPerson
 
 import spock.lang.Specification
 
-public class GroovyMocksForGroovyClasses extends Specification {
+class GroovyMocksForGroovyClasses extends Specification {
   def person = GroovyMock(Person)
 
   def "physical method"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocksForInterfaces.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocksForInterfaces.groovy
@@ -16,7 +16,7 @@ package org.spockframework.smoke.mock
 
 import spock.lang.Specification
 
-public class GroovyMocksForInterfaces extends Specification {
+class GroovyMocksForInterfaces extends Specification {
   def person = GroovyMock(Person)
 
   def "physical method"() {

--- a/spock-spring/src/test/groovy/org/spockframework/spring/IService2.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/IService2.groovy
@@ -14,6 +14,6 @@
 
 package org.spockframework.spring
 
-public interface IService2 {
+interface IService2 {
   String generateQuickBrownFox()
 }

--- a/spock-spring/src/test/groovy/org/spockframework/spring/MockInjectionWithEmbeddedConfig.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/MockInjectionWithEmbeddedConfig.groovy
@@ -18,12 +18,12 @@ class MockInjectionWithEmbeddedConfig extends Specification {
     private DetachedMockFactory factory = new DetachedMockFactory()
 
     @Bean
-    public IService1 service1() {
+    IService1 service1() {
         return factory.Mock(IService1, name: "service1")
     }
 
     @Bean
-    public IService2 service2() {
+    IService2 service2() {
         return factory.Mock(IService2, name: "service2")
     }
   }

--- a/spock-spring/src/test/groovy/org/spockframework/spring/Service1.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/Service1.groovy
@@ -16,7 +16,7 @@
 
 package org.spockframework.spring
 
-public class Service1 implements IService1 {
+class Service1 implements IService1 {
   private IService2 service2
 
   Service1(Service2 service2) {

--- a/spock-spring/src/test/groovy/org/spockframework/spring/docs/DetachedJavaConfig.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/docs/DetachedJavaConfig.groovy
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean
 import spock.mock.DetachedMockFactory
 
 //tag::javaconfig[]
-public class DetachedJavaConfig {
+class DetachedJavaConfig {
   def mockFactory = new DetachedMockFactory()
 
   @Bean

--- a/spock-spring/src/test/groovy/org/spockframework/spring/docs/GreeterService.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/docs/GreeterService.groovy
@@ -1,5 +1,5 @@
 package org.spockframework.spring.docs;
 
-public interface GreeterService {
+interface GreeterService {
   String getGreeting()
 }

--- a/spock-tapestry/src/test/java/org/spockframework/tapestry/IService1.java
+++ b/spock-tapestry/src/test/java/org/spockframework/tapestry/IService1.java
@@ -17,5 +17,5 @@
 package org.spockframework.tapestry;
 
 public interface IService1 {
-  public String generateString();
+  String generateString();
 }

--- a/spock-tapestry/src/test/java/org/spockframework/tapestry/IService2.java
+++ b/spock-tapestry/src/test/java/org/spockframework/tapestry/IService2.java
@@ -17,5 +17,5 @@
 package org.spockframework.tapestry;
 
 public interface IService2 {
-  public String generateQuickBrownFox();
+  String generateQuickBrownFox();
 }

--- a/spock-tapestry/src/test/java/org/spockframework/tapestry/IService3.java
+++ b/spock-tapestry/src/test/java/org/spockframework/tapestry/IService3.java
@@ -17,5 +17,5 @@
 package org.spockframework.tapestry;
 
 public interface IService3 {
-  public String generateString();
+  String generateString();
 }


### PR DESCRIPTION
This pull request removes redundant `public` and `static` modifiers where it is possible.
In case of Java, only interfaces were cleaned up. While in Groovy all unnecessary modifiers were removed.

[Java Specification](https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html):

>Every field declaration in the body of an interface is implicitly `public`, `static`, and `final`. It is permitted to redundantly specify any or all of these modifiers for such fields.

[Groovy documentation](http://groovy-lang.org/style-guide.html#_public_by_default):
>By default, Groovy considers classes and methods public. So you don’t have to use the public modifier everywhere something is public.


