### PR TITLE
Better default response for CompletableFuture

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/EmptyOrDummyResponse.java
+++ b/spock-core/src/main/java/org/spockframework/mock/EmptyOrDummyResponse.java
@@ -37,10 +37,14 @@ import spock.lang.Specification;
 public class EmptyOrDummyResponse implements IDefaultResponse {
   public static final EmptyOrDummyResponse INSTANCE = new EmptyOrDummyResponse();
   private static final Class<?> OPTIONAL = ReflectionUtil.loadClassIfAvailable("java.util.Optional");
+  private static final Class<?> COMPLETABLE_FUTURE = ReflectionUtil.loadClassIfAvailable("java.util.concurrent.CompletableFuture");
   private static final Method optionalEmptyMethod;
+  private static final Method completableFutureCompletedFutureMethod;
 
   static {
     optionalEmptyMethod = OPTIONAL == null ? null : ReflectionUtil.getDeclaredMethodByName(OPTIONAL, "empty");
+    completableFutureCompletedFutureMethod = COMPLETABLE_FUTURE == null ? null :
+      ReflectionUtil.getDeclaredMethodByName(COMPLETABLE_FUTURE, "completedFuture");
   }
 
   private EmptyOrDummyResponse() {}
@@ -90,6 +94,7 @@ public class EmptyOrDummyResponse implements IDefaultResponse {
     }
 
     if (returnType == OPTIONAL) return ReflectionUtil.invokeMethod(null, optionalEmptyMethod);
+    if (returnType == COMPLETABLE_FUTURE) return ReflectionUtil.invokeMethod(null, completableFutureCompletedFutureMethod, (Object) null);
 
     Object emptyWrapper = createEmptyWrapper(returnType);
     if (emptyWrapper != null) return emptyWrapper;

--- a/spock-specs/src/test.java1.8/groovy/org/spockframework/smoke/mock/CompletableFutureSpec.groovy
+++ b/spock-specs/src/test.java1.8/groovy/org/spockframework/smoke/mock/CompletableFutureSpec.groovy
@@ -1,0 +1,24 @@
+package org.spockframework.smoke.mock
+
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+
+class CompletableFutureSpec extends Specification {
+
+  def "default answer for CompletableFuture should be completed future"() {
+    given:
+    TestService service = Stub()
+
+    when:
+    CompletableFuture<String> receivedFuture = service.future
+
+    then:
+    receivedFuture.done
+    !receivedFuture.completedExceptionally
+  }
+
+  interface TestService {
+    CompletableFuture<String> getFuture()
+  }
+}

--- a/spock-specs/src/test.java1.8/groovy/org/spockframework/smoke/mock/OptionalSpec.groovy
+++ b/spock-specs/src/test.java1.8/groovy/org/spockframework/smoke/mock/OptionalSpec.groovy
@@ -14,8 +14,9 @@ class OptionalSpec extends Specification {
     then:
     !result.present
   }
+
+  interface TestService {
+    Optional<String> getValue()
+  }
 }
 
-interface TestService {
-  Optional<String> getValue()
-}


### PR DESCRIPTION
sually it is better to get already completed future with (any) value waiting to be returned than wait forever on `get()`.