### PR TITLE
support later groovy versions including 3.0+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,11 @@ plugins {
 description = "Spock Framework"
 
 ext {
+  baseVersion = "1.1"
+  snapshotVersion = true
+  releaseCandidate = 0
   variants = [2.0, 2.3, 2.4]
   variant = System.getProperty("variant") as BigDecimal ?: variants.last()
-  snapshotVersion = true
   if (variant == 2.0) {
     groovyVersion = "2.0.8"
     minGroovyVersion = "2.0.0"
@@ -25,12 +27,10 @@ ext {
   } else {
     throw new InvalidUserDataException("Unknown variant: $variant. Choose one of: $variants")
   }
-  javaVersions = [1.6, 1.7, 1.8]
-  javaVersion = System.getProperty("java.specification.version") as BigDecimal
-  baseVersion = "1.1"
-  releaseCandidate = 0
   fullVersion = "$baseVersion-groovy-$variant" + (snapshotVersion ? "-SNAPSHOT" :  (releaseCandidate ? "-rc-$releaseCandidate" : ""))
   variantLessVersion = baseVersion + (snapshotVersion ? "-SNAPSHOT" : (releaseCandidate ? "-rc-$releaseCandidate" : ""))
+  javaVersions = [1.6, 1.7, 1.8]
+  javaVersion = System.getProperty("java.specification.version") as BigDecimal
   libs = [
     jetbrainsAnnotations: "org.jetbrains:annotations:13.0",
     ant: "org.apache.ant:ant:1.9.7",

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ description = "Spock Framework"
 ext {
   variants = [2.0, 2.3, 2.4]
   variant = System.getProperty("variant") as BigDecimal ?: variants.last()
+  snapshotVersion = true
   if (variant == 2.0) {
     groovyVersion = "2.0.8"
     minGroovyVersion = "2.0.0"
@@ -18,16 +19,15 @@ ext {
     minGroovyVersion = "2.3.0"
     maxGroovyVersion = "2.3.99"
   } else if (variant == 2.4) {
-    groovyVersion = "2.4.6"
+    groovyVersion = "2.4.9"
     minGroovyVersion = "2.4.0"
-    maxGroovyVersion = "2.9.99"
+    maxGroovyVersion = snapshotVersion ? "3.9.99" : "2.9.99" // TODO lock these down once Groovy 3 gets close to RC stage
   } else {
     throw new InvalidUserDataException("Unknown variant: $variant. Choose one of: $variants")
   }
   javaVersions = [1.6, 1.7, 1.8]
   javaVersion = System.getProperty("java.specification.version") as BigDecimal
   baseVersion = "1.1"
-  snapshotVersion = true
   releaseCandidate = 0
   fullVersion = "$baseVersion-groovy-$variant" + (snapshotVersion ? "-SNAPSHOT" :  (releaseCandidate ? "-rc-$releaseCandidate" : ""))
   variantLessVersion = baseVersion + (snapshotVersion ? "-SNAPSHOT" : (releaseCandidate ? "-rc-$releaseCandidate" : ""))

--- a/spock-core/src/main/java/org/spockframework/runtime/ConfigurationScriptLoader.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ConfigurationScriptLoader.java
@@ -116,10 +116,15 @@ public class ConfigurationScriptLoader {
     if (url == null) return null;
 
     GroovyShell shell = createShell();
+    GroovyCodeSource codeSource = null;
+    // try block below for compatibility pre/post Groovy 2.4.7 (see GROOVY-8126)
     try {
-      return (DelegatingScript) shell.parse(new GroovyCodeSource(url));
-    } catch (IOException e) {
+      codeSource = new GroovyCodeSource(url);
+    } catch (Exception e) {
       throw new ConfigurationException("Error reading configuration script '%s'", location);
+    }
+    try {
+      return (DelegatingScript) shell.parse(codeSource);
     } catch (CompilationFailedException e) {
       throw new ConfigurationException("Error compiling configuration script '%s'", location);
     }


### PR DESCRIPTION
Hi, a PR for supporting later versions of Groovy. We are currently wanting to move Groovy master to 3.0.0 but have held back since we currently use some Spock tests in some of the modules.

Locally when testing this I changed the baseVersion to 1.2 but didn't include that in the PR as I am not sure what your plans are in that regard. Perhaps it is time for a 1.1 branch and this could go on a master branch along with things like PR#632?

At the moment there aren't any breaking changes in master that we are aware of, so I didn't make another variant. (There is possibly a change in 2.4.10 which impacts Spock but that is another issue - run the Spock build using 2.4.10 and see test failures if you want details).

We are however about to merge a bunch of largish features into later branches, so we'll need to track what happens as we go. As long as you are only releasing SNAPSHOTs in the 1.2 stream and Groovy is only doing SNAPSHOTs too, I think all should be good.