### PR TITLE
Fix issue with aborted build on Travis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,9 @@ subprojects {
         destination = file("$destination/$variant")
       }
     }
+    //Required for building on Travis' container-based infrastructure to not be killed with
+    //'exit code 137' - https://github.com/travis-ci/travis-ci/issues/5582
+    jvmArgs '-Xmx512m'
   }
 }
 


### PR DESCRIPTION
At least a try to fix it. However, it helped in [Mockito](https://github.com/mockito/mockito/commit/d45fecfabc98a0f5d972886dd0541cdb69b41ca4) and micro-infra-spring to get rid of that issues after switching to container-based architecture.

Error message:
Process 'Gradle Test Executor 23' finished with non-zero exit value 137

Related Travis issue: https://github.com/travis-ci/travis-ci/issues/5582