### PR TITLE
Add code coverage with jacoco and codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,12 @@ matrix:
 
 install: true
 
-script: ./gradlew --no-daemon travisCiBuild -Dvariant=$VARIANT -Dscan
+script: 
+  - ./gradlew --no-daemon --version
+  - ./gradlew --no-daemon travisCiBuild -Dvariant=$VARIANT -Dscan
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.spockframework/spock-core.svg?label=Maven%20Central)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.spockframework%22%20AND%20a%3A%22spock-core%22)
 [![Linux Build Status](https://img.shields.io/travis/spockframework/spock/master.svg?label=Linux%20Build)](https://travis-ci.org/spockframework/spock)
 [![Windows Build Status](https://img.shields.io/appveyor/ci/spockframework/spock/master.svg?label=Windows%20Build)](https://ci.appveyor.com/project/spockframework/spock/branch/master)
+[![Codecov](https://codecov.io/gh/spockframework/spock/branch/master/graph/badge.svg)](https://codecov.io/gh/spockframework/spock)
 [![Gitter](https://badges.gitter.im/spockframework/spock.svg)](https://gitter.im/spockframework/spock?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Spock Framework

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
 shallow_clone: true
 
 build_script:
+  - gradlew --no-daemon --version
   - gradlew --no-daemon appveyorCiBuild -Dscan
 
 test: off

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'com.gradle.build-scan' version '1.1.1'
   id "base"
   id "org.asciidoctor.gradle.asciidoctor" version "1.5.1"
+  id "jacoco"
 }
 
 description = "Spock Framework"
@@ -65,6 +66,7 @@ apply from: script("ide")
 
 subprojects {
   apply plugin: "groovy"
+  apply plugin: "jacoco"
   apply plugin: "signing"
 
   sourceCompatibility = javaVersions.min()
@@ -153,12 +155,13 @@ subprojects {
   testCglib.mustRunAfter test
 
   tasks.withType(Test) {
+    def taskName = name
     reports {
       junitXml {
-        destination = file("$destination/$variant")
+        destination = file("$destination/$taskName-$variant")
       }
       html {
-        destination = file("$destination/$variant")
+        destination = file("$destination/$taskName-$variant")
       }
     }
     //Required for building on Travis' container-based infrastructure to not be killed with
@@ -167,8 +170,35 @@ subprojects {
   }
 }
 
+task codeCoverageReport (type: JacocoReport, group: 'Coverage reports') {
+  description = "Creates an aggregate coverage for the whole project."
+  def reportingProjects = subprojects.findAll()
+  dependsOn(reportingProjects.tasks.collectMany{it.withType(Test)})
+
+  onlyIf = { true } // required to circumvent a wrong check in the jacoco report plugin (v2.13)
+
+  sourceDirectories = files() //must be set
+  classDirectories = files()  //must be set
+  additionalSourceDirs files(reportingProjects.sourceSets.main.allSource.srcDirs)
+  additionalClassDirs files(reportingProjects.sourceSets.main.output)
+
+  executionData = files(reportingProjects.jacocoTestReport.executionData)
+
+  doFirst {
+    // find all *.exec files
+    executionData = fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+  }
+
+  reports {
+    html.enabled = true
+    xml.enabled = true
+    xml.destination "${buildDir}/reports/jacoco/report.xml" // report must be here for codecov to pick it up
+    csv.enabled = false
+  }
+}
+
 if (gradle.startParameter.taskNames == ["travisCiBuild"]) {
-  gradle.startParameter.taskNames = ["build"]
+  gradle.startParameter.taskNames = ["build", "codeCoverageReport"]
   subprojects {
     tasks.withType(Test) {
       maxParallelForks = 2

--- a/shippable.yml
+++ b/shippable.yml
@@ -25,4 +25,5 @@ before_script:
   - java -version
 
 script:
+  - ./gradlew --no-daemon --version
   - ./gradlew --no-daemon shippableCiBuild -Dvariant=$VARIANT -Dscan

--- a/spock-bom/bom.gradle
+++ b/spock-bom/bom.gradle
@@ -67,8 +67,10 @@ def bom = {
     }
   }
 }
-task writeBom << {
-  pom(bom).withXml(modifyBom) .writeTo("$buildDir/pom.xml")
+task writeBom {
+  doLast {
+    pom(bom).withXml(modifyBom) .writeTo("$buildDir/pom.xml")
+  }
 }
 
 def deployers = []


### PR DESCRIPTION
Test results are now put into a folder that includes the test task name
to prevent two different test tasks to override each others result, and
thus requiring a rebuild instead of staying up-to-date.

Also replaced deprecated task.leftShift with doLast