### PR TITLE
Allow to reset a blocking variable

### DIFF
--- a/spock-core/src/main/java/spock/util/concurrent/BlockingVariable.java
+++ b/spock-core/src/main/java/spock/util/concurrent/BlockingVariable.java
@@ -60,7 +60,7 @@ public class BlockingVariable<T> {
   private final double timeout;
 
   private T value; // access guarded by valueReady
-  private final CountDownLatch valueReady = new CountDownLatch(1);
+  private CountDownLatch valueReady;
 
   /**
    * Same as <tt>BlockingVariable(1)</tt>.
@@ -76,6 +76,7 @@ public class BlockingVariable<T> {
    */
   public BlockingVariable(double timeout) {
     this.timeout = timeout;
+    this.reset();
   }
 
   /**
@@ -123,5 +124,14 @@ public class BlockingVariable<T> {
   public void set(T value) {
     this.value = value;
     valueReady.countDown();
+  }
+
+  /**
+   * Resets this <tt>BlockingVariable</tt> to its initial state. That affects all
+   * operations currently working on this object.
+   */
+  public void reset() {
+    value = null;
+    valueReady = new CountDownLatch(1);
   }
 }

--- a/spock-core/src/main/java/spock/util/concurrent/BlockingVariablesImpl.java
+++ b/spock-core/src/main/java/spock/util/concurrent/BlockingVariablesImpl.java
@@ -27,7 +27,7 @@ class BlockingVariablesImpl {
   public BlockingVariablesImpl(double timeout) {
     this.timeout = timeout;
   }
-  
+
   public Object get(String name) throws InterruptedException {
     BlockingVariable<Object> entry = new BlockingVariable<Object>(timeout);
     BlockingVariable<Object> oldEntry = map.putIfAbsent(name, entry);

--- a/spock-specs/src/test/groovy/spock/util/concurrent/BlockingVariableSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/concurrent/BlockingVariableSpec.groovy
@@ -67,4 +67,26 @@ class BlockingVariableSpec extends Specification {
     then:
     thrown(SpockTimeoutError)
   }
+
+  def "reset allows to use the same blocking variable several times in a row"() {
+    def blockingVar = new BlockingVariable<String>(1, TimeUnit.MILLISECONDS)
+
+    when:
+    blockingVar.set("foo")
+    then:
+    blockingVar.get() == "foo"
+    blockingVar.get() == "foo"
+    blockingVar.get() == "foo"
+
+    when:
+    blockingVar.reset()
+    blockingVar.get()
+    then:
+    thrown(SpockTimeoutError)
+
+    when:
+    blockingVar.set("bar")
+    then:
+    blockingVar.get() == "bar"
+  }
 }


### PR DESCRIPTION
Often it's needed to use the same `BlockingVariable` again but reset it. E.g. when the variable is used for Messaging and is contained in a consumer. Than it isn't always that easy to replace the existing variable with a new instance. So I added a simple reset method which resets the `value` and the `CountDownLatch` of the `BlockingVariable`.

This also was suggested in 
https://github.com/spockframework/spock/issues/312

So it is now possible to do:

```
BlockingVariable<String> b = ...
// do something async with the var

when:
sender.send("val1")
then:
b.get() == "val1"

when:
b.reset()
sender.send("val2")
then:
b.get() == "val2"

when:
b.reset()
sender.error();
b.get()
then:
thrown(SpockTimeoutError)
```

(I know, this samples can be split up to own tests, but there are other circumstances where such cases are needed)