### PR TITLE
Fix ExpressionInfoValueRenderer.renderAsFailedStringComparison overflow

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionRenderingSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionRenderingSpec.groovy
@@ -16,9 +16,8 @@
 
 package org.spockframework.smoke.condition
 
-import org.spockframework.runtime.ConditionNotSatisfiedError
 import org.spockframework.runtime.Condition
-
+import org.spockframework.runtime.ConditionNotSatisfiedError
 import spock.lang.Specification
 
 /**
@@ -36,6 +35,18 @@ abstract class ConditionRenderingSpec extends Specification {
       condition()
     } catch (ConditionNotSatisfiedError e) {
       isRendered(expectedRendering, e.condition)
+      return
+    }
+
+    assert false, "condition should have failed but didn't"
+  }
+
+  void renderedConditionContains(Closure condition, String... contents) {
+    try {
+      condition()
+    } catch (ConditionNotSatisfiedError e) {
+      String rendering = e.condition.rendering.trim()
+      contents.each { assert rendering.contains(it)}
       return
     }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/StringComparisonRendering.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/StringComparisonRendering.groovy
@@ -16,6 +16,7 @@
 
 package org.spockframework.smoke.condition
 
+import org.spockframework.runtime.ExpressionInfoValueRenderer
 import spock.lang.Issue
 
 class StringComparisonRendering extends ConditionRenderingSpec {
@@ -77,5 +78,97 @@ null == "foo"
     """, {
       assert ("the quick" == "the quick") instanceof String
     }
+  }
+  @Issue("https://github.com/spockframework/spock/issues/121")
+  def "large String comparision does not cause OOM-Error, difference at start"() {
+    StringBuilder sb = largeStringBuilder()
+    String a = sb.toString()
+    sb.setCharAt(0, 'b'  as char)
+    String b = sb.toString()
+
+    expect:
+    renderedConditionContains({
+      assert a == b
+    },
+      "1 difference (90% similarity) (comparing subset start: 0, end1: 11, end2: 11)",
+      "(a)aaaaaaaaaa",
+      "(b)aaaaaaaaaa"
+    )
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/121")
+  def "large String comparision does not cause OOM-Error, difference in the middle"() {
+    StringBuilder sb = largeStringBuilder()
+    String a = sb.toString()
+    sb.setCharAt(sb.length() / 2 as int, 'b'  as char)
+    String b = sb.toString()
+
+    expect:
+    renderedConditionContains({
+      assert a == b
+    },
+      "1 difference (95% similarity) (comparing subset start: 12789, end1: 12811, end2: 12811)",
+      "aaaaaaaaaaa(a)aaaaaaaaaa",
+      "aaaaaaaaaaa(b)aaaaaaaaaa"
+    )
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/121")
+  def "large String comparision does not cause OOM-Error, difference at end"() {
+    StringBuilder sb = largeStringBuilder()
+    String a = sb.toString()
+    sb.setCharAt(sb.length()-1, 'b'  as char)
+    String b = sb.toString()
+
+    expect:
+    renderedConditionContains({
+      assert a == b
+    },
+      "1 difference (91% similarity) (comparing subset start: 25588, end1: 25600, end2: 25600)",
+      "aaaaaaaaaaa(a)",
+      "aaaaaaaaaaa(b)")
+  }
+
+
+
+  @Issue("https://github.com/spockframework/spock/issues/121")
+  def "large String comparision does not cause OOM-Error, difference at start and  end"() {
+    StringBuilder sb = largeStringBuilder()
+    String a = sb.toString()
+    sb.setCharAt(0, 'b'  as char)
+    sb.setCharAt(sb.length()-1, 'b'  as char)
+    String b = sb.toString()
+
+    expect:
+    renderedConditionContains({
+      assert a == b
+    },
+      "false",
+      "Strings too large to calculate edit distance.")
+  }
+
+
+  @Issue("https://github.com/spockframework/spock/issues/121")
+  def "large String comparision does not cause OOM-Error, complete difference"() {
+    String a = largeStringBuilder()
+    String b = largeStringBuilder("bbbbbbbbbbbbbbbb")
+
+
+    expect:
+    renderedConditionContains({
+      assert a == b
+    },
+      "false",
+      "Strings too large to calculate edit distance.")
+  }
+
+  private StringBuilder largeStringBuilder(CharSequence source = "aaaaaaaaaaaaaaaa") {
+    int length = ExpressionInfoValueRenderer.MAX_EDIT_DISTANCE_MEMORY / 2
+    def sb = new StringBuilder(length + 10)
+    int cslength = source.length()
+    for (int i = 0; i < length; i += cslength) {
+      sb.append(source, 0, Math.min(length - i, cslength))
+    }
+    return sb
   }
 }


### PR DESCRIPTION
This fixes some bugs that were introduced in #706:

The length check in renderAsFailedStringComparison did overflow, so we need to cast it to long first. Also add some more info when the OOM protection kicks in. Furthermore, decrease the the memory limit from
1mb to 50kb. And add some specs for tryReduceStringSizes.
