### PR TITLE
Add ReusableBlockingVariable to allow reset the state of the variable…

### DIFF
--- a/spock-core/src/main/java/spock/util/concurrent/ReuseableBlockingVariable.java
+++ b/spock-core/src/main/java/spock/util/concurrent/ReuseableBlockingVariable.java
@@ -1,0 +1,117 @@
+package spock.util.concurrent;
+
+
+import org.spockframework.runtime.SpockTimeoutError;
+import org.spockframework.util.ThreadSafe;
+import org.spockframework.util.TimeUtil;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Behaves like <tt>BlockingVariable</tt> except that it can be reset
+ * to it's initial state.
+ *
+ * <p>Example:
+ * <pre>
+ *
+ * def result = new ReuseableBlockingVariable&lt;WorkResult&gt;
+ *
+ * // register async callback
+ * queueListener.receive << { r ->
+ *  result.set(r)
+ * }
+ *
+ * when:
+ * queue.send("a")
+ *
+ * then:
+ * // blocks until workDone callback has set result, or a timeout expires
+ * result.get() == "a"
+ *
+ * when:
+ * // resets the internal state to ensure that successive get's wait for a new value to be set
+ * result.reset()
+ * queue.send("a")
+ *
+ * then:
+ * // blocks until workDone callback has set result, or a timeout expires
+ * result.get() == "b"
+ * </pre>
+ *
+ * @see BlockingVariable
+ * @author Günther Grill
+ */
+@ThreadSafe
+public class ReuseableBlockingVariable<T> {
+  private static final int DEFAULT_TIMEOUT_SEC = 1;
+
+  private final double timeout;
+  private BlockingVariable<T> blockingVariable;
+
+  /**
+   * Instantiates a <tt>ReuseableBlockingVariable</tt> with a timeout of one second.
+   */
+  public ReuseableBlockingVariable() {
+    this(DEFAULT_TIMEOUT_SEC);
+  }
+
+  /**
+   * Instantiates a <tt>ReuseableBlockingVariable</tt> with the specified timeout in seconds.
+   *
+   * @param timeout the timeout (in seconds) for calls to <tt>get()</tt>.
+   */
+  public ReuseableBlockingVariable(double timeout) {
+    this.timeout = timeout;
+    this.blockingVariable = new BlockingVariable<T>(timeout);
+  }
+
+  /**
+   * Instantiates a <tt>ReuseableBlockingVariable</tt> with the specified timeout.
+   *
+   * @param timeout the timeout for calls to <tt>get()</tt>.
+   * @param unit the time unit
+   */
+  public ReuseableBlockingVariable(long timeout, TimeUnit unit) {
+    this(TimeUtil.toSeconds(timeout, unit));
+  }
+
+  /**
+   * Returns the timeout (in seconds).
+   *
+   * @return the timeout (in seconds)
+   */
+  public double getTimeout() {
+    return timeout;
+  }
+
+  /**
+   * Blocks until a value has been set for this variable, or a timeout expires.
+   * The wait process won't be interrupted when the <tt>rest</tt> is called.
+   *
+   * @return the variable's value
+   *
+   * @throws SpockTimeoutError if the timeout is reached
+   * @throws InterruptedException if the calling thread is interrupted
+   */
+  public T get() throws InterruptedException {
+    return blockingVariable.get();
+  }
+
+  /**
+   * Sets a value for this variable. Wakes up all threads blocked in <tt>get()</tt>.
+   *
+   *
+   * @param value the value to be set for this variable
+   */
+  public void set(T value) {
+    blockingVariable.set(value);
+  }
+
+  /**
+   * Resets this <tt>ReuseableBlockingVariable</tt> to its initial state. That affects all
+   * operations currently working on this object.
+   */
+  public void reset() {
+    blockingVariable = new BlockingVariable<T>();
+  }
+}

--- a/spock-specs/src/test/groovy/spock/util/concurrent/ReuseableBlockingVariableSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/concurrent/ReuseableBlockingVariableSpec.groovy
@@ -1,0 +1,94 @@
+
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spock.util.concurrent
+
+import org.spockframework.runtime.SpockTimeoutError
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+class ReuseableBlockingVariableSpec extends Specification {
+
+  def "variable is read after it is written"() {
+    def list = new ReuseableBlockingVariable<List<Integer>>()
+
+    when:
+    Thread.start {
+      list.set([1, 2, 3])
+    }
+    Thread.yield()
+    sleep(500)
+
+    then:
+    list.get() == [1, 2, 3]
+  }
+
+  def "variable is read before it is written"() {
+    def list = new ReuseableBlockingVariable<List<String>>()
+
+    when:
+    Thread.start {
+      list.set([1, 2, 3])
+      Thread.yield()
+      sleep(500)
+    }
+
+    then:
+    list.get() == [1, 2, 3]
+  }
+
+  def "read times out if no write occurs"() {
+    def list = new ReuseableBlockingVariable<String>()
+
+    when:
+    list.get()
+
+    then:
+    thrown(SpockTimeoutError)
+  }
+
+  def "timeout is configurable"() {
+    def list = new ReuseableBlockingVariable<String>(1, TimeUnit.MILLISECONDS)
+
+    when:
+    list.get()
+
+    then:
+    thrown(SpockTimeoutError)
+  }
+
+  def "reset allows to use the same blocking variable several times in a row"() {
+    def blockingVar = new ReuseableBlockingVariable<String>(1, TimeUnit.MILLISECONDS)
+
+    when:
+    blockingVar.set("foo")
+    then:
+    blockingVar.get() == "foo"
+    blockingVar.get() == "foo"
+    blockingVar.get() == "foo"
+
+    when:
+    blockingVar.reset()
+    blockingVar.get()
+    then:
+    thrown(SpockTimeoutError)
+
+    when:
+    blockingVar.set("bar")
+    then:
+    blockingVar.get() == "bar"
+  }
+}


### PR DESCRIPTION
Often it's needed to use the same BlockingVariable again but reset it. E.g. when the variable is used for Messaging and is contained in a consumer. Than it isn't always that easy to replace the existing variable with a new instance. So I added a simple reset method which resets the value and the CountDownLatch of the BlockingVariable.

This also was suggested in
#312

So it is now possible to do:

```
BlockingVariable<String> b = ...
// do something async with the var

when:
sender.send("val1")
then:
b.get() == "val1"

when:
b.reset()
sender.send("val2")
then:
b.get() == "val2"

when:
b.reset()
sender.error();
b.get()
then:
thrown(SpockTimeoutError)
```

(I know, this samples can be split up to own tests, but there are other circumstances where such cases are needed)