### PR TITLE
Fix URL to Spring Boot examples.

### DIFF
--- a/docs/module_spring.adoc
+++ b/docs/module_spring.adoc
@@ -56,7 +56,7 @@ include::{sourcedir-spring-boot}/WebMvcTestIntegrationSpec.groovy[tag=include]
 ----
 
 
-For more examples see the specs in the https://github.com/spockframework/spock/tree/master/spock-spring/src/test/groovy/org/spockframework/spring[codebase] and https://github.com/spockframework/spock/tree/master/spock-spring/src/test/groovy/org/spockframework/spring/boot-test[boot examples].
+For more examples see the specs in the https://github.com/spockframework/spock/tree/master/spock-spring/src/test/groovy/org/spockframework/spring[codebase] and https://github.com/spockframework/spock/tree/master/spock-spring/boot-test/src/test/groovy/org/spockframework/boot[boot examples].
 
 == Scopes
 


### PR DESCRIPTION
Current URL linked on "boot examples" on http://spockframework.org/spock/docs/1.1/modules.html (waaaaay down at the bottom) gives a 404.

Current URL (404): https://github.com/spockframework/spock/tree/master/spock-spring/src/test/groovy/org/spockframework/spring/boot-test
Correct URL: https://github.com/spockframework/spock/tree/master/spock-spring/boot-test/src/test/groovy/org/spockframework/boot