### PR TITLE
Enable early injection for Spring ...

### DIFF
--- a/spock-spring/src/main/java/org/spockframework/spring/SpringExtension.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringExtension.java
@@ -72,6 +72,7 @@ public class SpringExtension extends AbstractGlobalExtension {
     });
 
     spec.addSetupSpecInterceptor(interceptor);
+    spec.addInitializerInterceptor(interceptor);
     spec.addSetupInterceptor(interceptor);
     spec.addCleanupInterceptor(interceptor);
     spec.addCleanupSpecInterceptor(interceptor);

--- a/spock-spring/src/main/java/org/spockframework/spring/SpringInterceptor.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringInterceptor.java
@@ -38,8 +38,12 @@ public class SpringInterceptor extends AbstractMethodInterceptor {
   }
 
   @Override
-  public void interceptSetupMethod(IMethodInvocation invocation) throws Throwable {
+  public void interceptInitializerMethod(IMethodInvocation invocation) throws Throwable {
     manager.prepareTestInstance(invocation.getInstance());
+  }
+
+  @Override
+  public void interceptSetupMethod(IMethodInvocation invocation) throws Throwable {
     exception = null;
     beforeTestMethodInvoked = true;
     manager.beforeTestMethod(invocation.getInstance(),


### PR DESCRIPTION
by moving `prepareTestInstance` from `interceptSetupMethod` to
`interceptInitializerMethod` which is called directly after instance
creation and is already used by the `GuiceExtension`
and `TapestryExtension`.