### PR TITLE
Use EmptyStatement.INSTANCE to get the instance

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
@@ -640,7 +640,7 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
   private TryCatchStatement surroundWithTryCatch(Expression condition, Expression message, Expression executeAndVerify) {
     final TryCatchStatement tryCatchStatement = new TryCatchStatement(
         new ExpressionStatement(executeAndVerify),
-        new EmptyStatement()
+        EmptyStatement.INSTANCE
     );
 
     tryCatchStatement.addCatch(


### PR DESCRIPTION
Since EmptyStatement will be made singleton, its constructor will be removed soon, so use EmptyStatement.INSTANCE instead to get the instance.

https://github.com/apache/groovy/blob/fa3c2719c594ca7710e976dd5330a2e442713551/src/main/org/codehaus/groovy/ast/stmt/EmptyStatement.java#L40