### PR TITLE
Add JPMS module name definition in MANIFEST.MF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,11 @@
+import java.text.SimpleDateFormat
+
 plugins {
   id 'com.gradle.build-scan' version '1.8'
   id "base"
   id "org.asciidoctor.gradle.asciidoctor" version "1.5.1"
   id "jacoco"
+  id "net.nemerosa.versioning" version "2.6.0"
 }
 
 description = "Spock Framework"
@@ -39,6 +42,9 @@ ext {
     log4j: "log4j:log4j:1.2.17",
     objenesis: "org.objenesis:objenesis:2.5.1"
   ]
+  Date buildTimeAndDate = new Date()
+  buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
+  buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
 }
 
 allprojects {

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -23,6 +23,19 @@ dependencies {
 jar {
   manifest {
     name = 'spock-core'
+    attributes(
+      'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+      'Build-Date': buildDate,
+      'Build-Time': buildTime,
+      'Build-Revision': versioning.info.commit,
+      'Specification-Title': project.name,
+      'Specification-Version': baseVersion,
+      'Specification-Vendor': 'spockframework.org',
+      'Implementation-Title': project.name,
+      'Implementation-Version': variantLessVersion,
+      'Implementation-Vendor': 'spockframework.org',
+      'Automatic-Module-Name': 'org.spockframework'
+    )
     instruction 'Export-Package', 'org.spockframework.*', 'spock.*'
     instruction 'Embed-Dependency', 'groovy;inline=false', 'junit;inline=false'
     instruction 'Import-Package',

--- a/spock-guice/guice.gradle
+++ b/spock-guice/guice.gradle
@@ -10,3 +10,21 @@ dependencies {
   // surfaces in the Guice API; groovyc complains if we don't add it
   compile "aopalliance:aopalliance:1.0", internal
 }
+
+jar {
+  manifest {
+    attributes(
+      'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+      'Build-Date': buildDate,
+      'Build-Time': buildTime,
+      'Build-Revision': versioning.info.commit,
+      'Specification-Title': project.name,
+      'Specification-Version': baseVersion,
+      'Specification-Vendor': 'spockframework.org',
+      'Implementation-Title': project.name,
+      'Implementation-Version': variantLessVersion,
+      'Implementation-Vendor': 'spockframework.org',
+      'Automatic-Module-Name': 'org.spockframework.guice'
+    )
+  }
+}

--- a/spock-report/report.gradle
+++ b/spock-report/report.gradle
@@ -11,6 +11,24 @@ dependencies {
   // "com.fasterxml.jackson.core:jackson-databind:2.1.2"
 }
 
+jar {
+  manifest {
+    attributes(
+      'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+      'Build-Date': buildDate,
+      'Build-Time': buildTime,
+      'Build-Revision': versioning.info.commit,
+      'Specification-Title': project.name,
+      'Specification-Version': baseVersion,
+      'Specification-Vendor': 'spockframework.org',
+      'Implementation-Title': project.name,
+      'Implementation-Version': variantLessVersion,
+      'Implementation-Vendor': 'spockframework.org',
+      'Automatic-Module-Name': 'org.spockframework.report'
+    )
+  }
+}
+
 test {
   exclude "org/spockframework/report/sample/ParameterizedFightSpec.class"
   exclude "org/spockframework/report/sample/FightOrFlightStory.class"

--- a/spock-spring/spring.gradle
+++ b/spock-spring/spring.gradle
@@ -26,3 +26,21 @@ dependencies {
   testRuntime libs.h2database
   testRuntime libs.log4j
 }
+
+jar {
+  manifest {
+    attributes(
+      'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+      'Build-Date': buildDate,
+      'Build-Time': buildTime,
+      'Build-Revision': versioning.info.commit,
+      'Specification-Title': project.name,
+      'Specification-Version': baseVersion,
+      'Specification-Vendor': 'spockframework.org',
+      'Implementation-Title': project.name,
+      'Implementation-Version': variantLessVersion,
+      'Implementation-Vendor': 'spockframework.org',
+      'Automatic-Module-Name': 'org.spockframework.spring'
+    )
+  }
+}

--- a/spock-tapestry/tapestry.gradle
+++ b/spock-tapestry/tapestry.gradle
@@ -31,3 +31,21 @@ if (!useTapestry54) {
     exclude '**/*WithImportModule.class'
   }
 }
+
+jar {
+  manifest {
+    attributes(
+      'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+      'Build-Date': buildDate,
+      'Build-Time': buildTime,
+      'Build-Revision': versioning.info.commit,
+      'Specification-Title': project.name,
+      'Specification-Version': baseVersion,
+      'Specification-Vendor': 'spockframework.org',
+      'Implementation-Title': project.name,
+      'Implementation-Version': variantLessVersion,
+      'Implementation-Vendor': 'spockframework.org',
+      'Automatic-Module-Name': 'org.spockframework.tapestry'
+    )
+  }
+}

--- a/spock-unitils/unitils.gradle
+++ b/spock-unitils/unitils.gradle
@@ -30,3 +30,20 @@ dependencies {
   testRuntime libs.log4j
 }
 
+jar {
+  manifest {
+    attributes(
+      'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+      'Build-Date': buildDate,
+      'Build-Time': buildTime,
+      'Build-Revision': versioning.info.commit,
+      'Specification-Title': project.name,
+      'Specification-Version': baseVersion,
+      'Specification-Vendor': 'spockframework.org',
+      'Implementation-Title': project.name,
+      'Implementation-Version': variantLessVersion,
+      'Implementation-Vendor': 'spockframework.org',
+      'Automatic-Module-Name': 'org.spockframework.unitils'
+    )
+  }
+}


### PR DESCRIPTION
JUnit 5 already did it, so it cannot hurt to add it to spock as well. https://github.com/junit-team/junit5/issues/866

@sormuras you created the PR for JUnit5 and ota4j would you mind reviewing this PR?

One thing to note is that spock uses the `spock.lang` package for the public api, and the `org.spockframework` package for the implementation, so a common super package is not possible without breaking up the jars. I opted to use `org.spockframework` for core and `org.spockframework.<module>` for the extensions.