### PR TITLE
Improve assertion messages by using `dump` instead of `toString`...

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -4,6 +4,7 @@ include::include.adoc[]
 == 1.2 (tbd)
 
 === What's New In This release
+* In assertions Spock now uses `DefaultGroovyMethods.dump` instead of `toString` if a class doesn't override the default `Object.toString`.
 * Add flag to UnrollNameProvider to assert unroll expressions (set the system property `spock.assertUnrollExpressions` to `true`) https://github.com/spockframework/spock/issues/767[#767]
 
 == 1.1 (2017-05-01)

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ImplicitClosureCallRendering.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ImplicitClosureCallRendering.groovy
@@ -83,7 +83,7 @@ func(42) == null
 holder.func(42) == null
 |      |        |
 |      42       false
-${holder.toString()}
+${holder.dump()}
         """, {
       assert holder.func(42) == null
     }
@@ -101,7 +101,7 @@ ${holder.toString()}
 getFunc()(42) == null
 |             |
 |             false
-${getFunc().toString()}
+${getFunc().dump()}
         """, {
       assert getFunc()(42) == null
     }
@@ -115,8 +115,8 @@ ${getFunc().toString()}
 holder.getFunc()(42) == null
 |      |             |
 |      |             false
-|      ${holder.func.toString()}
-${holder.toString()}
+|      ${holder.func.dump()}
+${holder.dump()}
         """, {
       assert holder.getFunc()(42) == null
     }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ValueRendering.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ValueRendering.groovy
@@ -17,6 +17,7 @@
 package org.spockframework.smoke.condition
 
 import spock.lang.Issue
+
 import static java.lang.Thread.State.NEW
 
 /**
@@ -261,6 +262,34 @@ NEW
     }
   }
 
+  def "variable with default to string is dump()ed"() {
+    def x = new DefaultToString()
+    expect:
+    isRendered """
+x == null
+| |
+| false
+${x.dump()}
+    """, {
+      assert x == null
+    }
+  }
+
+  def "arrays of variables with default to string is dump()ed"() {
+    def a = new DefaultToString()
+    def b = new DefaultToString()
+    DefaultToString[] x = [a, b]
+    expect:
+    isRendered """
+x == null
+| |
+| false
+[${a.dump()}, ${b.dump()}]
+    """, {
+      assert x == null
+    }
+  }
+
   static class SingleLineToString {
     String toString() {
       "single line"
@@ -297,6 +326,11 @@ NEW
     String toString() {
       throw new UnsupportedOperationException()
     }
+  }
+
+
+  static class DefaultToString {
+    int a = 4
   }
 
   enum EnumWithToString {


### PR DESCRIPTION
for classes which don't provide a custom `toString`