### PR TITLE
Improve `constructorArgs` for spies can now accept a map directly

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -20,6 +20,7 @@ Breaking Changes: Spock 1.2 drops support for Java 6, Groovy 2.0 and Groovy 2.3
 * Improve default responses for stubs, Java 8 types like `Optional` and `Streams` now return empty, `CompleteableFuture` completes with `null` result
 * Improve support for builder pattern, stubs now return themselves if the return type matches the type of the stub
 * Improve tapestry support with by supporting `@ImportModule`
+* Improve `constructorArgs` for spies can now accept a map directly without the need to wrap it in a list
 * General dependency update
 
 Thanks to all the contributors to this release: Rob Elliot, jochenberger, Jan Papenbrock, Paul King, Marcin Zajączkowski, mrb-twx

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockConfiguration.java
@@ -48,7 +48,7 @@ public class MockConfiguration implements IMockConfiguration {
     this.instance = getOption(options, "instance", Object.class, instance);
     this.nature = getOption(options, "nature", MockNature.class, nature);
     this.implementation = getOption(options, "implementation", MockImplementation.class, implementation);
-    this.constructorArgs = getOption(options, "constructorArgs", List.class, null);
+    this.constructorArgs = getOptionAsList(options, "constructorArgs");
     this.additionalInterfaces = getOption(options, "additionalInterfaces", List.class, Collections.emptyList());
     this.defaultResponse = getOption(options, "defaultResponse", IDefaultResponse.class, this.nature.getDefaultResponse());
     this.global = getOption(options, "global", Boolean.class, false);
@@ -120,5 +120,16 @@ public class MockConfiguration implements IMockConfiguration {
 
   private <T> T getOption(Map<String, Object> options, String key, Class<T> type, T defaultValue) {
     return options.containsKey(key) ? type.cast(options.get(key)) : defaultValue;
+  }
+
+  private List getOptionAsList(Map<String, Object> options, String key) {
+    if (options.containsKey(key)) {
+      Object obj = options.get(key);
+      if (obj instanceof Map) {
+        return Collections.singletonList((Map)obj);
+      }
+      return (List)obj;
+    }
+    return null;
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaSpies.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaSpies.groovy
@@ -20,7 +20,7 @@ import spock.lang.*
 class JavaSpies extends Specification {
   def "construct spied-on object using default constructor when no constructor args given (even if Objenesis is available on class path)"() {
     when:
-    Spy(Constructable)
+    Spy(NoDefaultConstructor)
 
     then:
     thrown(CannotCreateMockException)
@@ -36,10 +36,14 @@ class JavaSpies extends Specification {
     spy.arg4 == arg4
 
     where:
-    ctorArgs | arg1 | arg2 | arg3 | arg4
-    [1]      | 1    | 0    | 0    | null
-    [2, 3]   | 0    | 2    | 3    | null
-    ["hi"]   | 0    | 0    | 0    | "hi"
+    ctorArgs                         | arg1 | arg2 | arg3 | arg4
+    [1]                              | 1    | 0    | 0    | null
+    [2, 3]                           | 0    | 2    | 3    | null
+    ["hi"]                           | 0    | 0    | 0    | "hi"
+    [arg4: "hi"]                     | 0    | 0    | 0    | "hi"
+    [arg1: 2, arg3: 5, arg4: "hi"]   | 2    | 0    | 5    | "hi"
+    [[arg1: 2, arg3: 5, arg4: "hi"]] | 2    | 0    | 5    | "hi"
+    [arg2: 1]                        | 0    | 1    | 0    | null
   }
 
   def "call real methods by default"() {
@@ -158,6 +162,9 @@ class JavaSpies extends Specification {
     int arg2
     int arg3
     String arg4
+
+    Constructable() {
+    }
 
     Constructable(int arg1) {
       this.arg1 = arg1


### PR DESCRIPTION
fixes #662