### PR TITLE
Improve unmatched mock messages by using `dump` instead of `inspect`...

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockInvocation.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockInvocation.java
@@ -17,11 +17,9 @@
 package org.spockframework.mock.runtime;
 
 import org.spockframework.mock.*;
-import org.spockframework.util.TextUtil;
+import org.spockframework.util.*;
 
 import java.util.*;
-
-import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
 /**
  *
@@ -98,7 +96,7 @@ public class MockInvocation implements IMockInvocation {
 
   private String render(List<Object> arguments) {
     List<String> strings = new ArrayList<>();
-    for (Object arg : arguments) strings.add(DefaultGroovyMethods.inspect(arg));
+    for (Object arg : arguments) strings.add(RenderUtil.inspectOrDump(arg));
     return TextUtil.join(", ", strings);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/ExpressionInfoValueRenderer.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ExpressionInfoValueRenderer.java
@@ -19,7 +19,6 @@ import org.spockframework.runtime.model.ExpressionInfo;
 import org.spockframework.util.*;
 
 import groovy.lang.GString;
-import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
 public class ExpressionInfoValueRenderer {
   public static final long MAX_EDIT_DISTANCE_MEMORY = 50 * 1024;
@@ -94,43 +93,8 @@ public class ExpressionInfoValueRenderer {
     return renderToStringOrDump(expr);
   }
 
-  private String renderToStringOrDump(ExpressionInfo expr) {
-    Object value = expr.getValue();
-    Class<?> valueClass = value.getClass();
-    if (valueClass.isArray()) {
-      if (isToStringOverridden(valueClass.getComponentType()) || valueClass.getComponentType().isPrimitive()) {
-        return GroovyRuntimeUtil.toString(value);
-      } else {
-        return dumpArrayString((Object[])value);
-      }
-    } else if (isToStringOverridden(valueClass)) {
-      return GroovyRuntimeUtil.toString(value);
-    } else {
-      return DefaultGroovyMethods.dump(value);
-    }
-  }
-
-  /*
-   * Adapted from org.codehaus.groovy.runtime.InvokerHelper.toArrayString(java.lang.Object[]) to use dump()
-   */
-  private String dumpArrayString(Object[] arguments) {
-    StringBuilder argBuf = new StringBuilder("[");
-    for (int i = 0; i < arguments.length; i++) {
-      if (i > 0) {
-        argBuf.append(", ");
-      }
-      argBuf.append(DefaultGroovyMethods.dump(arguments[i]));
-    }
-    argBuf.append("]");
-    return argBuf.toString();
-  }
-
-  private boolean isToStringOverridden(Class<?> valueClass) {
-    try {
-      return !Object.class.equals(valueClass.getMethod("toString").getDeclaringClass());
-    } catch (NoSuchMethodException e) {
-      return false;
-    }
+  private static String renderToStringOrDump(ExpressionInfo expr) {
+    return RenderUtil.toStringOrDump(expr.getValue());
   }
 
   private String renderAsFailedStringComparison(ExpressionInfo expr) {

--- a/spock-core/src/main/java/org/spockframework/util/ObjectUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ObjectUtil.java
@@ -18,24 +18,24 @@ package org.spockframework.util;
  * Utility methods applicable to (almost) any object. Includes null-safe variants of methods on class Object.
  */
 public abstract class ObjectUtil {
-  public static boolean equals(Object obj1, Object obj2) {
+  public static boolean equals(@Nullable Object obj1, @Nullable Object obj2) {
     if (obj1 == null) return obj2 == null;
     return obj1.equals(obj2);
   }
 
-  public static int hashCode(Object obj) {
+  public static int hashCode(@Nullable Object obj) {
     return obj == null ? 0 : obj.hashCode();
   }
 
-  public static String toString(Object obj) {
+  public static String toString(@Nullable Object obj) {
     return obj == null ? "null" : obj.toString();
   }
 
-  public static Class<?> getClass(Object obj) {
+  public static Class<?> getClass(@Nullable Object obj) {
     return obj == null ? null : obj.getClass();
   }
 
-  public static Class<?> voidAwareGetClass(Object obj) {
+  public static Class<?> voidAwareGetClass(@Nullable Object obj) {
     return obj == null ? void.class : obj.getClass();
   }
 
@@ -52,7 +52,7 @@ public abstract class ObjectUtil {
     return type.isInstance(obj) ? (T) obj : null;
   }
 
-  public static <T extends Comparable<T>> int compare(T comparable1, T comparable2) {
+  public static <T extends Comparable<T>> int compare(@Nullable T comparable1, @Nullable T comparable2) {
     if (comparable1 == null && comparable2 == null) return 0;
     if (comparable1 == null) return -1;
     if (comparable2 == null) return 1;

--- a/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
@@ -234,4 +234,12 @@ public abstract class ReflectionUtil {
     }
     return result;
   }
+
+  public static boolean isToStringOverridden(Class<?> valueClass) {
+    try {
+      return !Object.class.equals(valueClass.getMethod("toString").getDeclaringClass());
+    } catch (NoSuchMethodException e) {
+      return false;
+    }
+  }
 }

--- a/spock-core/src/main/java/org/spockframework/util/RenderUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/RenderUtil.java
@@ -1,0 +1,84 @@
+package org.spockframework.util;
+
+import org.spockframework.runtime.GroovyRuntimeUtil;
+
+import java.util.*;
+
+import groovy.lang.Range;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.w3c.dom.Element;
+
+public abstract class RenderUtil {
+  /**
+   * Returns true if the Object is handled properly by {@link org.codehaus.groovy.runtime.InvokerHelper#inspect(java.lang.Object)}
+   * or {@link org.codehaus.groovy.runtime.InvokerHelper#toString(Object)}, either by special handling or if the Class has
+   * an own {@code toString()} implementation.
+   */
+  public static boolean isHandledByInspectOrToString(@Nullable Object arguments) {
+    if (arguments == null) {
+      return true;
+    }
+    if (arguments instanceof Range) {
+      return true;
+    }
+    if (arguments instanceof Collection) {
+      return true;
+    }
+    if (arguments instanceof Map) {
+      return true;
+    }
+    if (arguments instanceof Element) {
+      return true;
+    }
+    if (arguments instanceof String) {
+      return true;
+    }
+
+    Class<?> argumentsClass = arguments.getClass();
+    if (argumentsClass.isArray()) {
+      return argumentsClass.getComponentType().isPrimitive()
+        || ReflectionUtil.isToStringOverridden(argumentsClass.getComponentType());
+    }
+
+    return ReflectionUtil.isToStringOverridden(argumentsClass);
+  }
+
+  public static String toStringOrDump(@Nullable Object value) {
+    if (isHandledByInspectOrToString(value)) {
+      return GroovyRuntimeUtil.toString(value);
+    }
+    return dump(value);
+  }
+
+  public static String inspectOrDump(@Nullable Object value) {
+    if (isHandledByInspectOrToString(value)) {
+      return DefaultGroovyMethods.inspect(value);
+    }
+    return dump(value);
+  }
+
+  private static String dump(@Nullable Object value) {
+    if (value.getClass().isArray()) {
+      return dumpArrayString((Object[])value);
+    } else {
+      return DefaultGroovyMethods.dump(value);
+    }
+  }
+
+
+  /*
+   * Adapted from org.codehaus.groovy.runtime.InvokerHelper.toArrayString(java.lang.Object[]) to use dump()
+   */
+  private static String dumpArrayString(Object[] arguments) {
+    StringBuilder argBuf = new StringBuilder("[");
+    for (int i = 0; i < arguments.length; i++) {
+      if (i > 0) {
+        argBuf.append(", ");
+      }
+      argBuf.append(DefaultGroovyMethods.dump(arguments[i]));
+    }
+    argBuf.append("]");
+    return argBuf.toString();
+  }
+
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/TooFewInvocations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/TooFewInvocations.groovy
@@ -174,7 +174,27 @@ then:
     e.message.contains("barney.setName")
   }
 
-  static class Person {}
+
+  def "renders with dump() if no better toString exists"() {
+    when:
+    runner.runFeatureBody("""
+def list = Mock(List)
+def person = new org.spockframework.smoke.mock.TooFewInvocations.Person(age: 18, name: 'Foo')
+
+when:
+list.add(person)
+
+then:
+1 * list.add('bar')
+    """)
+
+    then:
+    TooFewInvocationsError e = thrown()
+    e.message.trim() =~ /(?m)^\Q1 * list.add(<org.spockframework.smoke.mock.TooFewInvocations\E.Person@\w+ name=Foo age=18>\)$/
+  }
+
+  static class Person {
     String name
     int age
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/util/ReflectionUtilSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/ReflectionUtilSpec.groovy
@@ -14,8 +14,7 @@
 
 package org.spockframework.util
 
-import spock.lang.Specification
-import spock.lang.Stepwise
+import spock.lang.*
 
 class ReflectionUtilSpec extends Specification {
   def "get package name"() {
@@ -161,6 +160,23 @@ class ReflectionUtilSpec extends Specification {
 
     expect:
     ReflectionUtil.eraseTypes(types) == [Object, List, List]
+  }
+
+
+  def "detects overridden toString"(Class clazz) {
+    expect:
+    ReflectionUtil.isToStringOverridden(clazz)
+
+    where:
+    clazz << [String, ArrayList, AbstractCollection]
+  }
+
+  def "detects not overridden toString"(Class clazz) {
+    expect:
+    !ReflectionUtil.isToStringOverridden(clazz)
+
+    where:
+    clazz << [Object, Base, InvokeMe, Generics]
   }
 
   static class Base {


### PR DESCRIPTION
for classes which don't provide a custom `toString`