### PR TITLE
Fix #778 Nested with expressions are wrapped with SpockRuntime::verif…

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
@@ -17,6 +17,7 @@
 package org.spockframework.compiler;
 
 import org.spockframework.compiler.model.*;
+import org.spockframework.util.Identifiers;
 import org.spockframework.util.Nullable;
 
 import java.util.*;
@@ -152,7 +153,8 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
     groupConditionFound = currSpecialMethodCall.isGroupConditionBlock();
 
     if ((currSpecialMethodCall.isWithCall() || currSpecialMethodCall.isGroupConditionBlock())
-      && AstUtil.isInvocationWithImplicitThis(stat.getExpression())) {
+      && AstUtil.isInvocationWithImplicitThis(stat.getExpression())
+      && !Identifiers.WITH.equals(AstUtil.getMethodName(stat.getExpression()))) {
       replaceObjectExpressionWithCurrentClosure(stat);
     }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlockFailingConditions.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlockFailingConditions.groovy
@@ -125,6 +125,22 @@ class WithBlockFailingConditions extends Specification {
     }
   }
 
+  @FailsWith(ConditionNotSatisfiedError)
+  def "nested with expressions, the last one has a failing method condition"() {
+    def list = [[['value']]]
+
+    expect:
+    with(list) {
+      with(it[0]) {
+        with(it[0]) {
+          with(it[0]) {
+            isEmpty()
+          }
+        }
+      }
+    }
+  }
+
   @FailsWith(value = SpockAssertionError, reason = "Expected target of 'with' block to have type '%s', but got '%s'")
   def "with target and incompatible type fails"() {
     def list = [1, 2, 3]

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlockPassingConditions.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlockPassingConditions.groovy
@@ -108,6 +108,63 @@ class WithBlockPassingConditions extends Specification {
     }
   }
 
+  def "nested with expressions, the last one has a method condition"() {
+    def list = [[['value']]]
+
+    expect:
+    with(list) {
+      with(it[0]) {
+        with(it[0]) {
+          with(it[0]) {
+            !isEmpty()
+          }
+        }
+      }
+    }
+  }
+
+  def "nested with expressions with conditions"() {
+    def list = [[['value']]]
+
+    expect:
+    with(list) {
+      with(it[0]) {
+        size() > 0
+        with(it[0]) {
+          !isEmpty()
+          with(it[0]) {
+            it == 'value'
+          }
+        }
+      }
+    }
+  }
+
+  def "nested with expressions with interaction"() {
+    Supplier<String> supplier = Mock(Supplier) {
+      get() >> 'value'
+    }
+    def list = [[[supplier]]]
+
+    when:
+    supplier.get()
+
+    then:
+    with(list) {
+      with(it[0]) {
+        with(it[0]) {
+          with(it[0]) {
+            1 * get()
+          }
+        }
+      }
+    }
+  }
+
+  static interface Supplier<T> {
+    T get()
+  }
+
   def "in helper method"() {
     def list = [1, 2]
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlocks.groovy
@@ -19,6 +19,21 @@ import org.spockframework.runtime.SpockAssertionError
 import spock.lang.Specification
 
 class WithBlocks extends Specification {
+  def "don't turn nested with expressions into condition"() {
+    def list = [[['end']]]
+
+    expect:
+    with(list) {
+      with(it[0]) {
+        with(it[0]) {
+          with(it[0]) {
+            it == 'end'
+          }
+        }
+      }
+    }
+  }
+
   def "don't turn nested statements into conditions"() {
     def list = [1, 2]
 


### PR DESCRIPTION
Due to the fix in PR #606 if there is a method invocation with implicit this inside a with block, SpockRuntime::verifyMethodCondition is invoked on the closure, but not on the "this" variable, because this points to the spec. If the with block has a nested with block it is invoked on the closure, which is wrong because it should be invoked on the spec. Additionally the nested with is wrapped with another SpockRuntime::verifyMethodCondition and because Specification::with returns no value SpockRuntime::verifyMethodCondition always fails at this point.

Example.
This code
```
    def list = [[['end']]]

    expect:
    with(list) {
      with(it[0]) {
        with(it[0]) {
          with(it[0]) {
            it == 'end'
          }
        }
      }
    }
```
transforms into something like
```
    def list = [[['end']]]

    expect:
    with(list) {
      with(it[0]) {
        SpockRuntime.verifyMethodCondition(this.each(), 'with', [it[0], {
          with(it[0]) {
            SpockRuntime.verifyCondition(it == 'end')
          }
        }]
      }
    }
```
The original issue fixed in PR #606 was that every method was invoked on the spec but not on the closure. The problem is that with in the expect (or then) section is a method of spock.lang.Specification.
```
  public <U> void with(
    @DelegatesTo.Target
    U target,
    @DelegatesTo(strategy = Closure.DELEGATE_FIRST) @ClosureParams(FirstParam.class)
    Closure<?> closure
  ) { ... }
```
It means that this method is always invoked on the spec and shouldn't be wrapped with SpockRuntime::verifyMethodCondition because it is not a method condition.
The simplest fix is not to transform nested with expressions (but still check and transform their closures' body) 

This fix excludes nested with expression from being invoked on the current closure instead of the spec. 