### PR TITLE
Fixed broken links

### DIFF
--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -289,5 +289,3 @@ include::{sourcedir}/datadriven/DataSpec.groovy[tag=unrolled-3a]
     ...
 include::{sourcedir}/datadriven/DataSpec.groovy[tag=unrolled-3b]
 ----
-
-

--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -498,7 +498,7 @@ runner {
 
 Spock can create a report log of the executed tests in JSON format. This report contains also things like
 <<Title and Narrative,`@Title`>>, <<Title and Narrative,`@Narrative`>>, <<See,`@See`>> and <<Issue,`@Issue`>> values or
-<<specs-as-doc,block descriptors>>.
+<<spock_primer.adoc#_blocks,block descriptors>>.
 This report can be enabled according to the <<Spock Configuration File>> section. The default is to not generate this
 report.
 

--- a/docs/modules.adoc
+++ b/docs/modules.adoc
@@ -17,13 +17,10 @@ https://github.com/spockframework/spock/tree/master/spock-tapestry/src/test/groo
 == Unitils Module
 
 Integration with the http://www.unitils.org/[Unitils] library. For examples see the specs in the
-https://github.com/spockframework/spock/tree/master/spock-unitils/src/test/groovy/org/spockframework/unitils/dbunit[codebase].
+https://github.com/spockframework/spock/tree/master/spock-unitils/src/test/groovy/org/spockframework/unitils[codebase].
 
 == Grails Module
 
 The Grails plugin has moved to its own https://github.com/spockframework/spock-grails[GitHub project].
 
 NOTE: Grails 2.3 and higher have built-in Spock support and do not require a plugin.
-
-
-

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -153,7 +153,7 @@ The Spock Team
 * https://github.com/Fuud[Fedor Bobin]
 * https://github.com/leonard84[Leonard Brünings]
 * https://github.com/cetnar[cetnar]
-* https://github.com/alkemist[Luke Daley]
+* http://ldaley.com[Luke Daley]
 * https://github.com/daviddawson[David Dawson]
 * https://github.com/selenium34[Scott G]
 * https://github.com/msgilligan[Sean Gilligan]
@@ -236,7 +236,7 @@ These great features didn't make it into this release (but hopefully the next!):
 
 === Snapshot Repository Moved
 
-Spock snapshots are now available from http://oss.sonatype.org/content/repositories/snapshots/.
+Spock snapshots are now available from https://oss.sonatype.org/content/repositories/snapshots/org/spockframework/.
 
 === New Reference Documentation
 
@@ -264,7 +264,7 @@ Matching invocations (ordered by last occurrence):
 1 * person.sing("mi")
 ----
 
-<<interaction_based_testing.adoc#ShowAllMatchingInvocations,Reference Documentation>>
+<<interaction_based_testing.adoc#_verification_of_interactions,Reference Documentation>>
 
 === Improved Mocking Failure Message for `TooFewInvocationsError`
 
@@ -283,7 +283,7 @@ Unmatched invocations (ordered by similarity):
 1 * person2.shout("mi")
 ----
 
-<<interaction_based_testing.adoc#ShowUnmatchedInvocations,Reference Documentation>>
+<<interaction_based_testing.adoc#_verification_of_interactions,Reference Documentation>>
 
 === Stubs
 
@@ -330,7 +330,7 @@ def person = Mock(Person) {
 
 This feature is particularly attractive for <<Stubs>>.
 
-<<interaction_based_testing.adoc#declaring-interactions-at-creation-time,Reference Documentation>>
+<<interaction_based_testing.adoc#Stubs,Reference Documentation>>
 
 === Groovy Mocks
 
@@ -401,7 +401,7 @@ with(service) {
 }
 ----
 
-<<interaction_based_testing.adoc#GroupingInteractionsWithSameTarget,Reference Documentation>>
+<<interaction_based_testing.adoc#_grouping_interactions_with_same_target,Reference Documentation>>
 
 === Polling Conditions
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -153,7 +153,7 @@ The Spock Team
 * https://github.com/Fuud[Fedor Bobin]
 * https://github.com/leonard84[Leonard Brünings]
 * https://github.com/cetnar[cetnar]
-* http://ldaley.com[Luke Daley]
+* https://github.com/ldaley[Luke Daley]
 * https://github.com/daviddawson[David Dawson]
 * https://github.com/selenium34[Scott G]
 * https://github.com/msgilligan[Sean Gilligan]

--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -540,6 +540,8 @@ with(service) {
   1 * stop()
 }
 ----
+
+[[specifications_as_documentation]]
 == Specifications as Documentation
 
 Well-written specifications are a valuable source of information. Especially for higher-level specifications targeting

--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -161,7 +161,7 @@ def elem = "push me"
 The `setup` block is where you do any setup work for the feature that you are describing. It may not be preceded by
 other blocks, and may not be repeated. A `setup` block doesn't have any special semantics. The `setup:` label is
 optional and may be omitted, resulting in an _implicit_ `setup` block. The `given:` label is an alias for `setup:`,
-and sometimes leads to a more readable feature method description (see <<specs-as-doc,Specifications as Documentation>>).
+and sometimes leads to a more readable feature method description (see <<Specifications as Documentation,Specifications as Documentation>>).
 
 ==== When and Then Blocks
 


### PR DESCRIPTION
Fixed broken links

Several of the hyperlinks in the documentation either went nowhere, or to the wrong location. This has been remedied.