### PR TITLE
Fix for #802 Removed thrown IllegalArgumentException to make sure non-spock-tests …

### DIFF
--- a/spock-spring/spring5-test/src/test/groovy/org/spockframework/spring5/SpringRunnerTest.java
+++ b/spock-spring/spring5-test/src/test/groovy/org/spockframework/spring5/SpringRunnerTest.java
@@ -1,0 +1,21 @@
+package org.spockframework.spring5;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Make sure we still can correctly execute tests executed by the SpringRunner that are not spock tests
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class SpringRunnerTest {
+
+  @Test
+  public void testThatSpringRunnerExecutesCorrectly() {
+    Assert.assertTrue(true);
+  }
+
+}

--- a/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
@@ -83,8 +83,6 @@ public class SpringMockTestExecutionListener extends AbstractSpringTestExecution
 
       testContext.setAttribute(MOCKED_BEANS_LIST, mockedBeans);
 
-    } else {
-      throw new IllegalArgumentException("SpringMockTestExecutionListener is only applicable for spock specifications.");
     }
   }
 

--- a/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/SpringMockTestExecutionListener.java
@@ -46,44 +46,45 @@ public class SpringMockTestExecutionListener extends AbstractSpringTestExecution
 
   @Override
   public void prepareTestInstance(SpringTestContext testContext) throws Exception {
+    Object testInstance = testContext.getTestInstance();
+    if (!(testInstance instanceof Specification)) return;
+
     ApplicationContext applicationContext = testContext.getApplicationContext();
     if (applicationContext.containsBean(SpockMockPostprocessor.class.getName())) {
       SpockMockPostprocessor mockPostprocessor = applicationContext.getBean(SpockMockPostprocessor.class);
-      mockPostprocessor.injectSpies(testContext.getTestInstance());
+      mockPostprocessor.injectSpies(testInstance);
     }
   }
 
   @Override
   public void beforeTestMethod(SpringTestContext testContext) throws Exception {
     Object testInstance = testContext.getTestInstance();
+    if (!(testInstance instanceof Specification)) return;
 
-    if (testInstance instanceof Specification) {
-      Specification specification = (Specification) testInstance;
-      ScanScopedBeans scanScopedBeans = ReflectionUtil.getAnnotationRecursive(specification.getClass(), ScanScopedBeans.class);
-      Set<String> scopes = scanScopedBeans == null ? Collections.<String>emptySet() :
-        new HashSet<>(Arrays.asList(scanScopedBeans.value()));
+    Specification specification = (Specification)testInstance;
+    ScanScopedBeans scanScopedBeans = ReflectionUtil.getAnnotationRecursive(specification.getClass(), ScanScopedBeans.class);
+    Set<String> scopes = scanScopedBeans == null ? Collections.<String>emptySet() :
+      new HashSet<>(Arrays.asList(scanScopedBeans.value()));
 
-      ApplicationContext applicationContext = testContext.getApplicationContext();
-      String[] mockBeanNames = applicationContext.getBeanDefinitionNames();
-      List<Object> mockedBeans = new ArrayList<>();
+    ApplicationContext applicationContext = testContext.getApplicationContext();
+    String[] mockBeanNames = applicationContext.getBeanDefinitionNames();
+    List<Object> mockedBeans = new ArrayList<>();
 
-      for (String beanName : mockBeanNames) {
-        BeanDefinition beanDefinition = ((BeanDefinitionRegistry)applicationContext).getBeanDefinition(beanName);
-        if(beanDefinition.isAbstract()){
-            continue;
-        }
-        if (beanDefinition.isSingleton() || scanScopedBean(scanScopedBeans, scopes, beanDefinition)){
-          Object bean = applicationContext.getBean(beanName);
-          if (mockUtil.isMock(bean)) {
-            mockUtil.attachMock(bean, specification);
-            mockedBeans.add(bean);
-          }
+    for (String beanName : mockBeanNames) {
+      BeanDefinition beanDefinition = ((BeanDefinitionRegistry)applicationContext).getBeanDefinition(beanName);
+      if (beanDefinition.isAbstract()) {
+        continue;
+      }
+      if (beanDefinition.isSingleton() || scanScopedBean(scanScopedBeans, scopes, beanDefinition)) {
+        Object bean = applicationContext.getBean(beanName);
+        if (mockUtil.isMock(bean)) {
+          mockUtil.attachMock(bean, specification);
+          mockedBeans.add(bean);
         }
       }
-
-      testContext.setAttribute(MOCKED_BEANS_LIST, mockedBeans);
-
     }
+
+    testContext.setAttribute(MOCKED_BEANS_LIST, mockedBeans);
   }
 
   private boolean scanScopedBean(ScanScopedBeans scanScopedBeans, Set<String> scopes, BeanDefinition beanDefinition) {


### PR DESCRIPTION
…executed by SpringRunner don't fail.

After investigating a bit, i've found the issue:
- Spock registers the SpringMockTestExecutionListener in spring.factories as a TestExecutionListener
- This calls the listener methods for all tests executed by SpringJUnit4ClassRunner
- If these tests are not spock tests, the SpringMockTestExecutionListener fails