### PR TITLE
Fix #817 Allow specifying global extension order

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/IExtensionRegistry.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IExtensionRegistry.java
@@ -16,8 +16,8 @@ package org.spockframework.runtime;
 
 import org.spockframework.runtime.extension.IGlobalExtension;
 
-import java.util.List;
+import java.util.Set;
 
 public interface IExtensionRegistry {
-  List<IGlobalExtension> getGlobalExtensions();
+  Set<IGlobalExtension> getGlobalExtensions();
 }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/GlobalExtensionRegistrySpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/GlobalExtensionRegistrySpec.groovy
@@ -161,6 +161,27 @@ class GlobalExtensionRegistrySpec extends Specification {
     e.message.contains("unknown configuration class")
   }
 
+  // See https://github.com/spockframework/spock/issues/817
+  def "Extensions discovered later in the classpath are ignored if already processed earlier"() {
+    when:
+    def registry = new GlobalExtensionRegistry(extensionClasses, [])
+    registry.initializeGlobalExtensions()
+
+    then:
+    registry.globalExtensions*.class == expectedExtensionClasses
+
+    where:
+    // Ignore subsequent additions, even if they appear later in the list
+    extensionClasses                                                 || expectedExtensionClasses
+    [MyExtension, MyExtension]                                       || [MyExtension]
+    [SpringExtension, MyExtension, SpringExtension]                  || [SpringExtension, MyExtension]
+    [SpringExtension, SpringExtension, MyExtension, SpringExtension] || [SpringExtension, MyExtension]
+  }
+
+  static class SpringExtension extends AbstractGlobalExtension {
+
+  }
+
   static class MyExtension extends AbstractGlobalExtension {
     static instantiated = false
 


### PR DESCRIPTION
Allow specifying the extension order explicitly.

For instance if
* `spock-spring` provides the `SpringExtension` via its `IGlobalExtension` file,
* `MyProject` provides `com.example.MyExtension`
* and `MyExtension` depends on `SpringExtension`
then the `MyProject/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension` would look like this:
```
org.spockframework.spring.SpringExtension
com.example.MyExtension
```