### PR TITLE
Spock can be compiled on JDK 10 [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ dist: precise # downgrade to avoid jdk7 SSL Bug https://github.com/docker-librar
 jdk:
   - oraclejdk7 # openjdk7 has SSL Bug avoid jdk7 SSL Bug https://github.com/docker-library/openjdk/issues/117
   - oraclejdk8
-  - openjdk9
   - openjdk10
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ dist: precise # downgrade to avoid jdk7 SSL Bug https://github.com/docker-librar
 jdk:
   - oraclejdk7 # openjdk7 has SSL Bug avoid jdk7 SSL Bug https://github.com/docker-library/openjdk/issues/117
   - oraclejdk8
+  - openjdk9
+  - openjdk10
 
 env:
   matrix:

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,10 @@ ext {
   if (variant == 2.4) {
     groovyVersion = "2.4.15"
     minGroovyVersion = "2.4.0"
-    groovyDependency = "org.codehaus.groovy:groovy-all:${groovyVersion}"
+    groovyDependency = ["org.codehaus.groovy:groovy-all:${groovyVersion}"]
   } else if (variant == 2.5) {
     groovyVersion = "2.5.2"
-    minGroovyVersion = "2.5.0"
+    minGroovyVersion = "2.5.2"
     groovyDependency = [
       "org.codehaus.groovy:groovy:${groovyVersion}",
       "org.codehaus.groovy:groovy-groovysh:${groovyVersion}",
@@ -43,14 +43,19 @@ ext {
   }
   fullVersion = baseVersion + ((!snapshotVersion && releaseCandidate) ? "-RC$releaseCandidate" : "") + "-groovy-$variant" + (snapshotVersion ? "-SNAPSHOT" : '')
   variantLessVersion = baseVersion + (snapshotVersion ? "-SNAPSHOT" : (releaseCandidate ? "-RC$releaseCandidate" : ""))
-  javaVersions = [1.7, 1.8]
+  javaVersions = [1.7, 1.8, 9, 10, 11]
   javaVersion = System.getProperty("java.specification.version") as BigDecimal
+
+  if (javaVersion >= 9) {
+    groovyDependency += ["javax.xml.bind:jaxb-api:2.3.0"]
+  }
+
   libs = [
     jetbrainsAnnotations: "org.jetbrains:annotations:13.0",
     ant: "org.apache.ant:ant:1.9.7",
     asm: "org.ow2.asm:asm:6.2",
     bytebuddy: "net.bytebuddy:byte-buddy:1.8.3",
-    cglib: "cglib:cglib-nodep:3.2.6",
+    cglib: "cglib:cglib-nodep:3.2.7",
     groovy: groovyDependency,
     h2database: "com.h2database:h2:1.3.176",
     junit: "junit:junit:4.12",
@@ -70,7 +75,19 @@ allprojects {
 
   apply from: script("common")
 
-  if (javaVersion >= 1.8) {
+  if (javaVersion == 1.8) {
+    tasks.withType(Javadoc) {
+      options.addStringOption('Xdoclint:none', '-quiet')
+      options.noTimestamp()
+    }
+  } else if (javaVersion >= 9){
+    tasks.withType(JavaCompile) {
+      sourceCompatibility = javaVersions.min()
+      targetCompatibility = javaVersions.min()
+      options.compilerArgs += ['--release', '8']
+      options.encoding = 'UTF-8'
+    }
+
     tasks.withType(Javadoc) {
       options.addStringOption('Xdoclint:none', '-quiet')
       options.noTimestamp()
@@ -337,6 +354,7 @@ def configureJavadoc(task) {
   configure(task) {
     include "spock/**"
     configure(options) {
+      options.addStringOption('source', '1.8')
       links "http://docs.oracle.com/javase/8/docs/api/"
       links "http://docs.groovy-lang.org/docs/groovy-$groovyVersion/html/gapi/"
       links "http://junit.org/junit4/javadoc/latest/"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=af334d994b5e69e439ab55b5d2b7d086da5ea6763d78054f49f147b06370ed71
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionSha256Sum=e66e69dce8173dd2004b39ba93586a184628bc6c28461bc771d6835f7f9b0d28
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,12 @@ include "spock-spring"
 include "spock-spring:spring2-test"
 include "spock-spring:spring3-test"
 include "spock-guice"
-include "spock-tapestry"
+
+// https://issues.apache.org/jira/projects/TAP5/issues/TAP5-2588
+if (JavaVersion.current().isJava7() || JavaVersion.current().isJava8()) {
+  include "spock-tapestry"
+}
+
 include "spock-unitils"
 include "spock-report"
 include "spock-gradle"
@@ -18,7 +23,6 @@ if (JavaVersion.current().java8Compatible) {
   include "spock-spring:boot2-test"
   include "spock-spring:spring5-test"
 }
-
 
 rootProject.name = "spock"
 nameBuildScriptsAfterProjectNames(rootProject.children)

--- a/spock-specs/src/test/groovy/org/spockframework/EmbeddedSpecification.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/EmbeddedSpecification.groovy
@@ -30,8 +30,18 @@ abstract class EmbeddedSpecification extends Specification {
   EmbeddedSpecRunner runner = new EmbeddedSpecRunner()
   EmbeddedSpecCompiler compiler = new EmbeddedSpecCompiler()
 
+  def javaVersion = System.getProperty("java.specification.version") as BigDecimal
+
   void stackTraceLooksLike(Throwable exception, String template) {
-    def trace = exception.stackTrace
+
+    def trace
+
+    if (javaVersion >= 9) {
+      trace = exception.stackTrace.findAll { it['moduleName'] != "java.base" }
+    } else {
+      trace = exception.stackTrace
+    }
+
     def lines = template.trim().split("\n")
     assert trace.size() == lines.size()
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
@@ -29,7 +29,7 @@ class IgnoreIfExtension extends Specification {
     expect: false
   }
 
-  @IgnoreIf({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 })
+  @IgnoreIf({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 || jvm.java10 })
   def "provides JVM information"() {
     expect: false
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
@@ -41,7 +41,7 @@ class RequiresExtension extends Specification {
     expect: true
   }
 
-  @Requires({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 })
+  @Requires({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 || jvm.java10 })
   def "provides JVM information"() {
     expect: true
   }


### PR DESCRIPTION
Hi,

I did some work on #808 and I can compile Spock with JDK 10. There are several important things though:

* Tapestry 5 is not ready for JDK9+ (https://issues.apache.org/jira/projects/TAP5/issues/TAP5-2588)
* Compilation on JDK 11+ fails due to #843 (see #865)

Regards,
Martin