### PR TITLE
Allow to configure retry condition

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -214,6 +214,7 @@ the timeout was exceeded.
 
 The `@Retry` extensions can be used for flaky integration tests, where remote systems can fail sometimes.
 By default it retries an iteration `3` times with `0` delay if either an `Exception` or `AssertionError` has been thrown, all this is configurable.
+In addition, an optional `condition` closure can be used to determine if a feature should be retried.
 It also provides special support for data driven features, offering to either retry all iterations or just the failing ones.
 
 [source,groovy]
@@ -227,6 +228,12 @@ class FlakyInegrationSpec extends Specification {
 
   @Retry(exceptions=[IOException])
   def onlyRetryIOException() { ... }
+
+  @Retry(condition = { failure.message.contains('foo') })
+  def onlyRetryIfConditionOnFailureHolds() { ... }
+
+  @Retry(condition = { instance.field != null })
+  def onlyRetryIfConditionOnInstanceHolds() { ... }
 
   @Retry
   def retryFailingIterations() {

--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -219,7 +219,7 @@ It also provides special support for data driven features, offering to either re
 
 [source,groovy]
 ----
-class FlakyInegrationSpec extends Specification {
+class FlakyIntegrationSpec extends Specification {
   @Retry
   def retry3Times() { ... }
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -1,6 +1,12 @@
 = Release Notes
 include::include.adoc[]
 
+== 1.2-RC2 (tbd)
+
+=== What's New In This release
+
+* The `@Retry` extension can now be configured to evaluate a `condition` (<<extensions.adoc#_retry,Docs>>)
+
 == 1.2-RC1 (2018-08-14)
 
 Breaking Changes: Spock 1.2 drops support for Java 6, Groovy 2.0 and Groovy 2.3

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryBaseInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryBaseInterceptor.java
@@ -33,14 +33,18 @@ import spock.lang.Retry;
 public class RetryBaseInterceptor {
 
   protected final Retry retry;
-  private final Closure condition;
+  protected final Closure condition;
 
   public RetryBaseInterceptor(Retry retry) {
-    this.retry = retry;
-    condition = createCondition(retry.condition());
+    this(retry, createCondition(retry.condition()));
   }
 
-  private Closure createCondition(Class<? extends Closure> clazz) {
+  protected RetryBaseInterceptor(Retry retry, Closure condition) {
+    this.retry = retry;
+    this.condition = condition;
+  }
+
+  private static Closure createCondition(Class<? extends Closure> clazz) {
     if (clazz.equals(Closure.class)) {
       return null;
     }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryBaseInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryBaseInterceptor.java
@@ -19,7 +19,10 @@ package org.spockframework.runtime.extension.builtin;
 import java.util.ArrayList;
 import java.util.List;
 
+import groovy.lang.Closure;
 import org.junit.runners.model.MultipleFailureException;
+import org.spockframework.runtime.GroovyRuntimeUtil;
+import org.spockframework.runtime.extension.ExtensionException;
 import org.spockframework.runtime.extension.IMethodInvocation;
 
 import spock.lang.Retry;
@@ -30,18 +33,49 @@ import spock.lang.Retry;
 public class RetryBaseInterceptor {
 
   protected final Retry retry;
+  private final Closure condition;
 
   public RetryBaseInterceptor(Retry retry) {
     this.retry = retry;
+    condition = createCondition(retry.condition());
   }
 
-  protected boolean isExpected(Throwable e) {
+  private Closure createCondition(Class<? extends Closure> clazz) {
+    if (clazz.equals(Closure.class)) {
+      return null;
+    }
+    try {
+      return clazz.getConstructor(Object.class, Object.class).newInstance(null, null);
+    } catch (Exception e) {
+      throw new ExtensionException("Failed to instantiate @Retry condition", e);
+    }
+  }
+
+  protected boolean isExpected(IMethodInvocation invocation, Throwable failure) {
+    return hasExpectedClass(failure) && satisfiesCondition(invocation, failure);
+  }
+
+  private boolean hasExpectedClass(Throwable failure) {
     for (Class<? extends Throwable> exception : retry.exceptions()) {
-      if(exception.isInstance(e)) {
+      if (exception.isInstance(failure)) {
         return true;
       }
     }
     return false;
+  }
+
+  private boolean satisfiesCondition(IMethodInvocation invocation, Throwable failure) {
+    if (condition == null) {
+      return true;
+    }
+    condition.setDelegate(new RetryConditionContext(invocation, failure));
+    condition.setResolveStrategy(Closure.DELEGATE_ONLY);
+
+    try {
+      return GroovyRuntimeUtil.isTruthy(condition.call());
+    } catch (Exception e) {
+      throw new ExtensionException("Failed to evaluate @Retry condition", e);
+    }
   }
 
   protected void handleInvocation(IMethodInvocation invocation) throws Throwable {
@@ -51,7 +85,7 @@ public class RetryBaseInterceptor {
         invocation.proceed();
         return;
       } catch (Throwable e) {
-        if (isExpected(e)) {
+        if (isExpected(invocation, e)) {
           throwables.add(e);
           if (retry.delay() > 0) {
             Thread.sleep(retry.delay());

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryConditionContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryConditionContext.java
@@ -1,0 +1,36 @@
+package org.spockframework.runtime.extension.builtin;
+
+import org.spockframework.runtime.extension.IMethodInvocation;
+
+/**
+ * The context (delegate) for a {@link spock.lang.Retry} condition.
+ */
+public class RetryConditionContext {
+
+  private final IMethodInvocation invocation;
+  private final Throwable failure;
+
+  RetryConditionContext(IMethodInvocation invocation, Throwable failure) {
+    this.invocation = invocation;
+    this.failure = failure;
+  }
+
+  /**
+   * Returns the {@code Throwable} thrown by the feature method.
+   *
+   * @return the current failure
+   */
+  public Throwable getFailure() {
+    return failure;
+  }
+
+  /**
+   * Returns the current {@code Specification} instance.
+   *
+   * @return the current {@code Specification} instance
+   */
+  public Object getInstance() {
+    return invocation.getInstance();
+  }
+
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryIterationInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryIterationInterceptor.java
@@ -66,7 +66,7 @@ public class RetryIterationInterceptor extends RetryBaseInterceptor implements I
       try {
         invocation.proceed();
       } catch (Throwable e) {
-        if (isExpected(e)) {
+        if (isExpected(invocation, e)) {
           throwables.add(e);
         } else {
           throw e;

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryIterationInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryIterationInterceptor.java
@@ -16,6 +16,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
+import groovy.lang.Closure;
 import org.spockframework.runtime.extension.*;
 import spock.lang.Retry;
 
@@ -38,7 +39,7 @@ public class RetryIterationInterceptor extends RetryBaseInterceptor implements I
     List<Throwable> throwableList = new ArrayList<>();
     for (int i = 0; i <= retry.count(); i++) {
       Queue<Throwable> throwables = new ConcurrentLinkedQueue<>();
-      invocation.getFeature().getFeatureMethod().addInterceptor(new InnerRetryInterceptor(retry, throwables));
+      invocation.getFeature().getFeatureMethod().addInterceptor(new InnerRetryInterceptor(retry, condition, throwables));
       invocation.proceed();
       if (throwables.isEmpty()) {
         break;
@@ -56,8 +57,8 @@ public class RetryIterationInterceptor extends RetryBaseInterceptor implements I
 
     private final Queue<Throwable> throwables;
 
-    public InnerRetryInterceptor(Retry retry, Queue<Throwable> throwables) {
-      super(retry);
+    public InnerRetryInterceptor(Retry retry, Closure condition, Queue<Throwable> throwables) {
+      super(retry, condition);
       this.throwables = throwables;
     }
 

--- a/spock-core/src/main/java/spock/lang/IgnoreIf.java
+++ b/spock-core/src/main/java/spock/lang/IgnoreIf.java
@@ -29,6 +29,11 @@ import org.spockframework.runtime.extension.builtin.IgnoreIfExtension;
 /**
  * Ignores the annotated spec or feature if the given condition holds.
  * Same as {@link Requires} except that the condition is inverted.
+ *
+ * The configured closure is called with a delegate of type
+ * {@link org.spockframework.runtime.extension.builtin.PreconditionContext}
+ * which provides access to system properties, environment variables, the type
+ * of operating system and JVM.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})

--- a/spock-core/src/main/java/spock/lang/Requires.java
+++ b/spock-core/src/main/java/spock/lang/Requires.java
@@ -29,6 +29,11 @@ import org.spockframework.runtime.extension.builtin.RequiresExtension;
 /**
  * Ignores the annotated spec or feature unless the given condition holds.
  * Same as {@link IgnoreIf} except that the condition is inverted.
+ *
+ * The configured closure is called with a delegate of type
+ * {@link org.spockframework.runtime.extension.builtin.PreconditionContext}
+ * which provides access to system properties, environment variables, the type
+ * of operating system and JVM.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})

--- a/spock-core/src/main/java/spock/lang/Retry.java
+++ b/spock-core/src/main/java/spock/lang/Retry.java
@@ -16,6 +16,7 @@
 
 package spock.lang;
 
+import groovy.lang.Closure;
 import org.spockframework.runtime.extension.ExtensionAnnotation;
 import org.spockframework.runtime.extension.builtin.RetryExtension;
 import org.spockframework.util.Beta;
@@ -42,6 +43,23 @@ public @interface Retry {
    * @return array of Exception classes to retry.
    */
   Class<? extends Throwable>[] exceptions() default {Exception.class, AssertionError.class};
+
+  /**
+   * Condition that is evaluated to decide whether the feature should be
+   * retried.
+   *
+   * The configured closure is called with a delegate of type
+   * {@link org.spockframework.runtime.extension.builtin.RetryConditionContext}
+   * which provides access to the current exception and {@code Specification}
+   * instance.
+   *
+   * The feature is retried if the exception class passes the type check and the
+   * specified condition holds true. If no condition is specified, only the type
+   * check is performed.
+   *
+   * @return predicate that must hold for the feature to be retried.
+   */
+  Class<? extends Closure> condition() default Closure.class;
 
   /**
    * The number of retries.


### PR DESCRIPTION
The `@Retry` annotation can now be used to configure an optional `condition` closure that is evaluated when a feature fails to determine whether it should be retried.

Resolves #872.