### PR TITLE
Ensure successful retry makes test succeed

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -5,7 +5,8 @@ include::include.adoc[]
 
 === What's New In This release
 
-* The `@Retry` extension can now be configured to evaluate a `condition` (<<extensions.adoc#_retry,Docs>>)
+* Add configurable `condition` to `@Retry` extension to allow for customizing when retries should be attempted (<<extensions.adoc#_retry,Docs>>)
+* Fix `Retry.Mode.FEATURE` and `Retry.Mode.SETUP_FEATURE_CLEANUP` to make a test pass if a retry was successful.
 
 == 1.2-RC1 (2018-08-14)
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryIterationInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryIterationInterceptor.java
@@ -42,6 +42,7 @@ public class RetryIterationInterceptor extends RetryBaseInterceptor implements I
       invocation.getFeature().getFeatureMethod().addInterceptor(new InnerRetryInterceptor(retry, condition, throwables));
       invocation.proceed();
       if (throwables.isEmpty()) {
+        throwableList.clear();
         break;
       } else {
         throwableList.addAll(throwables);


### PR DESCRIPTION
When using `Retry.Mode.{SETUP_FEATURE_CLEANUP, FEATURE}`, a failed iteration always made a test fail even when a retry was successful.

Fixes #876.