### PR TITLE
Upgrade Groovy to 2.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     minGroovyVersion = "2.4.0"
     groovyDependency = "org.codehaus.groovy:groovy-all:${groovyVersion}"
   } else if (variant == 2.5) {
-    groovyVersion = "2.5.0"
+    groovyVersion = "2.5.2"
     minGroovyVersion = "2.5.0"
     groovyDependency = [
       "org.codehaus.groovy:groovy:${groovyVersion}",


### PR DESCRIPTION
In the `-groovy-2.5` variant.

Preferably to be merged before the final Spock 1.2 version is released. As Spock uses `groovy-*` modules as dependency it is less convenient to override the version in your end project.