### PR TITLE
Exclude groovy-groovysh dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,12 @@ ext {
     groovyVersion = "2.4.15"
     minGroovyVersion = "2.4.0"
     groovyDependency = ["org.codehaus.groovy:groovy-all:${groovyVersion}"]
+    groovyConsoleExtraDependency = []  //bundled in groovy-all
   } else if (variant == 2.5) {
     groovyVersion = "2.5.2"
     minGroovyVersion = "2.5.2"
     groovyDependency = [
       "org.codehaus.groovy:groovy:${groovyVersion}",
-      "org.codehaus.groovy:groovy-groovysh:${groovyVersion}",
       "org.codehaus.groovy:groovy-json:${groovyVersion}",
       "org.codehaus.groovy:groovy-nio:${groovyVersion}",
       "org.codehaus.groovy:groovy-macro:${groovyVersion}",
@@ -33,6 +33,9 @@ ext {
       "org.codehaus.groovy:groovy-test:${groovyVersion}",
       "org.codehaus.groovy:groovy-sql:${groovyVersion}",
       "org.codehaus.groovy:groovy-xml:${groovyVersion}",
+    ]
+    groovyConsoleExtraDependency = [
+      "org.codehaus.groovy:groovy-groovysh:${groovyVersion}"
     ]
   } else {
     throw new InvalidUserDataException("Unknown variant: $variant. Choose one of: $variants")

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -8,6 +8,8 @@ What makes it stand out from the crowd is its beautiful and highly expressive sp
 Thanks to its JUnit runner, Spock is compatible with most IDEs, build tools, and continuous integration servers.
 Spock is inspired from JUnit, jMock, RSpec, Groovy, Scala, Vulcans, and other fascinating life forms.'''
 
+configurations { coreConsoleRuntime }
+
 dependencies {
   compile libs.groovy // easiest way to add Groovy dependency to POM
   compile libs.junit
@@ -18,7 +20,10 @@ dependencies {
   compile libs.bytebuddy, optional
   compile libs.cglib, optional
   compile libs.objenesis, optional
+
+  coreConsoleRuntime groovyConsoleExtraDependency
 }
+
 
 jar {
   manifest {
@@ -61,7 +66,7 @@ processResources {
 task coreConsole(type: JavaExec,
                  description: 'Start a groovy Console with Spock Core Classpath, usefull for AST-Inspection') {
   main = "groovy.ui.Console"
-  classpath = sourceSets.main.runtimeClasspath
+  classpath = sourceSets.main.runtimeClasspath + configurations.coreConsoleRuntime
   workingDir = file('build/console')
   ignoreExitValue = true
   args file('CoreConsole.groovy').absolutePath


### PR DESCRIPTION
It is needed only to start the Groovy console and should not pollute the compile classpath with the number of transitive dependencies:

```
+--- org.spockframework:spock-core:1.2-RC1-groovy-2.5
|    +--- org.codehaus.groovy:groovy:2.5.0
|    +--- org.codehaus.groovy:groovy-groovysh:2.5.0 <----------- HERE
|    |    +--- org.codehaus.groovy:groovy:2.5.0
|    |    +--- org.codehaus.groovy:groovy-cli-picocli:2.5.0
|    |    |    +--- org.codehaus.groovy:groovy:2.5.0
|    |    |    \--- info.picocli:picocli:3.0.2
|    |    +--- org.codehaus.groovy:groovy-console:2.5.0
|    |    |    +--- org.codehaus.groovy:groovy:2.5.0
|    |    |    +--- org.codehaus.groovy:groovy-cli-picocli:2.5.0 (*)
|    |    |    +--- org.codehaus.groovy:groovy-swing:2.5.0
|    |    |    |    \--- org.codehaus.groovy:groovy:2.5.0
|    |    |    \--- org.codehaus.groovy:groovy-templates:2.5.0
|    |    |         +--- org.codehaus.groovy:groovy:2.5.0
|    |    |         \--- org.codehaus.groovy:groovy-xml:2.5.0
|    |    |              \--- org.codehaus.groovy:groovy:2.5.0
|    |    \--- jline:jline:2.14.6
(...)
```