### PR TITLE
Fix void methods with implicit targets failing in `with` and `verifyAll`

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -9,6 +9,7 @@ include::include.adoc[]
 * Fix `Retry.Mode.FEATURE` and `Retry.Mode.SETUP_FEATURE_CLEANUP` to make a test pass if a retry was successful.
 * Improve `@Retry` to be declarable on a spec class which will apply it to all feature methods in that class and subclasses (<<extensions.adoc#_retry,Docs>>)
 * Fix issue with `@SpringBean` mocks throwing `InvocationTargetException` instead of actual declared exceptions (#878, #887)
+* Fix void methods with implicit targets failing in `with` and `verifyAll` (#886)
 
 == 1.2-RC1 (2018-08-14)
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlocks.groovy
@@ -16,7 +16,7 @@
 package org.spockframework.smoke
 
 import org.spockframework.runtime.SpockAssertionError
-import spock.lang.Specification
+import spock.lang.*
 
 class WithBlocks extends Specification {
   def "don't turn nested with expressions into condition"() {
@@ -130,6 +130,23 @@ class WithBlocks extends Specification {
     }
   }
 
+  @Issue('https://github.com/spockframework/spock/issues/886')
+  def "with works with void methods"() {
+    given:
+    Person person = new Person()
+    expect:
+    person.check()
+    checkCondition()
+    with(person) {
+      check()
+      checkCondition()
+      verifyAll {
+        check()
+        checkCondition()
+      }
+    }
+  }
+
   int size() {
     42
   }
@@ -138,10 +155,18 @@ class WithBlocks extends Specification {
     object == 4
   }
 
+  void checkCondition() {
+    assert true
+  }
+
   static class Person {
     String name = "Fred"
     int age = 42
     Person spouse
+
+    void check() {
+      assert true
+    }
   }
 
   static class Employee extends Person {

--- a/spock-specs/src/test/groovy/org/spockframework/verifyall/VerifyAllSpecification.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/verifyall/VerifyAllSpecification.groovy
@@ -3,6 +3,7 @@ package org.spockframework.verifyall
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.runtime.*
 import spock.lang.FailsWith
+import spock.lang.Issue
 
 import groovy.transform.*
 
@@ -58,7 +59,7 @@ class VerifyAllSpecification extends EmbeddedSpecification {
     result.failures[0].exception instanceof SpockTimeoutError
   }
 
-  def "if exception is not in condition, all already failed conditions should be reported"(){
+  def "if exception is not in condition, all already failed conditions should be reported"() {
     when:
     def result = runner.runWithImports("""
       import spock.util.concurrent.PollingConditions
@@ -202,9 +203,41 @@ class VerifyAllSpecification extends EmbeddedSpecification {
     }
   }
 
+  @Issue('https://github.com/spockframework/spock/issues/886')
+  def "verifyAll works with void methods"() {
+    expect:
+    checkCondition()
+    verifyAll {
+      checkCondition()
+      verifyAll {
+        checkCondition()
+        verifyAll {
+          checkCondition()
+        }
+      }
+    }
+  }
+
+  @Issue('https://github.com/spockframework/spock/issues/886')
+  def "verifyAll works with void methods of delegates"() {
+    given:
+    Person person = new Person()
+    expect:
+    person.check()
+    verifyAll(person) {
+      check()
+      verifyAll {
+        check()
+        verifyAll {
+          check()
+        }
+      }
+    }
+  }
+
   def "method condition is invoked on closure but not on the spec"() {
 
-    def map = [ 'value1' : 1, 'value2' : 2]
+    def map = ['value1': 1, 'value2': 2]
 
     expect:
     verifyAll(map) {
@@ -215,7 +248,7 @@ class VerifyAllSpecification extends EmbeddedSpecification {
 
   def "nested method conditions are invoked on closure but not on the spec"() {
 
-    def map = [ 'value1' : 1, 'value2' : 2]
+    def map = ['value1': 1, 'value2': 2]
 
     expect:
     verifyAll(map) {
@@ -307,6 +340,10 @@ class VerifyAllSpecification extends EmbeddedSpecification {
   boolean contains(Object object) {
     object == 4
   }
+
+  void checkCondition() {
+    assert true
+  }
 }
 
 
@@ -314,4 +351,8 @@ class VerifyAllSpecification extends EmbeddedSpecification {
 class Person {
   String name = "Fred"
   int age = 42
+
+  void check() {
+    assert true
+  }
 }


### PR DESCRIPTION
fixes #886