### PR TITLE
Use Lookup class loading strategy if available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,10 @@ subprojects {
     //'exit code 137' - https://github.com/travis-ci/travis-ci/issues/5582
     jvmArgs '-Xmx512m'
   }
+
+  jacoco {
+    toolVersion = '0.8.2'
+  }
 }
 
 task codeCoverageReport (type: JacocoReport, group: 'Coverage reports') {

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ ext {
     jetbrainsAnnotations: "org.jetbrains:annotations:13.0",
     ant: "org.apache.ant:ant:1.9.7",
     asm: "org.ow2.asm:asm:6.2",
-    bytebuddy: "net.bytebuddy:byte-buddy:1.8.3",
+    bytebuddy: "net.bytebuddy:byte-buddy:1.8.21",
     cglib: "cglib:cglib-nodep:3.2.7",
     groovy: groovyDependency,
     h2database: "com.h2database:h2:1.3.176",

--- a/spock-core/src/main/java/org/spockframework/mock/codegen/CodegenDummy.java
+++ b/spock-core/src/main/java/org/spockframework/mock/codegen/CodegenDummy.java
@@ -1,0 +1,11 @@
+package org.spockframework.mock.codegen;
+
+/**
+ * Serves as a reference point for method handle based class loading and is makes the containing package
+ * non-empty so generated classes can be legally defined inside of it.
+ */
+public class CodegenDummy {
+  private CodegenDummy() {
+    // never called
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/mock/codegen/Target.java
+++ b/spock-core/src/main/java/org/spockframework/mock/codegen/Target.java
@@ -4,8 +4,8 @@ package org.spockframework.mock.codegen;
  * Serves as a reference point for method handle based class loading and is makes the containing package
  * non-empty so generated classes can be legally defined inside of it.
  */
-public class CodegenDummy {
-  private CodegenDummy() {
+public class Target {
+  private Target() {
     // never called
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
@@ -29,7 +29,7 @@ class IgnoreIfExtension extends Specification {
     expect: false
   }
 
-  @IgnoreIf({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 || jvm.java10 })
+  @IgnoreIf({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 })
   def "provides JVM information"() {
     expect: false
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
@@ -41,7 +41,7 @@ class RequiresExtension extends Specification {
     expect: true
   }
 
-  @Requires({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 || jvm.java10 })
+  @Requires({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 })
   def "provides JVM information"() {
     expect: true
   }


### PR DESCRIPTION
In order to create mock objects on Java 11, `ProxyBasedMockFactory` now uses ByteBuddy's `Lookup`-based `ClassLoadingStrategy`, if available.

Resolves #843.