### PR TITLE
Do not export Groovy 2.5 dependencies other than groovy.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,7 @@ ext {
     groovyVersion = "2.5.2"
     minGroovyVersion = "2.5.2"
     groovyDependency = [
-      "org.codehaus.groovy:groovy:${groovyVersion}",
-      "org.codehaus.groovy:groovy-json:${groovyVersion}",
-      "org.codehaus.groovy:groovy-nio:${groovyVersion}",
-      "org.codehaus.groovy:groovy-macro:${groovyVersion}",
-      "org.codehaus.groovy:groovy-templates:${groovyVersion}",
-      "org.codehaus.groovy:groovy-test:${groovyVersion}",
-      "org.codehaus.groovy:groovy-sql:${groovyVersion}",
-      "org.codehaus.groovy:groovy-xml:${groovyVersion}",
+      "org.codehaus.groovy:groovy:${groovyVersion}"
     ]
     groovyConsoleExtraDependency = [
       "org.codehaus.groovy:groovy-groovysh:${groovyVersion}"


### PR DESCRIPTION
Spock's Groovy 2.5 variant depends on and exports all Groovy libraries as non-optional transitive dependencies, even though Spock itself actually only uses `groovy.jar` itself. Thus a project depending on Spock will also consume things like `groovy-xml` and `groovy-sql` as well as third-party libs `jline` and `junit`. This is unnecessary and can cause unnecessary conflicts downstream.

It's also a change compared to Groovy 2.4, where only `groovy-all.jar` would be present on the downstream project's classpath (all third-party dependencies being jarjar'd).

Spock should only depend on `groovy.jar`. If a project needs, say, groovy-xml to run some tests, it should add that dependency.