### PR TITLE
Add :spock-specs:mock-integration subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,20 +176,6 @@ subprojects {
     archives sourcesJar, javadocJar
   }
 
-  task testCglib(type: Test) {
-    systemProperty("org.spockframework.mock.ignoreByteBuddy", "true")
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-  }
-
-  if (gradle.startParameter.taskNames.contains("travisCiBuild")
-    || gradle.startParameter.taskNames.contains("shippableCiBuild")
-    || gradle.startParameter.taskNames.contains("appveyorCiBuild")) {
-    check.dependsOn testCglib
-  }
-
-  testCglib.mustRunAfter test
-
   tasks.withType(Test) {
     def taskName = name
     reports {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 include "spock-bom"
 include "spock-core"
 include "spock-specs"
+include "spock-specs:mock-integration"
 include "spock-spring"
 include "spock-spring:spring2-test"
 include "spock-spring:spring3-test"

--- a/spock-report/report.gradle
+++ b/spock-report/report.gradle
@@ -35,12 +35,6 @@ test {
   exclude "org/spockframework/report/sample/FightOrFlightSpec.class"
 }
 
-testCglib {
-  exclude "org/spockframework/report/sample/ParameterizedFightSpec.class"
-  exclude "org/spockframework/report/sample/FightOrFlightStory.class"
-  exclude "org/spockframework/report/sample/FightOrFlightSpec.class"
-}
-
 ext.spockLogFileDir = file("$buildDir/spock/logFiles")
 ext.spockLogFileName = "spock-log"
 
@@ -75,4 +69,3 @@ task sampleReport(type: org.spockframework.gradle.GenerateSpockReport) {
   spockReportClasspath = sourceSets.main.runtimeClasspath
   outputDirectory = file("$buildDir/spock/reports/")
 }
-

--- a/spock-specs/mock-integration/mock-integration.gradle
+++ b/spock-specs/mock-integration/mock-integration.gradle
@@ -1,0 +1,39 @@
+ext.displayName = "Spock Framework - Integration Specs for Mocking"
+
+description = "Integration Specs for Mocking"
+
+configurations {
+  cglib
+  bytebuddy
+  objenesis
+}
+
+dependencies {
+  testCompile(project(":spock-core")) {
+    exclude group: "cglib"
+    exclude group: "net.bytebuddy"
+    exclude group: "org.objenesis"
+  }
+  cglib libs.cglib
+  bytebuddy libs.bytebuddy
+  objenesis libs.objenesis
+}
+
+def codeGenerationLibraries = [
+  cglib: configurations.cglib,
+  ByteBuddy: configurations.bytebuddy
+]
+
+codeGenerationLibraries.each { key, config ->
+  tasks.create("test${key.capitalize()}WithoutObjenesis", Test) {
+    systemProperty("org.spockframework.mock.testType", "${key.toLowerCase()} - objenesis")
+    classpath += config
+  }
+  tasks.create("test${key.capitalize()}WithObjenesis", Test) {
+    systemProperty("org.spockframework.mock.testType", "${key.toLowerCase()} + objenesis")
+    classpath += config
+    classpath += configurations.objenesis
+  }
+}
+
+check.dependsOn(tasks.withType(Test))

--- a/spock-specs/mock-integration/src/test/groovy/MockingIntegrationSpec.groovy
+++ b/spock-specs/mock-integration/src/test/groovy/MockingIntegrationSpec.groovy
@@ -1,0 +1,64 @@
+import org.spockframework.mock.CannotCreateMockException
+import spock.lang.IgnoreIf
+import spock.lang.Requires
+import spock.lang.Specification
+
+class MockingIntegrationSpec extends Specification {
+
+  static final String TEST_TYPE = System.getProperty("org.spockframework.mock.testType", "plain");
+
+  def "can mock interface"() {
+    given:
+    def list = Mock(List)
+
+    when:
+    list.add(1)
+
+    then:
+    1 * list.add(1)
+  }
+
+  @IgnoreIf({ TEST_TYPE == "plain" })
+  def "can mock class when cglib or byte-buddy are present"() {
+    given:
+    def list = Mock(ArrayList)
+
+    when:
+    list.add(1)
+
+    then:
+    1 * list.add(1)
+  }
+
+  @Requires({ TEST_TYPE == "plain" })
+  def "cannot mock class without cglib and byte-buddy"() {
+    when:
+    Mock(ArrayList)
+
+    then:
+    thrown(CannotCreateMockException)
+  }
+
+  @IgnoreIf({ TEST_TYPE == "plain" })
+  def "can spy on class when cglib or byte-buddy are present"() {
+    given:
+    def list = Spy(ArrayList)
+
+    when:
+    list.add(1)
+
+    then:
+    1 * list.add(1)
+    list.get(0) == 1
+  }
+
+  @Requires({ TEST_TYPE == "plain" })
+  def "cannot spy on class without cglib and byte-buddy"() {
+    when:
+    Spy(ArrayList)
+
+    then:
+    thrown(CannotCreateMockException)
+  }
+
+}

--- a/spock-spring/spring.gradle
+++ b/spock-spring/spring.gradle
@@ -27,6 +27,13 @@ dependencies {
   testRuntime libs.log4j
 }
 
+task testCglib(type: Test) {
+  systemProperty("org.spockframework.mock.ignoreByteBuddy", "true")
+  mustRunAfter test
+}
+
+check.dependsOn testCglib
+
 jar {
   manifest {
     attributes(


### PR DESCRIPTION
The new project contains integration tests for using Spock to mock Java
interfaces/classes with cglib/byte-buddy and objenesis, and without any
of them.

In addition, the old testCglib task is removed because it is no longer
necessary to rerun all tests with byte-buddy deactivated.