### PR TITLE
Set groovy minVersion to 2.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     groovyConsoleExtraDependency = []  //bundled in groovy-all
   } else if (variant == 2.5) {
     groovyVersion = "2.5.2"
-    minGroovyVersion = "2.5.2"
+    minGroovyVersion = "2.5.0"
     groovyDependency = [
       "org.codehaus.groovy:groovy:${groovyVersion}",
       "org.codehaus.groovy:groovy-json:${groovyVersion}",


### PR DESCRIPTION
Done to support cases where 2.5.2 cannot be used: https://issues.apache.org/jira/browse/GROOVY-8779

See 

- https://github.com/spockframework/spock/pull/862#discussion_r216134686
- https://github.com/spockframework/spock/commit/a962d8cdf2430ab20b471138cc276e5f1b66577d#r30465428

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/905)
<!-- Reviewable:end -->
