### PR TITLE
Add NamedParam support for gradle-2.5 with backport to 2.4

### DIFF
--- a/internal-backport/internal-backport.gradle
+++ b/internal-backport/internal-backport.gradle
@@ -1,0 +1,1 @@
+// WARNING: This is Module is only present here so that we can build with 2.4 as well, the code will not be shipped.

--- a/internal-backport/src/main/java/groovy/transform/NamedParam.java
+++ b/internal-backport/src/main/java/groovy/transform/NamedParam.java
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// Backport so that we can add it for 2.5 but can still build with 2.4 as well
+
+/**
+ * Marker interface used to indicate that the name of the annotated parameter
+ * (or specified optional name) is a valid key name when using named arguments
+ * and that the parameter type is applicable for type checking purposes.
+ *
+ * @since 2.5.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface NamedParam {
+  String value() default Undefined.STRING;
+  Class type() default Object.class;
+  boolean required() default false;
+}

--- a/internal-backport/src/main/java/groovy/transform/NamedParam.java
+++ b/internal-backport/src/main/java/groovy/transform/NamedParam.java
@@ -23,9 +23,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-// Backport so that we can add it for 2.5 but can still build with 2.4 as well
 
 /**
+ * WARNING: This is only present here so that we can build with 2.4 as well, the code will not be shipped.
+ *
  * Marker interface used to indicate that the name of the annotated parameter
  * (or specified optional name) is a valid key name when using named arguments
  * and that the parameter type is applicable for type checking purposes.

--- a/internal-backport/src/main/java/groovy/transform/NamedParams.java
+++ b/internal-backport/src/main/java/groovy/transform/NamedParams.java
@@ -23,9 +23,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-// Backport so that we can add it for 2.5 but can still build with 2.4 as well
-
 /**
+ * WARNING: This is only present here so that we can build with 2.4 as well, the code will not be shipped.
+ *
  * Collector annotation for {@link NamedParam}.
  *
  * @since 2.5.0

--- a/internal-backport/src/main/java/groovy/transform/NamedParams.java
+++ b/internal-backport/src/main/java/groovy/transform/NamedParams.java
@@ -1,0 +1,37 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package groovy.transform;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// Backport so that we can add it for 2.5 but can still build with 2.4 as well
+
+/**
+ * Collector annotation for {@link NamedParam}.
+ *
+ * @since 2.5.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface NamedParams {
+  NamedParam[] value();
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,10 @@ include "spock-spring:spring2-test"
 include "spock-spring:spring3-test"
 include "spock-guice"
 
+if ((System.getProperty("variant") as BigDecimal ?: 2.4) == 2.4) {
+  include "internal-backport"
+}
+
 // https://issues.apache.org/jira/projects/TAP5/issues/TAP5-2588
 if (JavaVersion.current().isJava7() || JavaVersion.current().isJava8()) {
   include "spock-tapestry"

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -20,6 +20,9 @@ dependencies {
   compile libs.bytebuddy, optional
   compile libs.cglib, optional
   compile libs.objenesis, optional
+  if (variant == 2.4) {
+    compileOnly project(':internal-backport')
+  }
 
   coreConsoleRuntime groovyConsoleExtraDependency
 }

--- a/spock-core/src/main/java/spock/mock/MockingApi.java
+++ b/spock-core/src/main/java/spock/mock/MockingApi.java
@@ -14,13 +14,15 @@
 
 package spock.mock;
 
-import java.util.Map;
+import java.util.*;
 
 import groovy.lang.DelegatesTo;
+import groovy.transform.*;
 import groovy.transform.stc.ClosureParams;
 import groovy.transform.stc.FirstParam;
 import groovy.transform.stc.SecondParam;
 import org.spockframework.lang.SpecInternals;
+import org.spockframework.mock.*;
 import org.spockframework.runtime.GroovyRuntimeUtil;
 import org.spockframework.runtime.InvalidSpecException;
 import org.spockframework.util.Beta;
@@ -163,7 +165,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * enclosing variable assignment
    */
   @Beta
-  public <T> T Mock(Map<String, Object> options) {
+  public <T> T Mock(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options) {
     invalidMockCreation();
     return null;
   }
@@ -207,7 +217,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Override
   @Beta
-  public <T> T Mock(Map<String, Object> options, Class<T> type) {
+  public <T> T Mock(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
     return null;
   }
@@ -317,7 +335,14 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Beta
   public <T> T Mock(
-    Map<String, Object> options,
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options,
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -360,7 +385,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * enclosing variable assignment
    */
   @Beta
-  public <T> T Stub(Map<String, Object> options) {
+  public <T> T Stub(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options) {
     invalidMockCreation();
     return null;
   }
@@ -405,7 +438,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Override
   @Beta
-  public <T> T Stub(Map<String, Object> options, Class<T> type) {
+  public <T> T Stub(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
     return null;
   }
@@ -456,7 +497,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * from the left-hand side of the enclosing assignment
    */
   @Beta
-  public <T> T Stub(Map<String, Object> options, Closure interactions) {
+  public <T> T Stub(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options, Closure interactions) {
     invalidMockCreation();
     return null;
   }
@@ -515,7 +564,14 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Beta
   public <T> T Stub(
-    Map<String, Object> options,
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options,
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -558,7 +614,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * enclosing variable assignment
    */
   @Beta
-  public <T> T Spy(Map<String, Object> options) {
+  public <T> T Spy(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options) {
     invalidMockCreation();
     return null;
   }
@@ -629,7 +693,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Override
   @Beta
-  public <T> T Spy(Map<String, Object> options, Class<T> type) {
+  public <T> T Spy(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
     return null;
   }
@@ -678,7 +750,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * from the left-hand side of the enclosing assignment
    */
   @Beta
-  public <T> T Spy(Map<String, Object> options, Closure interactions) {
+  public <T> T Spy(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options, Closure interactions) {
     invalidMockCreation();
     return null;
   }
@@ -736,7 +816,14 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Beta
   public <T> T Spy(
-    Map<String, Object> options,
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class)
+    })
+      Map<String, Object> options,
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -779,7 +866,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * enclosing variable assignment
    */
   @Beta
-  public <T> T GroovyMock(Map<String, Object> options) {
+  public <T> T GroovyMock(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options) {
     invalidMockCreation();
     return null;
   }
@@ -822,7 +918,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * @return a Groovy mock with the specified options and type
    */
   @Beta
-  public <T> T GroovyMock(Map<String, Object> options, Class<T> type) {
+  public <T> T GroovyMock(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
     return null;
   }
@@ -873,7 +978,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * from the left-hand side of the enclosing assignment
    */
   @Beta
-  public <T> T GroovyMock(Map<String, Object> options, Closure interactions) {
+  public <T> T GroovyMock(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options, Closure interactions) {
     invalidMockCreation();
     return null;
   }
@@ -932,7 +1046,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Beta
   public <T> T GroovyMock(
-    Map<String, Object> options,
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options,
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -975,7 +1097,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * enclosing variable assignment
    */
   @Beta
-  public <T> T GroovyStub(Map<String, Object> options) {
+  public <T> T GroovyStub(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options) {
     invalidMockCreation();
     return null;
   }
@@ -1018,7 +1149,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * @return a Groovy stub with the specified options and type
    */
   @Beta
-  public <T> T GroovyStub(Map<String, Object> options, Class<T> type) {
+  public <T> T GroovyStub(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
     return null;
   }
@@ -1069,7 +1209,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * from the left-hand side of the enclosing assignment
    */
   @Beta
-  public <T> T GroovyStub(Map<String, Object> options, Closure interactions) {
+  public <T> T GroovyStub(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options, Closure interactions) {
     invalidMockCreation();
     return null;
   }
@@ -1128,7 +1277,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Beta
   public <T> T GroovyStub(
-    Map<String, Object> options,
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options,
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -1171,7 +1328,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * enclosing variable assignment
    */
   @Beta
-  public <T> T GroovySpy(Map<String, Object> options) {
+  public <T> T GroovySpy(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options) {
     invalidMockCreation();
     return null;
   }
@@ -1214,7 +1380,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * @return a Groovy spy with the specified options and type
    */
   @Beta
-  public <T> T GroovySpy(Map<String, Object> options, Class<T> type) {
+  public <T> T GroovySpy(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
     return null;
   }
@@ -1263,7 +1438,16 @@ public class MockingApi extends SpecInternals implements MockFactory {
    * from the left-hand side of the enclosing assignment
    */
   @Beta
-  public <T> T GroovySpy(Map<String, Object> options, Closure interactions) {
+  public <T> T GroovySpy(
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options, Closure interactions) {
     invalidMockCreation();
     return null;
   }
@@ -1321,7 +1505,15 @@ public class MockingApi extends SpecInternals implements MockFactory {
    */
   @Beta
   public <T> T GroovySpy(
-    Map<String, Object> options,
+    @NamedParams({
+      @NamedParam(value = "name", type = String.class),
+      @NamedParam(value = "additionalInterfaces", type = List.class),
+      @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "verified", type = Boolean.class),
+      @NamedParam(value = "useObjenesis", type = Boolean.class),
+      @NamedParam(value = "global", type = Boolean.class)
+    })
+      Map<String, Object> options,
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/921)
<!-- Reviewable:end -->
