### PR TITLE
Updated net.bytebuddy version

### DIFF
--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -50,7 +50,7 @@ jar {
         'org.hamcrest.*;version="[1,2)";resolution:=optional',
         'org.objenesis.*;version="[2,3)";resolution:=optional',
         'org.apache.tools.ant.*;version="[1.7,2)";resolution:=optional',
-        'net.bytebuddy.*;version="[1.6,2)";resolution:=optional',
+        'net.bytebuddy.*;version="[1.8,2)";resolution:=optional',
         'net.sf.cglib.*;version="[3.2,4)";resolution:=optional',
         'org.objectweb.asm.*;version="[5.2,6)";resolution:=optional',
         'org.w3c.dom.*'


### PR DESCRIPTION
Avoid java.lang.NoSuchMethodError: net.bytebuddy.dynamic.loading.ClassInjector$UsingLookup.isAvailable() - method introduced in version 1.8.0

Used here:
https://github.com/spockframework/spock/blame/master/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java#L103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/926)
<!-- Reviewable:end -->
