### PR TITLE
Filter Java 9+ reflection stack frames and properly escape dots in the filter regex

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/StackTraceFilter.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/StackTraceFilter.java
@@ -32,14 +32,15 @@ import java.util.regex.*;
 // IDEA: find entry points into user code by looking for BaseSpecRunner.invoke()/invokeRaw()
 public class StackTraceFilter implements IStackTraceFilter {
   private static final Pattern FILTERED_CLASSES = Pattern.compile(
-      "org.codehaus.groovy.runtime\\..*" +
-      "|org.codehaus.groovy.reflection\\..*" +
-      "|org.codehaus.groovy\\..*MetaClass.*" +
+      "\\Qorg.codehaus.groovy.runtime.\\E.*" +
+      "|\\Qorg.codehaus.groovy.reflection.\\E.*" +
+      "|\\Qorg.codehaus.groovy.\\E.*MetaClass.*" +
       "|groovy\\..*MetaClass.*" +
-      "|groovy.lang.MetaMethod" +
-      "|java.lang.reflect\\..*" +
-      "|sun.reflect\\..*" +
-      "|org.spockframework.runtime\\.[^.]+" // exclude subpackages
+      "|groovy\\.lang\\.MetaMethod" +
+      "|\\Qjava.lang.reflect.\\E.*" +
+      "|sun\\.reflect\\..*" +
+      "|\\Qjdk.internal.reflect.\\E.*" +
+      "|\\Qorg.spockframework.runtime.\\E[^.]+" // exclude subpackages
   );
 
   private static final Pattern CLOSURE_CLASS = Pattern.compile("(.+)\\$_(.+)_closure(\\d+)");

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/StackTraceFiltering.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/StackTraceFiltering.groovy
@@ -18,6 +18,7 @@ package org.spockframework.smoke
 
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.runtime.ConditionNotSatisfiedError
+import org.spockframework.runtime.StackTraceFilter
 import org.spockframework.runtime.WrongExceptionThrownError
 import org.spockframework.util.Identifiers
 
@@ -282,7 +283,7 @@ setup:
     ConditionNotSatisfiedError e = thrown()
     e.stackTrace[0].lineNumber == 2
   }
-  
+
   @Issue("http://issues.spockframework.org/detail?id=156")
   def "causes get filtered as well"() {
     when:
@@ -292,8 +293,8 @@ throw new IOException()
 
 then:
 thrown(RuntimeException)
-    """   
-    
+    """
+
     then:
     WrongExceptionThrownError e = thrown()
 
@@ -302,9 +303,34 @@ org.spockframework.lang.SpecInternals|checkExceptionThrown|-
 org.spockframework.lang.SpecInternals|thrownImpl|-
 apackage.ASpec|a feature|5
     """
-    
+
     stackTraceLooksLike e.cause, """
 apackage.ASpec|a feature|2
+    """
+  }
+
+  def "expected stack frames are filtered out"() {
+    given:
+    def e = new Exception()
+    e.stackTrace = [
+        new StackTraceElement('org.codehaus.groovy.runtime.Foo', 'bar', null, 0),
+        new StackTraceElement('org.codehaus.groovy.reflection.Foo', 'bar', null, 0),
+        new StackTraceElement('org.codehaus.groovy.FooMetaClassBaz', 'bar', null, 0),
+        new StackTraceElement('groovy.FooMetaClassBaz', 'bar', null, 0),
+        new StackTraceElement('groovy.lang.MetaMethod', 'bar', null, 0),
+        new StackTraceElement('java.lang.reflect.Foo', 'bar', null, 0),
+        new StackTraceElement('sun.reflect.Foo', 'bar', null, 0),
+        new StackTraceElement('jdk.internal.reflect.Foo', 'bar', null, 0),
+        new StackTraceElement('org.spockframework.runtime.Foo', 'bar', null, 0),
+        new StackTraceElement('org.spockframework.runtime.foo.Baz', 'bar', null, 0)
+    ]
+
+    when:
+    new StackTraceFilter(this.specificationContext.currentSpec).filter e
+
+    then:
+    stackTraceLooksLike e, """
+org.spockframework.runtime.foo.Baz|bar|0
     """
   }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/933)
<!-- Reviewable:end -->
