### PR TITLE
Use canoncial class name in comparison failure results if present, as they are usually more readable

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/FailedEqualityComparisonRenderer.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/FailedEqualityComparisonRenderer.java
@@ -23,6 +23,8 @@ public class FailedEqualityComparisonRenderer implements ExpressionComparisonRen
     if (expr.getRenderedValue() == null) return;
 
     Class<?> exprType = ObjectUtil.voidAwareGetClass(expr.getValue());
-    expr.setRenderedValue(expr.getRenderedValue() + " (" + exprType.getName() + ")");
+    String typeName = exprType.getCanonicalName();
+    typeName = typeName == null ? exprType.getName() : typeName;
+    expr.setRenderedValue(expr.getRenderedValue() + " (" + typeName + ")");
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/EqualityComparisonRendering.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/EqualityComparisonRendering.groovy
@@ -37,9 +37,9 @@ x == y
     isRendered """
 x == y
 | |  |
-| |  Fred (org.spockframework.smoke.condition.EqualityComparisonRendering\$Person)
+| |  Fred (org.spockframework.smoke.condition.EqualityComparisonRendering.Person)
 | false
-Fred (org.spockframework.smoke.condition.EqualityComparisonRendering\$Person)
+Fred (org.spockframework.smoke.condition.EqualityComparisonRendering.Person)
     """, {
       def x = new Person(name: "Fred")
       def y = new Person(name: "Fred")
@@ -58,6 +58,36 @@ x == y
     """, {
       def x = 1
       def y = "1"
+      assert x == y
+    }
+  }
+
+  def "values with same representations and different array types"() {
+    expect:
+    isRendered """
+x == y
+| |  |
+| |  [1] (java.lang.String[])
+| false
+[1] (int[])
+    """, {
+      def x = [1] as int[]
+      def y = ['1'] as String[]
+      assert x == y
+    }
+  }
+
+  def "values with same representations and different anonymous types"() {
+    expect:
+    isRendered '''
+x == y
+| |  |
+| |  foo (org.spockframework.smoke.condition.EqualityComparisonRendering$2)
+| false
+foo (org.spockframework.smoke.condition.EqualityComparisonRendering$1)
+    ''', {
+      def x = new Serializable() { String toString() { "foo" } }
+      def y = new Serializable() { String toString() { "foo" } }
       assert x == y
     }
   }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/934)
<!-- Reviewable:end -->
