### PR TITLE
Use maven-publish plugin for publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,6 @@ apply from: script("ide")
 subprojects {
   apply plugin: "groovy"
   apply plugin: "jacoco"
-  apply plugin: "signing"
 
   sourceCompatibility = javaVersions.min()
   targetCompatibility = javaVersions.min()
@@ -143,22 +142,6 @@ subprojects {
     compile(project.name == "spock-gradle" ? [] : libs.groovy)
   }
 
-  signing {
-    required { gradle.taskGraph.hasTask(':uploadArchives') }
-    sign configurations.archives
-  }
-
-  signArchives {
-    onlyIf { gradle.taskGraph.hasTask(':uploadArchives') }
-  }
-
-  ext."signing.keyId" = "2EA0A67F"
-  if (System.getenv("SIGNING_PASSWORD")) {
-    // if the password property is set, even if its null null, the SigningExtension will try to load the key
-    ext."signing.password" = System.getenv("SIGNING_PASSWORD")
-  }
-  ext."signing.secretKeyRingFile" = "$rootDir/config/code-signing-secring.gpg"
-
   configureJavadoc(javadoc)
   configureGroovydoc(groovydoc)
 
@@ -170,10 +153,6 @@ subprojects {
   task javadocJar(type: Jar) {
     classifier "javadoc"
     from javadoc
-  }
-
-  artifacts {
-    archives sourcesJar, javadocJar
   }
 
   tasks.withType(Test) {
@@ -257,7 +236,7 @@ if (gradle.startParameter.taskNames == ["travisCiBuild"]) {
   }
   if (System.getenv("TRAVIS_PULL_REQUEST") == "false" && System.getenv("TRAVIS_BRANCH") == "master") {
     if (javaVersion == javaVersions.min()) {
-      gradle.startParameter.taskNames += ["uploadArchives"]
+      gradle.startParameter.taskNames += ["publish"]
       if (!snapshotVersion) {
         gradle.startParameter.taskNames += ["tagRelease"]
       }

--- a/gradle/publishMaven.gradle
+++ b/gradle/publishMaven.gradle
@@ -1,92 +1,90 @@
-apply plugin: "maven"
+apply plugin: "maven-publish"
+apply plugin: "signing"
 
-def basePom = {
-  project {
-    name project.ext.displayName
-    description project.description
-    url "http://spockframework.org"
-
-    licenses {
-      license {
-        name "The Apache Software License, Version 2.0"
-        url "http://www.apache.org/licenses/LICENSE-2.0.txt"
-        distribution "repo"
-      }
-    }
-
-    scm {
-      connection "scm:git:git://github.com/spockframework/spock.git"
-      developerConnection "scm:git:ssh://git@github.com/spockframework/spock.git"
-      url "http://github.spockframework.org/spock"
-    }
-
-    developers {
-      developer {
-        id "pniederw"
-        name "Peter Niederwieser"
-        email "peter@pniederw.com"
-      }
-
-      developer {
-        id "ldaley"
-        name "Luke Daley"
-        email "ld@ldaley.com"
-      }
-    }
-  }
-}
-
-def deployers = []
-
-project.afterEvaluate {
-  configure(deployers) {
-    pom basePom
-  }
-}
-
-install {
-  deployers << repositories.mavenInstaller
-}
-
-uploadArchives {
-  deployers << repositories.mavenDeployer {
-    snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-      authentication(userName: "pniederw", password: System.getenv("SONATYPE_OSS_PASSWORD"))
-    }
-    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-      authentication(userName: "pniederw", password: System.getenv("SONATYPE_OSS_PASSWORD"))
-    }
-  }
-}
-
-def poms = deployers*.pom
 def optionalDeps = []
 def providedDeps = []
-def internalDeps = []
 
 ext {
-    modifyPom = { Closure modification ->
-      poms.each {
-        it.whenConfigured(modification)
+  optional = { optionalDeps << it; it }
+  provided = { providedDeps << it; it }
+}
+
+publishing {
+  publications {
+    maven(MavenPublication) {
+      from(components.java)
+      afterEvaluate {
+        if (pom.packaging != "pom") {
+          artifact(sourcesJar)
+          artifact(javadocJar)
+        }
+      }
+      pom {
+        name = provider { project.ext.displayName }
+        description = provider { project.description }
+        url = "http://spockframework.org"
+        licenses {
+          license {
+            name = "The Apache Software License, Version 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            distribution = "repo"
+          }
+        }
+        scm {
+          connection = "scm:git:git://github.com/spockframework/spock.git"
+          developerConnection = "scm:git:ssh://git@github.com/spockframework/spock.git"
+          url = "http://github.spockframework.org/spock"
+        }
+        developers {
+          developer {
+            id = "pniederw"
+            name = "Peter Niederwieser"
+            email = "peter@pniederw.com"
+          }
+          developer {
+            id = "ldaley"
+            name = "Luke Daley"
+            email = "ld@ldaley.com"
+          }
+        }
+        afterEvaluate {
+          withXml {
+            def dependencies = asNode().dependencies[0]
+            optionalDeps.each { dep ->
+              dependencies.find { it.artifactId.text() == dep.name }.appendNode("optional", true)
+            }
+            providedDeps.each { dep ->
+              dependencies.find { it.artifactId.text() == dep.name }.scope[0].value = "provided"
+            }
+          }
+        }
       }
     }
-    optional = { optionalDeps << it; it }
-    provided = { providedDeps << it; it }
-    internal = { internalDeps << it; it }
+  }
+  repositories {
+    maven {
+      def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+      def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+      url = snapshotVersion ? snapshotsRepoUrl : releasesRepoUrl
+      credentials {
+        username = "pniederw"
+        password = System.getenv("SONATYPE_OSS_PASSWORD")
+      }
+    }
+  }
 }
 
-modifyPom { pom ->
-  optionalDeps.each { dep ->
-    pom.dependencies.find { it.artifactId == dep.name }.optional = true
-  }
-  providedDeps.each { dep ->
-    pom.dependencies.find { it.artifactId == dep.name }.scope = "provided"
-  }
-  internalDeps.each { dep ->
-    pom.dependencies.removeAll { it.artifactId == dep.name }
-  }
-  // no need to publish test dependencies
-  pom.dependencies.removeAll { it.scope == "test" }
+// ensure all checks pass before publishing
+tasks.withType(AbstractPublishToMaven) {
+  dependsOn(check)
 }
 
-deployers*.beforeDeployment { signing.signPom(it) }
+signing {
+  sign(publishing.publications).each { task ->
+    task.onlyIf { gradle.taskGraph.hasTask(publish) }
+  }
+}
+
+ext."signing.keyId" = "2EA0A67F"
+ext."signing.password" = System.getenv("SIGNING_PASSWORD")
+ext."signing.secretKeyRingFile" = "$rootDir/config/code-signing-secring.gpg"

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,3 +38,5 @@ def nameBuildScriptsAfterProjectNames(projects) {
     nameBuildScriptsAfterProjectNames(prj.children)
   }
 }
+
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/spock-bom/bom.gradle
+++ b/spock-bom/bom.gradle
@@ -1,21 +1,15 @@
-plugins {
-  id 'maven'
-}
+apply from: script("publishMaven")
 
 def modifyBom = { xml ->
   def projectNode = xml.asNode()
 
   projectNode.remove(projectNode['dependencies'][0]) // remove default dependency section
 
-  projectNode['version'] + { // add packaging next to version
-    packaging 'pom'
-  }
-
   projectNode.appendNode('properties').appendNode('spock.version', project.fullVersion)
 
   def dependencyManagement = projectNode.appendNode('dependencyManagement').appendNode('dependencies')
 
-  def mvnProjects = project.parent.subprojects.findAll { it.hasProperty('install') } // find all published projects
+  def mvnProjects = project.parent.subprojects.findAll { it.plugins.hasPlugin('maven-publish') } // find all published projects
   mvnProjects -= project // don't self reference
 
   String groupId = project.group
@@ -32,68 +26,9 @@ ext.displayName = "Spock Framework - Bill of Materials"
 
 description = '''This bill of materials provides managed spock dependencies.'''
 
-def bom = {
-  project {
-    name project.ext.displayName
-    description project.description
-    url "http://spockframework.org"
-
-    licenses {
-      license {
-        name "The Apache Software License, Version 2.0"
-        url "http://www.apache.org/licenses/LICENSE-2.0.txt"
-        distribution "repo"
-      }
-    }
-
-    scm {
-      connection "scm:git:git://github.com/spockframework/spock.git"
-      developerConnection "scm:git:ssh://git@github.com/spockframework/spock.git"
-      url "http://github.spockframework.org/spock"
-    }
-
-    developers {
-      developer {
-        id "pniederw"
-        name "Peter Niederwieser"
-        email "peter@pniederw.com"
-      }
-
-      developer {
-        id "ldaley"
-        name "Luke Daley"
-        email "ld@ldaley.com"
-      }
-    }
+publishing.publications.maven {
+  pom {
+    packaging = 'pom'
+    withXml modifyBom
   }
 }
-task writeBom {
-  doLast {
-    pom(bom).withXml(modifyBom) .writeTo("$buildDir/pom.xml")
-  }
-}
-
-def deployers = []
-
-project.afterEvaluate {
-  configure(deployers) {
-    pom(bom).withXml(modifyBom)
-  }
-}
-
-install {
-  deployers << repositories.mavenInstaller
-}
-
-uploadArchives {
-  deployers << repositories.mavenDeployer {
-    snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-      authentication(userName: "pniederw", password: System.getenv("SONATYPE_OSS_PASSWORD"))
-    }
-    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-      authentication(userName: "pniederw", password: System.getenv("SONATYPE_OSS_PASSWORD"))
-    }
-  }
-}
-
-deployers*.beforeDeployment { signing.signPom(it) }

--- a/spock-guice/guice.gradle
+++ b/spock-guice/guice.gradle
@@ -7,8 +7,6 @@ description = "Spock's Guice Module provides support for testing Guice 2/3 based
 dependencies {
   compile project(":spock-core")
   compile "com.google.inject:guice:3.0", provided
-  // surfaces in the Guice API; groovyc complains if we don't add it
-  compile "aopalliance:aopalliance:1.0", internal
 }
 
 jar {

--- a/spock-unitils/unitils.gradle
+++ b/spock-unitils/unitils.gradle
@@ -8,12 +8,6 @@ dependencies {
   compile project(":spock-core")
   compile "org.unitils:unitils-core:3.3"
 
-  // the following are transitive deps of unitils-core with scope compile
-  // nevertheless, if we don't specify them explicitely, groovyc crashes with
-  // NoClassDefFoundError at org.codehaus.groovy.vmplugin.v5.Java5.configureClassNode(Java5.java:285)
-  compile "commons-collections:commons-collections:3.2", internal
-  compile "ognl:ognl:2.6.9", internal
-
   testCompile "org.unitils:unitils-dbunit:3.3", {
     exclude module: "jta"
   }


### PR DESCRIPTION
This commit changes the build's publishing from the old `maven` plugin to the new `maven-publish` plugin. Instead of calling `uploadArchives`, the new `publish` lifecycle task is used on Travis. After initially converting the `internal` dependencies to `compileOnly` ones, I've completely removed them and the build seemed fine. Moreover, the `spock-bom` subproject no longer publishes empty JAR artifacts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/950)
<!-- Reviewable:end -->
