### PR TITLE
Don't publish jar signature artifacts for spock-bom

### DIFF
--- a/gradle/publishMaven.gradle
+++ b/gradle/publishMaven.gradle
@@ -5,6 +5,7 @@ def optionalDeps = []
 def providedDeps = []
 
 ext {
+  packaging = null // use the default ("jar")
   optional = { optionalDeps << it; it }
   provided = { providedDeps << it; it }
 }
@@ -12,11 +13,21 @@ ext {
 publishing {
   publications {
     maven(MavenPublication) {
-      from(components.java)
       afterEvaluate {
-        if (pom.packaging != "pom") {
+        pom.packaging = project.ext.packaging
+        if (project.ext.packaging != "pom") {
+          from(components.java)
           artifact(sourcesJar)
           artifact(javadocJar)
+          pom.withXml {
+            def dependencies = asNode().dependencies[0]
+            optionalDeps.each { dep ->
+              dependencies.find { it.artifactId.text() == dep.name }.appendNode("optional", true)
+            }
+            providedDeps.each { dep ->
+              dependencies.find { it.artifactId.text() == dep.name }.scope[0].value = "provided"
+            }
+          }
         }
       }
       pom {
@@ -45,17 +56,6 @@ publishing {
             id = "ldaley"
             name = "Luke Daley"
             email = "ld@ldaley.com"
-          }
-        }
-        afterEvaluate {
-          withXml {
-            def dependencies = asNode().dependencies[0]
-            optionalDeps.each { dep ->
-              dependencies.find { it.artifactId.text() == dep.name }.appendNode("optional", true)
-            }
-            providedDeps.each { dep ->
-              dependencies.find { it.artifactId.text() == dep.name }.scope[0].value = "provided"
-            }
           }
         }
       }

--- a/spock-bom/bom.gradle
+++ b/spock-bom/bom.gradle
@@ -3,8 +3,6 @@ apply from: script("publishMaven")
 def modifyBom = { xml ->
   def projectNode = xml.asNode()
 
-  projectNode.remove(projectNode['dependencies'][0]) // remove default dependency section
-
   projectNode.appendNode('properties').appendNode('spock.version', project.fullVersion)
 
   def dependencyManagement = projectNode.appendNode('dependencyManagement').appendNode('dependencies')
@@ -22,13 +20,12 @@ def modifyBom = { xml ->
   }
 }
 
-ext.displayName = "Spock Framework - Bill of Materials"
-
-description = '''This bill of materials provides managed spock dependencies.'''
+ext.displayName = 'Spock Framework - Bill of Materials'
+description = 'This bill of materials provides managed spock dependencies.'
+ext.packaging = 'pom'
 
 publishing.publications.maven {
   pom {
-    packaging = 'pom'
     withXml modifyBom
   }
 }


### PR DESCRIPTION
Prior to this commit, spock-bom was using `components.java`
unnecessarily. As a side-effect, `spock-bom-*.jar.asc` was published
alongside the POM.

---

This PR was originally submitted as #951. However, the PR used the wrong base/target branch (`stable-publishing` instead of `master`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/953)
<!-- Reviewable:end -->
