### PR TITLE
Info annotation

### DIFF
--- a/spock-core/src/main/java/spock/lang/FeatureInfo.java
+++ b/spock-core/src/main/java/spock/lang/FeatureInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spock.lang;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+
+/**
+ * Allows to attaching id, impact, component and frequency of failure along with any addional data.
+ * This can be used in ACC analysis and risk based testing
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface FeatureInfo {
+  String id() default "";
+  int impact() default 1;
+  int frequencyOfFailure() default 1;
+  String component() default "";
+  String[] additionalInfo() default {};
+}

--- a/spock-core/src/main/java/spock/lang/FeatureInfo.java
+++ b/spock-core/src/main/java/spock/lang/FeatureInfo.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
 
 
 /**
- * Allows to attaching id, impact, component and frequency of failure along with any addional data.
+ * Allows attaching id, impact, component and frequency of failure along with any addional data.
  * This can be used in ACC analysis and risk based testing
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -32,5 +32,4 @@ public @interface FeatureInfo {
   int impact() default 1;
   int frequencyOfFailure() default 1;
   String component() default "";
-  String[] additionalInfo() default {};
 }

--- a/spock-specs/src/test/groovy/org/spockframework/example/FeatureUnrolling.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/example/FeatureUnrolling.groovy
@@ -16,6 +16,7 @@
 
 package org.spockframework.example
 
+import spock.lang.FeatureInfo
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -23,6 +24,7 @@ import spock.lang.Unroll
  * @author Peter Niederwieser
  */
 class FeatureUnrolling extends Specification {
+  @FeatureInfo(id = "4b873cc6-f204-4517-aa3a-93834963046c",impact = 6,frequencyOfFailure = 1,component = "Feature Unrolling")
   def "without unrolling"() {
     expect:
     name.size() == length
@@ -31,7 +33,7 @@ class FeatureUnrolling extends Specification {
     name << ["Kirk", "Spock", "Scotty"]
     length << [4, 5, 6]
   }
-
+  @FeatureInfo(id = "6cca6feb-8049-4d12-82fe-5534e41e311b",impact = 3,frequencyOfFailure = 1,component = "Feature Unrolling")
   @Unroll
   def "with unrolling"() {
     expect:
@@ -41,7 +43,7 @@ class FeatureUnrolling extends Specification {
     name << ["Kirk", "Spock", "Scotty"]
     length << [4, 5, 6]
   }
-
+  @FeatureInfo(id = "01fdbb08-7163-4a8a-a806-aad04f34406b",impact = 2,frequencyOfFailure = 1,component = "Feature Unrolling")
   @Unroll("length of '#name' should be #length")
   def "with unrolling and custom naming pattern"() {
     expect:


### PR DESCRIPTION
An annotation, FeatureInfo, to add information about some of the basic test attributes. 
This annotation then can be integrated with Spock Reports to add the following
1. Id (Need to identify every feature uniquely)
2. Impact (Impact of the feature, if it fails)
3. The frequency of Failure (Probability of a feature failing)
4. Component (Which component it may be associated with. Example: shopping cart, product page etc )

These params then cab be used to create reports like ACC (https://testing.googleblog.com/2011/10/google-test-analytics-now-in-open.html)