### PR TITLE
print contents of nested array in comparision

### DIFF
--- a/spock-core/src/main/java/org/spockframework/util/RenderUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/RenderUtil.java
@@ -59,7 +59,7 @@ public abstract class RenderUtil {
 
   private static String dump(@Nullable Object value) {
     if (value.getClass().isArray()) {
-      return dumpArrayString((Object[])value);
+      return Arrays.deepToString((Object[])value);
     } else {
       return DefaultGroovyMethods.dump(value);
     }


### PR DESCRIPTION
#958 use `Arrays.deepToString` instead of `dumpArrayString` to get values of nested array 