### PR TITLE
Add support for chaining sequences of closures

### DIFF
--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -672,6 +672,20 @@ subscriber.receive(_) >>> ["ok", "fail", "ok"] >> { throw new InternalError() } 
 This will return `"ok", "fail", "ok"` for the first three invocations, throw `InternalError`
 for the fourth invocations, and return `ok` for any further invocation.
 
+Alternatively, we can use a single list:
+
+[source,groovy]
+----
+subscriber.receive(_) >>> ["ok", "fail", "ok", { throw new InternalError() }, "ok"]
+----
+
+This can be particularly useful in cases where we have repeated method responses:
+
+[source,groovy]
+----
+subscriber.receive(_) >>> [{ throw new InternalError() }] * 3 >> "ok"
+----
+
 == Combining Mocking and Stubbing
 
 Mocking and stubbing go hand-in-hand:


### PR DESCRIPTION
This enables the use of closures in the lists passed to the triple-right-shift (>>>) operator.

**Examples**
 1. The expression

 ``queue.poll() >> { throw new UnsupportedOperationException() } >> { throw new UnsupportedOperationException() } >> 0``

 can now be written as

 ``queue.poll() >>> [{ throw new UnsupportedOperationException() }] * 2 >> 0``

  2. The lists can be heterogeneous, containing both closures and values:

  ``queue.poll() >>> [{ throw new UnsupportedOperationException() }, 0, { count++ }, 2, [3, 4]]``

   3. More examples can be found in the test file [spock-specs/src/test/groovy/org/spockframework/smoke/mock/ChainedResponseGenerators.groovy](https://github.com/jff/spock/blob/1da312602fdda8c0337b95ea42c6f07e5584e167/spock-specs/src/test/groovy/org/spockframework/smoke/mock/ChainedResponseGenerators.groovy)