### PR TITLE
Spock 2.0 fix skipped test count

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/MethodSelectorResolver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/MethodSelectorResolver.java
@@ -96,13 +96,12 @@ public class MethodSelectorResolver implements SelectorResolver {
     return new ParameterizedFeatureNode(toUniqueId(parentId, feature), feature);
   }
 
-  private FeatureNode describeSimpleFeature(UniqueId parentId, FeatureInfo feature) {
-    SimpleFeatureNode simpleFeatureNode = new SimpleFeatureNode(toUniqueId(parentId, feature), feature);
+  private SpockNode describeSimpleFeature(UniqueId parentId, FeatureInfo feature) {
     IterationInfo iterationInfo = new IterationInfo(feature, EMPTY_ARGS, 1);
     iterationInfo.setName(feature.getName());
-    IterationNode iterationNode = new IterationNode(toUniqueId(simpleFeatureNode.getUniqueId(), feature), iterationInfo);
-    simpleFeatureNode.addChild(iterationNode);
-    return simpleFeatureNode;
+    UniqueId uniqueId = toUniqueId(parentId, feature);
+    IterationNode iterationNode = new IterationNode(toUniqueId(uniqueId, feature), iterationInfo);
+    return new SimpleFeatureNode(uniqueId, feature, iterationNode);
   }
 
   private UniqueId toUniqueId(UniqueId parentId, FeatureInfo feature) {

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
@@ -24,6 +24,11 @@ public class ParameterizedFeatureNode extends FeatureNode {
     return context;
   }
 
+  @Override
+  public Type getType() {
+    return Type.CONTAINER_AND_TEST;
+  }
+
   class ChildExecutor implements DynamicTestExecutor {
 
     private final DynamicTestExecutor delegate;

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
@@ -26,7 +26,7 @@ public class ParameterizedFeatureNode extends FeatureNode {
 
   @Override
   public Type getType() {
-    return Type.CONTAINER_AND_TEST;
+    return Type.CONTAINER;
   }
 
   class ChildExecutor implements DynamicTestExecutor {

--- a/spock-core/src/main/java/org/spockframework/runtime/SimpleFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SimpleFeatureNode.java
@@ -5,13 +5,57 @@ import org.spockframework.runtime.model.FeatureInfo;
 import org.junit.platform.engine.*;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 
+/**
+ * A non-parametric feature (test) that only has a single "iteration".
+ * Contrary to parametric tests - where the iterations are the children - this is the actual test. The execution
+ * is only delegated, but does not cause any extra test events for the single iteration.
+ */
 public class SimpleFeatureNode extends FeatureNode {
-  public SimpleFeatureNode(UniqueId uniqueId, FeatureInfo featureInfo) {
+  private final IterationNode delegate;
+
+  public SimpleFeatureNode(UniqueId uniqueId, FeatureInfo featureInfo, IterationNode delegate) {
     super(uniqueId, featureInfo.getName(),  MethodSource.from(featureInfo.getFeatureMethod().getReflection()), featureInfo);
+    this.delegate = delegate;
   }
 
   @Override
-  public SpockExecutionContext prepare(SpockExecutionContext context) throws Exception {
-    return context.withCurrentFeature(featureInfo); //.withParentId(getUniqueId())
+  public Type getType() {
+    return delegate.getType();
   }
+
+
+  @Override
+  public SpockExecutionContext prepare(SpockExecutionContext context) throws Exception {
+    // return context.withCurrentFeature(featureInfo); //.withParentId(getUniqueId())
+    return delegate.prepare(context.withCurrentFeature(featureInfo));
+  }
+
+  @Override
+  public SpockExecutionContext before(SpockExecutionContext context) throws Exception {
+    context.getRunner().runSetup(context);
+    return context;
+  }
+
+  @Override
+  public SpockExecutionContext execute(SpockExecutionContext context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
+    // context.getRunner().runFeatureMethod(context);
+    delegate.execute(context, dynamicTestExecutor);
+    return context;
+  }
+
+  @Override
+  public void after(SpockExecutionContext context) throws Exception {
+    delegate.after(context);
+  }
+
+  @Override
+  public void around(SpockExecutionContext context, Invocation<SpockExecutionContext> invocation) {
+    delegate.around(context, invocation);
+  }
+
+  @Override
+  public SkipResult shouldBeSkipped(SpockExecutionContext context) throws Exception {
+    return delegate.shouldBeSkipped(context);
+  }
+
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecNode.java
@@ -31,6 +31,12 @@ public class SpecNode extends SpockNode {
   }
 
   @Override
+  public SkipResult shouldBeSkipped(SpockExecutionContext context) throws Exception {
+    System.out.println("Skipping spec=" + specInfo.isSkipped());
+    return specInfo.isSkipped() ? SkipResult.skip("because I said so") : SkipResult.doNotSkip();
+  }
+
+  @Override
   public SpockExecutionContext before(SpockExecutionContext context) throws Exception {
     context.getRunner().runSetupSpec(context);
     return context;


### PR DESCRIPTION
The `SpockHelloWorldTest` failed because each `FeatureNode` was of type `CONTAINER` and had an `IterationNode` as child. Appearently when a `CONTAINER` node is skipped, it does not generate any test event that show up in the summary of the unit test.

There are two cases:
* A `SimpleFeatureNode` represents the test itself. It should not have any children, thus it is of type `TEST` (a _leaf_ node in the tree). It delegates to an `IterationNode` without having it as a child.
* A `ParametrizedFeatureNode` represents both a container and (probably) a test itself. It can have zero or more `IteratioNode`s and the test results in all children summarize the test itself. This it should be either of type `CONTAINER` or `CONTAINER_AND_TEST`.

Additionally I added the possiblity to skip a whole `SpecNode` altogehter (`@Ignore(If)` on the specification class).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/981)
<!-- Reviewable:end -->
