### PR TITLE
Changed "eventually" usage example to reflect asynchronous logic

### DIFF
--- a/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
+++ b/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
@@ -36,8 +36,9 @@ import org.spockframework.util.Beta;
  *
  * then:
  * conditions.eventually {
- *   assert machine.temperature >= 100
- *   assert machine.efficiency >= 0.9
+ *   def reading = machine.engineReading
+ *   assert reading.temperature >= 100
+ *   assert reading.efficiency >= 0.9
  * }
  * </pre>
  */


### PR DESCRIPTION
I've attempted to make the usage example more transparent, as I've lost track on how many times I've been asked why the "machine" variable isn't (magically) updated by Spock.
And I attempt to explain that the original Machine example seems to be thread-based.

Hopefully this change aids those who use PollingConditions to test asynchronous logic.