### PR TITLE
Call invocation.proceed() by default in abstract method interceptor

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/AbstractMethodInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/AbstractMethodInterceptor.java
@@ -19,7 +19,7 @@ import org.spockframework.util.UnreachableCodeError;
 public abstract class AbstractMethodInterceptor implements IMethodInterceptor {
   @Override
   public final void intercept(IMethodInvocation invocation) throws Throwable {
-    switch(invocation.getMethod().getKind()) {
+    switch (invocation.getMethod().getKind()) {
       case INITIALIZER:
         interceptInitializerMethod(invocation);
         break;
@@ -61,16 +61,51 @@ public abstract class AbstractMethodInterceptor implements IMethodInterceptor {
     }
   }
 
-  public void interceptInitializerMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptSharedInitializerMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptSetupMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptCleanupMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptSetupSpecMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptCleanupSpecMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptFeatureMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptDataProviderMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptDataProcessorMethod(IMethodInvocation invocation) throws Throwable {}
-  public void interceptIterationExecution(IMethodInvocation invocation) throws Throwable {}
-  public void interceptSpecExecution(IMethodInvocation invocation) throws Throwable {}
-  public void interceptFeatureExecution(IMethodInvocation invocation) throws Throwable {}
+  public void interceptInitializerMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptSharedInitializerMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptSetupMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptCleanupMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptSetupSpecMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptCleanupSpecMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptFeatureMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptDataProviderMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptDataProcessorMethod(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptIterationExecution(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptSpecExecution(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
+
+  public void interceptFeatureExecution(IMethodInvocation invocation) throws Throwable {
+    invocation.proceed();
+  }
 }


### PR DESCRIPTION
I find it strange to use `AbstractMethodInterceptor` without the default `invocation.proceed()` behavior. This way I can only override the desired method(s) and don't worry that the whole spock execution will be ruined when using `foo.addInterceptor(...)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1012)
<!-- Reviewable:end -->
