### PR TITLE
Allow to intercept 'no data' exception in extensions

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/JUnitSupervisor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/JUnitSupervisor.java
@@ -188,8 +188,7 @@ public class JUnitSupervisor implements IRunSupervisor {
   public void afterFeature(FeatureInfo feature) {
     if (feature.isParameterized()) {
       if (iterationCount == 0 && !errorSinceLastReset)
-        notifier.fireTestFailure(new Failure(feature.getDescription(),
-            new SpockExecutionException("Data provider has no data")));
+        throw new SpockExecutionException("Data provider has no data");
     }
 
     masterListener.afterFeature(feature);


### PR DESCRIPTION
This is related to #961 . Currently there is no ability to intercept the thrown `SpockExecutionException`. This pr allows exception to be intercepted by extensions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1013)
<!-- Reviewable:end -->
