### PR TITLE
Fix anonymous inner classes

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -257,6 +257,14 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
     spec.getAst().addMethod(newAst);
     feature.setAst(newAst);
     AstUtil.deleteMethod(spec.getAst(), oldAst);
+
+    Iterator<InnerClassNode> innerClassesOfDeclaringClass = oldAst.getDeclaringClass().getInnerClasses();
+    while (innerClassesOfDeclaringClass.hasNext()) {
+      InnerClassNode innerClass = innerClassesOfDeclaringClass.next();
+      if (oldAst.equals(innerClass.getEnclosingMethod())) {
+        innerClass.setEnclosingMethod(newAst);
+      }
+    }
   }
 
   private String createInternalName(FeatureMethod feature) {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/AnonymousInnerClasses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/AnonymousInnerClasses.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke
+
+import org.spockframework.EmbeddedSpecification
+
+class AnonymousInnerClasses extends EmbeddedSpecification {
+  def "anonymous inner class and dot in feature name does not fail execution"() {
+    when:
+    runner.runSpecBody("""
+def '.'() {
+  expect:
+  new Object() { }
+}
+    """)
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "enclosing method of anonymous inner class can be accessed"() {
+    when:
+    runner.runFeatureBody("""
+expect:
+new Object() { }.getClass().enclosingMethod
+    """)
+
+    then:
+    noExceptionThrown()
+  }
+}


### PR DESCRIPTION
I have a test like
```groovy
def '#testee.getClass().simpleName should have #aliases #expectedAliases'() {
    expect:
        testee.aliases == expectedAliases

    where:
        testee                || expectedAliases
        new BaseCommand() { } || [testee.getClass().typeName[(testee.getClass().package.name.length() + 1)..-1].uncapitalize()]

    and:
        aliases = expectedAliases.size() == 1 ? 'alias' : 'aliases'
}
```
which runs fine with Java 8, but with Java 11 I get
```
Illegal method name "#testee.getClass().simpleName should have #aliases #expectedAliases" in class net/kautler/command/api/CommandTest$1
java.lang.ClassFormatError: Illegal method name "#testee.getClass().simpleName should have #aliases #expectedAliases" in class net/kautler/command/api/CommandTest$1
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:802)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:700)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:623)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at net.kautler.command.api.CommandTest.#testee.getClass().simpleName should have #aliases #expectedAliases(CommandTest.groovy:56)
```
Where `CommandTest$1` is the `new BaseCommand() { }`.
If I instead do
```groovy
@Unroll('#testee.getClass().simpleName should have #aliases #expectedAliases')
def 'foo'() {
```
it works fine.

I found out this has to do with the enclosing method.
If I run with Java 8 and do `testee.getClass().getEnclosingMethodInfo()`,
I get `#testee.getClass().simpleName should have #aliases #expectedAliases` as enclosing method,
but calling `testee.getClass().getEnclosingMethod()` throws an `InternalError("Enclosing method not found")`,
as in the transformed spec the enclosing method was changed due to AST rewriting,
but the inner class was not rewritten to have a valid method as enclosing method.

It seems in Java 11 the validation in `java.lang.ClassLoader.defineClass1(...)` was extended
to there already validate the enclosing method name for syntactical correctness.

I still get the `InternalError` when using the `@Unroll` annotation and name the method `foo`,
but at least then `defineClass1(...)` is happy.

I added a breakpoint in `org.spockframework.compiler.SpecRewriter#transplantMethod`
after `newAst` was created that does evaluate
`oldAst.declaringClass.innerClasses.findAll { it.enclosingMethod == oldAst }*.enclosingMethod = newAst`
and suddenly the test succeeds properly and also `testee.enclosingMethod` can be properly resolved.

So the changes in this PR do exactly this, they find inner classes that have the
old rewritten feature method as enclosing method and set the new rewritten feature
method as enclosing method instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1027)
<!-- Reviewable:end -->
