### PR TITLE
Make the $spock_interceptor field synthetic

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
@@ -3,6 +3,7 @@ package org.spockframework.mock.runtime;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.TypeCache;
 import net.bytebuddy.description.modifier.SynchronizationState;
+import net.bytebuddy.description.modifier.SyntheticState;
 import net.bytebuddy.description.modifier.Visibility;
 import net.bytebuddy.dynamic.Transformer;
 import net.bytebuddy.dynamic.loading.ClassInjector;
@@ -66,7 +67,7 @@ class ByteBuddyMockFactory {
             .transform(Transformer.ForMethod.withModifiers(SynchronizationState.PLAIN, Visibility.PUBLIC)) // Overridden methods should be public and non-synchronized.
             .implement(ByteBuddyInterceptorAdapter.InterceptorAccess.class)
             .intercept(FieldAccessor.ofField("$spock_interceptor"))
-            .defineField("$spock_interceptor", IProxyBasedMockInterceptor.class, Visibility.PRIVATE)
+            .defineField("$spock_interceptor", IProxyBasedMockInterceptor.class, Visibility.PRIVATE, SyntheticState.SYNTHETIC)
             .make()
             .load(classLoader, strategy)
             .getLoaded();


### PR DESCRIPTION
According to [JLS 4.7.8](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.8)

> A class member that does not appear in the source code must be marked using a Synthetic attribute,
> or else it must have its ACC_SYNTHETIC flag set. The only exceptions to this requirement are
> compiler-generated methods which are not considered implementation artifacts, namely the instance
> initialization method representing a default constructor of the Java programming language (§2.9),
> the class initialization method (§2.9), and the Enum.values() and Enum.valueOf() methods.

So I'd say it makes sense to mark the `$spock_interceptor` field as synthetic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1031)
<!-- Reviewable:end -->
