### PR TITLE
fix $ escaping in spock_primer.adoc

### DIFF
--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -632,10 +632,10 @@ Spock directly supports this style of specification with the `given:` label:
 given: "an empty bank account"
 // ...
 
-when: "the account is credited $10"
+when: "the account is credited \$10"
 // ...
 
-then: "the account's balance is $10"
+then: "the account's balance is \$10"
 // ...
 ----
 


### PR DESCRIPTION
Example before a fix cannot be compiled because there is used GString and $ have special meaning so we need escape $.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1052)
<!-- Reviewable:end -->
