### PR TITLE
Fix asciidoctor generation in Spock 2.0-m1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -347,9 +347,12 @@ asciidoctor {
   attributes "source-highlighter": "coderay", "linkcss": true, "sectanchors": true, "revnumber": variantLessVersion
   // also treats the included specs as inputs
   inputs.dir file("spock-specs/src/test/groovy/org/spockframework/docs")
-  inputs.dir file("spock-spring/src/test/groovy/org/spockframework/docs")
-  inputs.dir file("spock-spring/src/test/resources/org/spockframework/docs")
-  inputs.dir file("spock-spring/boot/test/src/test/groovy/org/spockframework/boot")
+  inputs.dir file("spock-spring/src/test/groovy/org/spockframework/spring/docs")
+  inputs.dir file("spock-spring/src/test/resources/org/spockframework/spring/docs")
+  inputs.dir file("spock-spring/boot-test/src/test/groovy/org/spockframework/boot")
+  inputs.dir file("spock-spring/boot2-test/src/test/groovy/org/spockframework/boot2")
+  inputs.dir file("spock-spring/spring3-test/src/test/groovy/org/spockframework/spring3")
+  inputs.dir file("spock-spring/spring5-test/src/test/groovy/org/spockframework/spring5")
 }
 
 File script(String name) {


### PR DESCRIPTION
Issue after 2.0-m1 merge [visible](https://travis-ci.org/spockframework/spock/jobs/607243490#L729) only in master (where asciidoctor documentation generation is enabled).

Local execution:
```
$ gw asciidoctor

> Configure project :spock-core
[versioning] WARNING - the working copy has unstaged or uncommitted changes.

> Task :asciidoctor
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.vmplugin.v7.Java7$1 (file:/home/foobar/.gradle/wrapper/dists/gradle-5.6.3-bin/71q0cerxks9z090hthk8vq8r7/gradle-5.6.3/lib/groovy-all-1.3-2.5.4.jar) to constructor java.lang.invoke.MethodHandles$Lookup(java.lang.Class,int)
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.vmplugin.v7.Java7$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Converting /home/foobar/Code/inne/spock/docs/include.adoc
Converting /home/foobar/Code/inne/spock/docs/migration_guide.adoc
Converting /home/foobar/Code/inne/spock/docs/interaction_based_testing.adoc
Converting /home/foobar/Code/inne/spock/docs/modules.adoc
Converting /home/foobar/Code/inne/spock/docs/data_driven_testing.adoc
Converting /home/foobar/Code/inne/spock/docs/module_spring.adoc
Converting /home/foobar/Code/inne/spock/docs/all_in_one.adoc
Converting /home/foobar/Code/inne/spock/docs/introduction.adoc
Converting /home/foobar/Code/inne/spock/docs/index.adoc
Converting /home/foobar/Code/inne/spock/docs/extensions.adoc
Converting /home/foobar/Code/inne/spock/docs/release_notes.adoc
Converting /home/foobar/Code/inne/spock/docs/getting_started.adoc
Converting /home/foobar/Code/inne/spock/docs/spock_primer.adoc

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 5s
1 actionable task: 1 executed

The HTML5 documentation looks ok, but I haven't checked for missing references, etc (some might required an update to 2.0-m1).

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1053)
<!-- Reviewable:end -->
