### PR TITLE
Modernize Jvm structure in conditional test execution

### DIFF
--- a/spock-core/src/main/java/spock/util/environment/Jvm.java
+++ b/spock-core/src/main/java/spock/util/environment/Jvm.java
@@ -101,6 +101,56 @@ public class Jvm {
   }
 
   /**
+   * Tells whether the Java version is 13.
+   *
+   * @since 2.0
+   * @return whether the Java version is 13
+   */
+  public boolean isJava13() {
+    return "13".equals(javaSpecVersion);
+  }
+
+  /**
+   * Tells whether the Java version is 14.
+   *
+   * @since 2.0
+   * @return whether the Java version is 14
+   */
+  public boolean isJava14() {
+    return "14".equals(javaSpecVersion);
+  }
+
+  /**
+   * Tells whether the Java version is 15.
+   *
+   * @since 2.0
+   * @return whether the Java version is 15
+   */
+  public boolean isJava15() {
+    return "15".equals(javaSpecVersion);
+  }
+
+  /**
+   * Tells whether the Java version is 16.
+   *
+   * @since 2.0
+   * @return whether the Java version is 16
+   */
+  public boolean isJava16() {
+    return "16".equals(javaSpecVersion);
+  }
+
+  /**
+   * Tells whether the Java version is 17.
+   *
+   * @since 2.0
+   * @return whether the Java version is 17
+   */
+  public boolean isJava17() {
+    return "17".equals(javaSpecVersion);
+  }
+
+  /**
    * Tells whether the Java version is equal to the given major Java version.
    *
    * @since 2.0
@@ -161,6 +211,56 @@ public class Jvm {
    */
   public boolean isJava12Compatible() {
     return javaSpecVersionNumber.getMajor() >= 12;
+  }
+
+  /**
+   * Tells whether the Java version is compatible with Java 13.
+   *
+   * @since 2.0
+   * @return whether the Java version is compatible with Java 13
+   */
+  public boolean isJava13Compatible() {
+    return javaSpecVersionNumber.getMajor() >= 13;
+  }
+
+  /**
+   * Tells whether the Java version is compatible with Java 14.
+   *
+   * @since 2.0
+   * @return whether the Java version is compatible with Java 14
+   */
+  public boolean isJava14Compatible() {
+    return javaSpecVersionNumber.getMajor() >= 14;
+  }
+
+  /**
+   * Tells whether the Java version is compatible with Java 15.
+   *
+   * @since 2.0
+   * @return whether the Java version is compatible with Java 15
+   */
+  public boolean isJava15Compatible() {
+    return javaSpecVersionNumber.getMajor() >= 15;
+  }
+
+  /**
+   * Tells whether the Java version is compatible with Java 16.
+   *
+   * @since 2.0
+   * @return whether the Java version is compatible with Java 16
+   */
+  public boolean isJava16Compatible() {
+    return javaSpecVersionNumber.getMajor() >= 16;
+  }
+
+  /**
+   * Tells whether the Java version is compatible with Java 17.
+   *
+   * @since 2.0
+   * @return whether the Java version is compatible with Java 17
+   */
+  public boolean isJava17Compatible() {
+    return javaSpecVersionNumber.getMajor() >= 17;
   }
 
   /**

--- a/spock-core/src/main/java/spock/util/environment/Jvm.java
+++ b/spock-core/src/main/java/spock/util/environment/Jvm.java
@@ -53,33 +53,6 @@ public class Jvm {
   }
 
   /**
-   * Tells whether the Java version is 5.
-   *
-   * @return whether the Java version is 5
-   */
-  public boolean isJava5() {
-    return "1.5".equals(javaSpecVersion);
-  }
-
-  /**
-   * Tells whether the Java version is 6.
-   *
-   * @return whether the Java version is 6
-   */
-  public boolean isJava6() {
-    return "1.6".equals(javaSpecVersion);
-  }
-
-  /**
-   * Tells whether the Java version is 7.
-   *
-   * @return whether the Java version is 7
-   */
-  public boolean isJava7() {
-    return "1.7".equals(javaSpecVersion);
-  }
-
-  /**
    * Tells whether the Java version is 8.
    *
    * @return whether the Java version is 8
@@ -128,30 +101,18 @@ public class Jvm {
   }
 
   /**
-   * Tells whether the Java version is compatible with Java 5.
+   * Tells whether the Java version is equal to the given major Java version.
    *
-   * @return whether the Java version is compatible with Java 5
+   * @since 2.0
+   * @param majorJavaVersion major java version (e.g. 8, 12, 17) to check the Java version is equal to
+   * @return whether the Java version is equal to the given major Java version
    */
-  public boolean isJava5Compatible() {
-    return javaSpecVersionNumber.getMajor() > 1 || javaSpecVersionNumber.getMinor() >= 5;
-  }
-
-  /**
-   * Tells whether the Java version is compatible with Java 6.
-   *
-   * @return whether the Java version is compatible with Java 6
-   */
-  public boolean isJava6Compatible() {
-    return javaSpecVersionNumber.getMajor() > 1 || javaSpecVersionNumber.getMinor() >= 6;
-  }
-
-  /**
-   * Tells whether the Java version is compatible with Java 7.
-   *
-   * @return whether the Java version is compatible with Java 7
-   */
-  public boolean isJava7Compatible() {
-    return javaSpecVersionNumber.getMajor() > 1 || javaSpecVersionNumber.getMinor() >= 7;
+  public boolean isJavaVersion(int majorJavaVersion) {
+    if (majorJavaVersion == 8) {
+      return isJava8();
+    } else {
+      return javaSpecVersionNumber.getMajor() == majorJavaVersion;
+    }
   }
 
   /**
@@ -200,6 +161,21 @@ public class Jvm {
    */
   public boolean isJava12Compatible() {
     return javaSpecVersionNumber.getMajor() >= 12;
+  }
+
+  /**
+   * Tells whether the Java version is compatible with the given major Java version.
+   *
+   * @since 2.0
+   * @param majorJavaVersion major java version (e.g. 8, 12, 17) to check the Java version compatibility with
+   * @return whether the Java version is compatible with the given major Java version
+   */
+  public boolean isJavaVersionCompatible(int majorJavaVersion) {
+    if (majorJavaVersion == 8) {
+      return isJava8Compatible();
+    } else {
+      return javaSpecVersionNumber.getMajor() >= majorJavaVersion;
+    }
   }
 
   /**

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
@@ -29,7 +29,7 @@ class IgnoreIfExtension extends Specification {
     expect: false
   }
 
-  @IgnoreIf({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 })
+  @IgnoreIf({ jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 || jvm.isJavaVersion(13) })
   def "provides JVM information"() {
     expect: false
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
@@ -29,7 +29,10 @@ class IgnoreIfExtension extends Specification {
     expect: false
   }
 
-  @IgnoreIf({ jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 || jvm.isJavaVersion(13) })
+  @IgnoreIf({
+    jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 || jvm.java13 || jvm.java14 || jvm.java15 || jvm.java16 || jvm.java17 ||
+      jvm.isJavaVersion(18)
+  })
   def "provides JVM information"() {
     expect: false
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
@@ -53,7 +53,10 @@ class RequiresExtension extends EmbeddedSpecification {
       expect: true
     }
 
-    @Requires({ jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 || jvm.isJavaVersion(13) })
+    @Requires({
+      jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 || jvm.java13 || jvm.java14 || jvm.java15 || jvm.java16 || jvm.java17 ||
+        jvm.isJavaVersion(18)
+    })
     def "provides JVM information"() {
       expect: true
     }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
@@ -53,7 +53,7 @@ class RequiresExtension extends EmbeddedSpecification {
       expect: true
     }
 
-    @Requires({ jvm.java5 || jvm.java6 || jvm.java7 || jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 })
+    @Requires({ jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 || jvm.isJavaVersion(13) })
     def "provides JVM information"() {
       expect: true
     }

--- a/spock-specs/src/test/groovy/spock/util/JvmSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/JvmSpec.groovy
@@ -67,12 +67,12 @@ class JvmSpec extends Specification {
     def jvm = Jvm.current
 
     expect:
-    for (i in 8..12) {
+    for (i in 8..17) {
       assert jvm."java$i" == (i == major)
     }
 
     where:
-    major << (9..17)
+    major << (9..20)
   }
 
   def "can check for Java version compatibility"() {
@@ -80,12 +80,12 @@ class JvmSpec extends Specification {
     def jvm = Jvm.current
 
     expect:
-    for (i in 8..12) {
+    for (i in 8..17) {
       assert jvm."java${i}Compatible" == (i <= major)
     }
 
     where:
-    major << (9..17)
+    major << (9..20)
   }
 
   def "can check for Java version (given major version)"() {
@@ -98,7 +98,7 @@ class JvmSpec extends Specification {
     }
 
     where:
-    major << (9..17)
+    major << (9..20)
   }
 
   def "can check for Java version compatibility (given major version)"() {
@@ -111,6 +111,6 @@ class JvmSpec extends Specification {
     }
 
     where:
-    major << (9..17)
+    major << (9..20)
   }
 }

--- a/spock-specs/src/test/groovy/spock/util/JvmSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/JvmSpec.groovy
@@ -18,55 +18,99 @@ import spock.util.environment.*
 
 @RestoreSystemProperties
 class JvmSpec extends Specification {
+  def "can check for Java 8 version (old scheme)"() {
+    System.setProperty("java.specification.version", "1.$minor")
+    def jvm = Jvm.current
+
+    expect:
+    assert jvm.java8 == (minor == 8)
+
+    where:
+    minor << (7..8)
+  }
+
+  def "can check for Java 8 version (old scheme) (given major version)"() {
+    System.setProperty("java.specification.version", "1.$minor")
+    def jvm = Jvm.current
+
+    expect:
+    assert jvm.isJavaVersion(minor) == (minor == 8)
+
+    where:
+    minor << (7..8)
+  }
+
+  def "can check for Java 8 version compatibility (old scheme)"() {
+    System.setProperty("java.specification.version", "1.$minor")
+    def jvm = Jvm.current
+
+    expect:
+    assert jvm."java8Compatible" == (minor >= 8)
+
+    where:
+    minor << (7..8)
+  }
+
+  def "can check for Java 8 version compatibility (old scheme) (given major version)"() {
+    System.setProperty("java.specification.version", "1.$minor")
+    def jvm = Jvm.current
+
+    expect:
+    assert jvm.isJavaVersionCompatible(minor) == (minor >= 8)
+
+    where:
+    minor << (7..8)
+  }
+
   def "can check for Java version"() {
-    System.setProperty("java.specification.version", "1.$minor")
-    def jvm = Jvm.current
-
-    expect:
-    for (i in 5..8) {
-      assert jvm."java$i" == (i == minor)
-    }
-
-    where:
-    minor << (5..8)
-  }
-
-  def "can check for Java version compatibility"() {
-    System.setProperty("java.specification.version", "1.$minor")
-    def jvm = Jvm.current
-
-    expect:
-    for (i in 5..8) {
-      assert jvm."java${i}Compatible" == (i <= minor)
-    }
-
-    where:
-    minor << (5..8)
-  }
-
-  def "can check for Java version (new scheme)"() {
     System.setProperty("java.specification.version", "$major")
     def jvm = Jvm.current
 
     expect:
-    for (i in 5..11) {
+    for (i in 8..12) {
       assert jvm."java$i" == (i == major)
     }
 
     where:
-    major << (9..11)
+    major << (9..17)
   }
 
-  def "can check for Java version compatibility (new scheme)"() {
+  def "can check for Java version compatibility"() {
     System.setProperty("java.specification.version", "$major")
     def jvm = Jvm.current
 
     expect:
-    for (i in 5..11) {
+    for (i in 8..12) {
       assert jvm."java${i}Compatible" == (i <= major)
     }
 
     where:
-    major << (9..11)
+    major << (9..17)
+  }
+
+  def "can check for Java version (given major version)"() {
+    System.setProperty("java.specification.version", "$major")
+    def jvm = Jvm.current
+
+    expect:
+    for (i in 8..17) {
+      assert jvm.isJavaVersion(i) == (i == major)
+    }
+
+    where:
+    major << (9..17)
+  }
+
+  def "can check for Java version compatibility (given major version)"() {
+    System.setProperty("java.specification.version", "$major")
+    def jvm = Jvm.current
+
+    expect:
+    for (i in 8..17) {
+      assert jvm.isJavaVersionCompatible(i) == (i <= major)
+    }
+
+    where:
+    major << (9..17)
   }
 }


### PR DESCRIPTION
Added flexible support for Java 13+. Removed methods for unsupported Java versions (`<8`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1068)
<!-- Reviewable:end -->
