### PR TITLE
Improve ExceptionUtil.sneakyThrow declaration

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMethodInvoker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMethodInvoker.java
@@ -20,8 +20,7 @@ public class ByteBuddyMethodInvoker implements IResponseGenerator {
       return superCall.call(invocation.getArguments().toArray());
     } catch (Throwable t) {
       // Byte Buddy doesn't wrap exceptions in InvocationTargetException, so no need to unwrap
-      ExceptionUtil.sneakyThrow(t);
-      return null; // unreachable
+      return ExceptionUtil.sneakyThrow(t);
     }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/CglibRealMethodInvoker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/CglibRealMethodInvoker.java
@@ -32,8 +32,7 @@ public class CglibRealMethodInvoker implements IResponseGenerator {
       return methodProxy.invokeSuper(invocation.getMockObject().getInstance(), invocation.getArguments().toArray());
     } catch (Throwable t) {
       // MethodProxy doesn't wrap exceptions in InvocationTargetException, so no need to unwrap
-      ExceptionUtil.sneakyThrow(t);
-      return null; // unreachable
+      return ExceptionUtil.sneakyThrow(t);
     }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
@@ -15,7 +15,6 @@ public class ErrorSpecNode extends SpecNode {
 
   @Override
   public SpockExecutionContext execute(SpockExecutionContext context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
-    ExceptionUtil.sneakyThrow(error);
-    return null; //
+    return ExceptionUtil.sneakyThrow(error);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/GroovyRuntimeUtil.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/GroovyRuntimeUtil.java
@@ -136,8 +136,7 @@ public abstract class GroovyRuntimeUtil {
     try {
       return InvokerHelper.getProperty(target, property);
     } catch (InvokerInvocationException e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 
@@ -159,8 +158,7 @@ public abstract class GroovyRuntimeUtil {
     try {
       return InvokerHelper.invokeConstructorOf(clazz, args);
     } catch (InvokerInvocationException e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 
@@ -171,8 +169,7 @@ public abstract class GroovyRuntimeUtil {
     try {
       return InvokerHelper.invokeMethod(target, method, args);
     } catch (InvokerInvocationException e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 
@@ -180,8 +177,7 @@ public abstract class GroovyRuntimeUtil {
     try {
       return InvokerHelper.invokeMethodSafe(target, method, args);
     } catch (InvokerInvocationException e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 
@@ -201,8 +197,7 @@ public abstract class GroovyRuntimeUtil {
     try {
       return closure.call(args);
     } catch (InvokerInvocationException e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 
@@ -214,8 +209,7 @@ public abstract class GroovyRuntimeUtil {
       Constructor<T> constructor = closureType.getConstructor(Object.class, Object.class);
       return constructor.newInstance(owner, thisObject);
     } catch (Exception e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 
@@ -226,8 +220,7 @@ public abstract class GroovyRuntimeUtil {
     try {
       return InvokerHelper.asIterator(object);
     } catch (InvokerInvocationException e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 
@@ -292,8 +285,7 @@ public abstract class GroovyRuntimeUtil {
     try {
       return InvokerHelper.getAttribute(target, name);
     } catch (InvokerInvocationException e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 

--- a/spock-core/src/main/java/org/spockframework/util/ExceptionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ExceptionUtil.java
@@ -24,20 +24,26 @@ import org.jetbrains.annotations.Contract;
 public class ExceptionUtil {
   /**
    * Allows to throw an unchecked exception without declaring it in a throws clause.
+   * The given {@code Throwable} will be unconditionally thrown.
+   * The return type is only present to be able to use the method as
+   * last statement in a method or lambda that needs a value returned,
+   * but the method will never return successfully.
+   *
+   * @param throwable the throwable to be thrown
+   * @param <R>       the fake return type
+   * @param <T>       the class of the throwable that will be thrown
+   * @return nothing as the method will never return successfully
+   * @throws T unconditionally
    */
-  public static void sneakyThrow(Throwable t) {
-    ExceptionUtil.<RuntimeException>doSneakyThrow(t);
+  @SuppressWarnings("unchecked")
+  public static <R, T extends Throwable> R sneakyThrow(Throwable t) throws T {
+    throw (T) t;
   }
 
   public static String printStackTrace(Throwable t) {
     StringWriter writer = new StringWriter();
     t.printStackTrace(new PrintWriter(writer));
     return writer.toString();
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T extends Throwable> void doSneakyThrow(Throwable t) throws T {
-    throw (T) t;
   }
 
   @Contract("!null, _ -> fail; _, !null -> fail")

--- a/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
@@ -199,11 +199,9 @@ public abstract class ReflectionUtil {
       validateArguments(method, args);
       return method.invoke(target, args);
     } catch (IllegalAccessException e) {
-      ExceptionUtil.sneakyThrow(e);
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e);
     } catch (InvocationTargetException e) {
-      ExceptionUtil.sneakyThrow(e.getCause());
-      return null; // never reached
+      return ExceptionUtil.sneakyThrow(e.getCause());
     }
   }
 

--- a/spock-spring/src/main/java/org/spockframework/spring/mock/DelegatingInterceptor.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/mock/DelegatingInterceptor.java
@@ -52,11 +52,10 @@ public class DelegatingInterceptor implements IProxyBasedMockInterceptor {
     try {
       return method.invoke(delegate, arguments);
     } catch (IllegalAccessException e) {
-      ExceptionUtil.sneakyThrow(e);
+      return ExceptionUtil.sneakyThrow(e);
     } catch (InvocationTargetException e) {
-      ExceptionUtil.sneakyThrow(e.getTargetException());
+      return ExceptionUtil.sneakyThrow(e.getTargetException());
     }
-    return null;
   }
 
   @Override


### PR DESCRIPTION
There is no need to separate `sneakyThrow` and `doSneakyThrow`, it can be done
in one declaration.

I also added a return type so it can be used in methods or lambdas that need a return value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1077)
<!-- Reviewable:end -->
