### PR TITLE
Transport isUsingAnonymousInnerClass property when transforming constructor call expressions

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
@@ -358,6 +358,7 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> {
             convert(expr.getArguments()));
 
     conversion.setSourcePosition(expr);
+    conversion.setUsingAnonymousInnerClass(expr.isUsingAnonymousInnerClass());
     result = record(conversion);
   }
 

--- a/spock-core/src/main/java/org/spockframework/compiler/ExpressionReplacingVisitorSupport.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ExpressionReplacingVisitorSupport.java
@@ -141,6 +141,7 @@ public class ExpressionReplacingVisitorSupport extends StatementReplacingVisitor
         expr.getType(),
         replaceExpr(expr.getArguments()));
     result.setSourcePosition(expr);
+    result.setUsingAnonymousInnerClass(expr.isUsingAnonymousInnerClass());
     replaceVisitedExpressionWith(result);
   }
 


### PR DESCRIPTION
This propery was not brought over previously.
This works fine for Groovy 2, as the meta class can find the synthetic constructor that is generated for the anonymous inner class.
With Groovy 3 this changed, so without this fix, rewritten anonymous inner class instantiations cannot be executed as the meta class does not find the synthetic constructor anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1078)
<!-- Reviewable:end -->
