### PR TITLE
Improve recognition of Groovy compiler generated constructors

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
@@ -75,22 +75,11 @@ public class SpecParser implements GroovyClassVisitor {
 
   @Override
   public void visitConstructor(ConstructorNode constructor) {
-    if (AstUtil.isSynthetic(constructor)) return;
-    if (constructorMayHaveBeenAddedByCompiler(constructor)) return;
+    // Groovy compiler generated constructor for example for joint compilation
+    if (constructor.hasNoRealSourcePosition()) return;
 
     errorReporter.error(constructor,
 "Constructors are not allowed; instead, define a 'setup()' or 'setupSpec()' method");
-  }
-
-  // In case of joint compilation, Verifier - which may add a default constructor
-  // - is run in phase CONVERSION. Additionally, groovyc 1.7 and above no longer
-  // marks default constructors as synthetic (following javac). Therefore, we have
-  // to add special logic to detect this case.
-  private boolean constructorMayHaveBeenAddedByCompiler(ConstructorNode constructor) {
-    Parameter[] params = constructor.getParameters();
-    Statement firstStat = constructor.getFirstStatement();
-    return AstUtil.isJointCompiled(spec.getAst()) && constructor.isPublic()
-      && params != null && params.length == 0 && firstStat == null;
   }
 
   @Override


### PR DESCRIPTION
Before Groovy 1.7 the Groovy compiler generated constructor was marked as synthetic.

In Groovy 1.7.* this was changed and the constructor was not distinguishable so Peter
added recognition logic based on parameter count, visibility, contained statements
and whether joint compilation is done.

In Groovy 1.8 though the constructor is marked with the new property `hasNoRealSourcePosition`
and in Groovy 3 the constructor is additionally annotated with a `@Generated` annotation.

This PR removes the recognition logic and the synthetic check as the minimum Groovy version is 2
and replaces it by checking the `hasNoRealSourcePosition` property which will work properly
with Groovy 2 and Groovy 3 alike.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1080)
<!-- Reviewable:end -->
