### PR TITLE
Reduce number of builds in Travis to 8 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ cache:
 dist: precise # downgrade to avoid jdk7 SSL Bug https://github.com/docker-library/openjdk/issues/117
 jdk:
   - oraclejdk8
-  - openjdk10
   - openjdk11
-  - openjdk12
 
 env:
   matrix:


### PR DESCRIPTION
To speed up the things before the M2 release.
Java 13 is not currently compatible with the used Gradle version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1088)
<!-- Reviewable:end -->
