### PR TITLE
Fix comment on code example

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/docs/interaction/InteractionDocSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/interaction/InteractionDocSpec.groovy
@@ -194,7 +194,8 @@ class PublisherSpec extends Specification {
 
     then:
 // tag::argConstraints[]
-    1 * subscriber.receive(endsWith("lo")) // any non-null argument that is-a String
+    1 * subscriber.receive(endsWith("lo")) // an argument matching the given Hamcrest matcher
+                                           // a String argument ending with "lo" in this case
 // end::argConstraints[]
   }
 


### PR DESCRIPTION
The previous comment was obviously a copy paste mistake.

Mentioning the fact that endsWith comes from Hamcrest is also a good idea in my opinion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1097)
<!-- Reviewable:end -->
