### PR TITLE
Default unroll and rollup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ ext {
     hamcrest            : [group: 'org.hamcrest', name: 'hamcrest-core', version: '2.2'],
     jaxb                : [group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'],
     junit4              : [group: 'junit', name: 'junit', version: '4.13'],
-    junitBom            : [group: 'org.junit', name: 'junit-bom', version: '5.6.1'],
+    junitBom            : [group: 'org.junit', name: 'junit-bom', version: '5.7.0-M1'],
     jupiter             : [group: 'org.junit.jupiter', name: 'junit-jupiter'],
     junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-engine'],
     junitPlatformTestkit: [group: 'org.junit.platform', name: 'junit-platform-testkit'],

--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -144,27 +144,34 @@ include::{sourcedir}/datadriven/v7/MathSpec.groovy[tag=example]
 
 Let's assume that our implementation of the `max` method has a flaw, and one of the iterations fails:
 
-[source,groovy]
 ----
-maximum of two numbers   FAILED
+maximum of two numbers [a: 1, b: 3, c: 3, #0]   PASSED
+maximum of two numbers [a: 7, b: 4, c: 7, #1]   FAILED
 
 Condition not satisfied:
 
 Math.max(a, b) == c
-    |    |  |  |  |
-    |    7  4  |  7
-    42         false
+|    |   |  |  |  |
+|    |   7  4  |  7
+|    42        false
+class java.lang.Math
+
+maximum of two numbers [a: 0, b: 0, c: 0, #2]   PASSED
 ----
 
 The obvious question is: Which iteration failed, and what are its data values? In our example, it isn't hard to figure
-out that it's the second iteration that failed. At other times this can be more difficult or even impossible.
-footnote:[For example, a feature method could use data variables in its `given:` block, but not in any conditions.]
-In any case, it would be nice if Spock made it loud and clear which iteration failed, rather than just reporting the
-failure. This is the purpose of the `@Unroll` annotation.
+out that it's the second iteration (with index 1) that failed even from the rich condition rendering. At other times
+this can be more difficult or even impossible.footnote:[For example, a feature method could use data variables in its
+`given:` block, but not in any conditions.] In any case, Spock makes it loud and clear which iteration failed, rather
+than just reporting the failure. Iterations of a feature method are by default unrolled with a rich naming pattern.
+This pattern can also be configured as documented at <<Unrolled Iteration Names>> or the unrolling can be disabled
+like described in the following section.
 
-== Method Unrolling
+== Method Uprolling and Unrolling
 
-A method annotated with `@Unroll` will have its iterations reported independently:
+A method annotated with `@Rollup` will have its iterations not reported independently but only aggregated within the
+feature. This can for example be used if you produce many test cases from calculations or if you use external data
+like the contents of a database as test data and do not want the test count to vary:
 
 [source,groovy,indent=0]
 ----
@@ -172,60 +179,60 @@ include::{sourcedir}/datadriven/v4/MathSpec.groovy[tag=example]
   ...
 ----
 
-.Why isn't `@Unroll` the default?
-****
-One reason why `@Unroll` isn't the default is that some execution environments (in particular IDEs) expect to be
-told the number of test methods in advance, and have certain problems if the actual number varies. Another reason
-is that `@Unroll` can drastically change the number of reported tests, which may not always be desirable.
-****
-
-Note that unrolling has no effect on how the method gets executed; it is only an alternation in reporting.
+Note that up- and unrolling has no effect on how the method gets executed; it is only an alternation in reporting.
 Depending on the execution environment, the output will look something like:
 
 ----
-maximum of two numbers [a: 1, b: 3, c: 3, #0]   PASSED
-maximum of two numbers [a: 7, b: 4, c: 7, #1]   FAILED
+maximum of two numbers   FAILED
+
+Condition not satisfied:
 
 Math.max(a, b) == c
-    |    |  |  |  |
-    |    7  4  |  7
-    42         false
-
-maximum of two numbers [a: 0, b: 0, c: 0, #2]   PASSED
+|    |   |  |  |  |
+|    |   7  4  |  7
+|    42        false
+class java.lang.Math
 ----
 
-This tells us that the second iteration (with index 1) failed. With a bit of effort, we can do even better:
+The `@Rollup` annotation can also be placed on a spec.
+This has the same effect as placing it on each data-driven feature method of the spec that does not have an
+`@Unroll` annotation.
 
-[source,groovy,indent=0]
+Alternatively the <<extensions.adoc#_spock_configuration_file,configuration file>> setting `enabledByDefault`
+in the `unroll` section can be set to `false` to roll up all features automatically unless
+they are annotated with `@Unroll` or are contained in an ``@Unroll``ed spec and thus reinstate the pre Spock 2.0
+behavior where this was the default.
+
+.Disable Default Unrolling
+[source,groovy]
 ----
-include::{sourcedir}/datadriven/v5/MathSpec.groovy[tag=example]
-  ...
-----
-
-This method name uses placeholders, denoted by a leading hash sign (`#`), to refer to data variables `a`, `b`,
-and `c`. In the output, the placeholders will be replaced with concrete values:
-
-----
-maximum of 1 and 3 is 3   PASSED
-maximum of 7 and 4 is 7   FAILED
-
-Math.max(a, b) == c
-    |    |  |  |  |
-    |    7  4  |  7
-    42         false
-
-maximum of 0 and 0 is 0   PASSED
+unroll {
+    enabledByDefault false
+}
 ----
 
-Now we can tell at a glance that the `max` method failed for inputs `7` and `4`. See <<More on Unrolled Method Names>>
-for further details on this topic.
+It is illegal to annotate a spec or a feature with both the `@Unroll` and the `@Rollup` annotation and if detected
+this will cause an exception to be thrown.
 
-The `@Unroll` annotation can also be placed on a spec. This has the same effect as placing it on each data-driven
-feature method of the spec.
 
-TIP: You can set the system property `spock.assertUnrollExpressions` to `true`,
-     to let tests fail that have invalid unroll expressions.
-     This can be used to help catch errors during refactoring.
+'''
+
+To summarize:
+
+A feature will be uprolled
+
+- if the method is annotated with `@Rollup`
+- if the method is not annotated with `@Unroll` and the spec is annotated with `@Rollup`
+- if neither the method nor the spec is annotated with `@Unroll`
+  and the configuration option `unroll { enabledByDefault }` is set to `false`
+
+A feature will be unrolled
+
+- if the method is annotated with `@Unroll`
+- if the method is not annotated with `@Rollup` and the spec is annotated with `@Unroll`
+- if neither the method nor the spec is annotated with `@Rollup`
+  and the configuration option `unroll { enabledByDefault }` is set to its default value `true`
+
 
 == Data Pipes
 
@@ -376,7 +383,40 @@ exactly one iteration.
 After all iterations have completed, the zero-argument `close` method is called on all data providers that have
 such a method.
 
-== More on Unrolled Method Names
+== Unrolled Iteration Names
+
+By default the names of unrolled iterations are the name of the feature, plus the data variables and the iteration
+index. This will always produce unique names and should enable you to identify easily the failing data variable
+combination.
+
+The example at <<Reporting of Failures>> for example shows with `maximum of two numbers [a: 7, b: 4, c: 7, #1]`,
+that the second iteration (`#1`) where the data variables have the values `7`, `4` and `7` failed.
+
+With a bit of effort, we can do even better:
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/datadriven/v5/MathSpec.groovy[tag=example]
+  ...
+----
+
+This method name uses placeholders, denoted by a leading hash sign (`#`), to refer to data variables `a`, `b`, and `c`.
+In the output, the placeholders will be replaced with concrete values:
+
+----
+maximum of 1 and 3 is 3   PASSED
+maximum of 7 and 4 is 7   FAILED
+
+Math.max(a, b) == c
+|    |   |  |  |  |
+|    |   7  4  |  7
+|    42        false
+class java.lang.Math
+
+maximum of 0 and 0 is 0   PASSED
+----
+
+Now we can tell at a glance that the `max` method failed for inputs `7` and `4`.
 
 An unrolled method name is similar to a Groovy `GString`, except for the following differences:
 
@@ -402,7 +442,7 @@ def "#person.name.split(' ')[1]" {  // cannot have method arguments
 def "#person.age / 2" {  // cannot use operators
 ----
 
-If necessary, additional data variables can be introduced to hold more complex expression:
+If necessary, additional data variables can be introduced to hold more complex expressions:
 
 [source,groovy,indent=0]
 ----
@@ -430,7 +470,8 @@ def "person age should be calculated properly"() {
 ----
 
 If neither a parameter to the annotation is given, nor the method name contains a `#`,
-the system property `spock.globalUnrollPattern` is inspected. If it is set to a non-blank
+the <<extensions.adoc#_spock_configuration_file,configuration file>> setting `defaultPattern`
+in the `unroll` section is inspected. If it is set to a non-`null`
 string, this value is used as unroll pattern. This could for example be set to
 
 - `#featureName` to have all iterations reported with the same name, or
@@ -438,7 +479,33 @@ string, this value is used as unroll pattern. This could for example be set to
 - `#iterationName` if you make sure that in each data-driven feature you also set
   a data variable called `iterationName` that is then used for reporting
 
+.Set Default Unroll Pattern
+[source,groovy]
+----
+unroll {
+    defaultPattern '#featureName[#iterationIndex]'
+}
+----
+
 If none of the three described ways is used to set a custom unroll pattern, by default
 the feature name is used, suffixed with all data variable names and their values and
 finally the iteration index, so the result will be for example
 `my feature [x: 1, y: 2, z: 3, #0]`.
+
+If there is an error in an unroll expression, for example typo in variable name, exception during
+evaluation of a property or method in the expression and so on, the test will fail. This is not
+true for the automatic fall back rendering of the data variables if there is no unroll pattern
+set in any way, this will never fail the test, no matter what happens.
+
+The failing of test with errors in the unroll expression can be disabled by setting the
+<<extensions.adoc#_spock_configuration_file,configuration file>> setting `expressionsAsserted`
+in the `unroll` section to `false`. If this is done and an error happens, the erroneous expression
+`#foo.bar` will be substituted by `#Error:foo.bar`.
+
+.Disable Unroll Pattern Expression Asserting
+[source,groovy]
+----
+unroll {
+    expressionsAsserted false
+}
+----

--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -198,7 +198,7 @@ The `@Rollup` annotation can also be placed on a spec.
 This has the same effect as placing it on each data-driven feature method of the spec that does not have an
 `@Unroll` annotation.
 
-Alternatively the <<extensions.adoc#_spock_configuration_file,configuration file>> setting `enabledByDefault`
+Alternatively the <<extensions.adoc#_spock_configuration_file,configuration file>> setting `unrollByDefault`
 in the `unroll` section can be set to `false` to roll up all features automatically unless
 they are annotated with `@Unroll` or are contained in an ``@Unroll``ed spec and thus reinstate the pre Spock 2.0
 behavior where this was the default.
@@ -207,7 +207,7 @@ behavior where this was the default.
 [source,groovy]
 ----
 unroll {
-    enabledByDefault false
+    unrollByDefault false
 }
 ----
 
@@ -224,14 +224,14 @@ A feature will be uprolled
 - if the method is annotated with `@Rollup`
 - if the method is not annotated with `@Unroll` and the spec is annotated with `@Rollup`
 - if neither the method nor the spec is annotated with `@Unroll`
-  and the configuration option `unroll { enabledByDefault }` is set to `false`
+  and the configuration option `unroll { unrollByDefault }` is set to `false`
 
 A feature will be unrolled
 
 - if the method is annotated with `@Unroll`
 - if the method is not annotated with `@Rollup` and the spec is annotated with `@Unroll`
 - if neither the method nor the spec is annotated with `@Rollup`
-  and the configuration option `unroll { enabledByDefault }` is set to its default value `true`
+  and the configuration option `unroll { unrollByDefault }` is set to its default value `true`
 
 
 == Data Pipes
@@ -498,7 +498,7 @@ true for the automatic fall back rendering of the data variables if there is no 
 set in any way, this will never fail the test, no matter what happens.
 
 The failing of test with errors in the unroll expression can be disabled by setting the
-<<extensions.adoc#_spock_configuration_file,configuration file>> setting `expressionsAsserted`
+<<extensions.adoc#_spock_configuration_file,configuration file>> setting `validateExpressions`
 in the `unroll` section to `false`. If this is done and an error happens, the erroneous expression
 `#foo.bar` will be substituted by `#Error:foo.bar`.
 
@@ -506,6 +506,6 @@ in the `unroll` section to `false`. If this is done and an error happens, the er
 [source,groovy]
 ----
 unroll {
-    expressionsAsserted false
+    validateExpressions false
 }
 ----

--- a/docs/migration_guide.adoc
+++ b/docs/migration_guide.adoc
@@ -11,6 +11,8 @@ include::release_notes.adoc[tag=renamed-iteration-count-token]
 
 include::release_notes.adoc[tag=no-access-to-data-variables-in-data-pipes]
 
+include::release_notes.adoc[tag=assert-unroll-expressions-by-default]
+
 == 1.0
 
 Specs, Spec base classes and third-party extensions may have be recompiled in order to work with Spock 1.0.

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -113,7 +113,7 @@ The system property `spock.assertUnrollExpressions` is not supported anymore.
 Instead the new default behavior is equal to having this property set to `true`.
 This means tests that were successful but had an `#Error:` name rendering will now fail.
 It can be set back to the old pre Spock 2.0 behaviour by setting
-`unroll { expressionsAsserted false }` in the Spock configuration file.
+`unroll { validateExpressions false }` in the Spock configuration file.
 // end::assert-unroll-expressions-by-default[]
 
 ==== For extension developers
@@ -237,14 +237,14 @@ def "I'll run everywhere but on Windows"() { ... }
 
 - Data driven features are now unrolled by default. `@Unroll` can still be used to specify a custom naming pattern.
   A simple `@Unroll` without argument is not needed anymore except when undoing a spec-level `@Rollup` annotation
-  or if uprolling is disabled globally, so any simple `@Unroll` annotations can be removed from existing code. You
+  or if unrolling by default is disabled, so any simple `@Unroll` annotations can be removed from existing code. You
   can verify this by looking at the test count which should not have been changed after you removed the simple
   `@Unroll` annotations.
 
 - `@Rollup` can now be used on feature and spec level to explicitly roll up any feature where the reporting of single
   iterations is not wanted.
 
-- The setting `unroll { enabledByDefault false }` in the Spock configuration file can be set to roll up all
+- The setting `unroll { unrollByDefault false }` in the Spock configuration file can be set to roll up all
   features by default if not overwritten by explicit `@Unroll` annotations and thus reinstate the pre
   Spock 2.0 behaviour.
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -71,7 +71,8 @@ subscriber.receive(_) >> _
 
 The token `#iterationCount` in unroll patterns was renamed to `#iterationIndex`.
 If you use it somewhere, you have to manually change it to the new name
-or you will get an `#Error:iterationCount` rendering instead.
+or the test will fail unless you disabled expression asserting,
+then you will get an `#Error:iterationCount` rendering instead.
 // end::renamed-iteration-count-token[]
 
 // tag::no-access-to-data-variables-in-data-pipes[]
@@ -104,6 +105,16 @@ a << [1, 2]
 b = a
 ----
 // end::no-access-to-data-variables-in-data-pipes[]
+
+// tag::assert-unroll-expressions-by-default[]
+==== Assert unroll expressions by default
+
+The system property `spock.assertUnrollExpressions` is not supported anymore.
+Instead the new default behavior is equal to having this property set to `true`.
+This means tests that were successful but had an `#Error:` name rendering will now fail.
+It can be set back to the old pre Spock 2.0 behaviour by setting
+`unroll { expressionsAsserted false }` in the Spock configuration file.
+// end::assert-unroll-expressions-by-default[]
 
 ==== For extension developers
 
@@ -154,12 +165,13 @@ a ; b ;; c
 // tag::fancy-iteration-naming[]
 - The default unroll pattern changed from the rather generic `#featureName[#iterationIndex]` to a more fancy
   version that lists all data variables and their values additionally to the feature name and iteration index.
-  If you prefer to retain the old behaviour, you can set the system property `spock.globalUnrollPattern`
-  to the value `#featureName[#iterationIndex]` and you will get the same result as previously.
+  If you prefer to retain the old behaviour, you can set the setting
+  `unroll { defaultPattern '#featureName[#iterationIndex]' }` in the Spock configuration file
+  and you will get the same result as previously.
 // end::fancy-iteration-naming[]
 
 - If neither a parameter to the `@Unroll` annotation is given, nor the method name contains a `#`,
-  now the system property `spock.globalUnrollPattern` is inspected. If it is set to a non-blank string,
+  now the configuration file setting `unroll { defaultPattern }` is inspected. If it is set to a non-`null` string,
   this value is used as unroll pattern.
 
 - `IterationInfo` now has a property for the `iterationIndex` and one for a map of data variable names to values.
@@ -222,6 +234,19 @@ def "I'll run everywhere but on Windows"() { ... }
 - The condition closures for `@IgnoreIf`, `@Requires` and `@PendingFeatureIf` can now access data variables
   if applied to a data driven feature. This has further implications that are documented in the respective
   documentation parts and JavaDocs.
+
+- Data driven features are now unrolled by default. `@Unroll` can still be used to specify a custom naming pattern.
+  A simple `@Unroll` without argument is not needed anymore except when undoing a spec-level `@Rollup` annotation
+  or if uprolling is disabled globally, so any simple `@Unroll` annotations can be removed from existing code. You
+  can verify this by looking at the test count which should not have been changed after you removed the simple
+  `@Unroll` annotations.
+
+- `@Rollup` can now be used on feature and spec level to explicitly roll up any feature where the reporting of single
+  iterations is not wanted.
+
+- The setting `unroll { enabledByDefault false }` in the Spock configuration file can be set to roll up all
+  features by default if not overwritten by explicit `@Unroll` annotations and thus reinstate the pre
+  Spock 2.0 behaviour.
 
 == 2.0-M2 (2020-02-10)
 

--- a/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
+++ b/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
@@ -47,6 +47,10 @@ class EmbeddedSpecRunner {
   List<Class> extensionClasses = []
   boolean inheritParentExtensions = true
 
+  void configurationScript(Closure configurationScript) {
+    this.configurationScript = configurationScript
+  }
+
   void addPackageImport(String pkg) {
     compiler.addPackageImport(pkg)
   }

--- a/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
+++ b/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
@@ -179,6 +179,26 @@ class EmbeddedSpecRunner {
         .map{it.timestamp.toEpochMilli()}.orElseGet {0}
     }
 
+    long getDynamicallyRegisteredCount() {
+      return results.allEvents().dynamicallyRegistered().count()
+    }
+
+    long getTotalStartedCount() {
+      return results.allEvents().started().count()
+    }
+
+    long getTotalSkippedCount() {
+      return results.allEvents().skipped().count()
+    }
+
+    long getTotalAbortedCount() {
+      return results.allEvents().aborted().count()
+    }
+
+    long getTotalSucceededCount() {
+      return results.allEvents().succeeded().count()
+    }
+
     @Override
     long getTotalFailureCount() {
       return results.allEvents().failed().count()

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecialMethodCall.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecialMethodCall.java
@@ -14,7 +14,6 @@
 
 package org.spockframework.compiler;
 
-import org.jetbrains.annotations.NotNull;
 import org.spockframework.lang.ConditionBlock;
 import org.spockframework.util.*;
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
@@ -19,7 +19,6 @@ import org.spockframework.util.Nullable;
 
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static net.bytebuddy.matcher.ElementMatchers.any;

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureChildExecutor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureChildExecutor.java
@@ -9,7 +9,6 @@ import org.opentest4j.TestAbortedException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureChildExecutor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureChildExecutor.java
@@ -1,0 +1,74 @@
+package org.spockframework.runtime;
+
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.support.hierarchical.Node.DynamicTestExecutor;
+import org.opentest4j.TestAbortedException;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
+
+class ParameterizedFeatureChildExecutor {
+
+  private final ParameterizedFeatureNode parameterizedFeatureNode;
+  private AtomicInteger executionCounter = new AtomicInteger();
+
+  private Map<TestExecutionResult.Status, Queue<Throwable>> results = new ConcurrentHashMap<>();
+
+  private final DynamicTestExecutor delegate;
+  private EngineExecutionListener executionListener;
+
+  ParameterizedFeatureChildExecutor(ParameterizedFeatureNode parameterizedFeatureNode, DynamicTestExecutor delegate) {
+    this.parameterizedFeatureNode = parameterizedFeatureNode;
+    this.delegate = delegate;
+
+    // if we are not going to report single iterations,
+    // we will need a listener for the child executions
+    // so create it here once and use it repeatedly later on
+    if (!parameterizedFeatureNode.featureInfo.isReportIterations()) {
+      executionListener = new EngineExecutionListener() {
+        @Override
+        public void executionSkipped(TestDescriptor testDescriptor, String reason) {
+          results
+            .computeIfAbsent(ABORTED, status -> new ConcurrentLinkedQueue<>())
+            .add(new TestAbortedException(reason));
+        }
+
+        @Override
+        public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
+          Queue<Throwable> failures = results
+            .computeIfAbsent(testExecutionResult.getStatus(), status -> new ConcurrentLinkedQueue<>());
+          testExecutionResult.getThrowable().ifPresent(failures::add);
+        }
+      };
+    }
+  }
+
+  public void execute(TestDescriptor testDescriptor) {
+    executionCounter.incrementAndGet();
+    parameterizedFeatureNode.addChild(testDescriptor);
+    if (parameterizedFeatureNode.featureInfo.isReportIterations()) {
+      delegate.execute(testDescriptor);
+    } else {
+      delegate.execute(testDescriptor, executionListener);
+    }
+  }
+
+  public void awaitFinished() throws InterruptedException {
+    delegate.awaitFinished();
+  }
+
+  int getExecutionCount() {
+    return executionCounter.get();
+  }
+
+  Map<TestExecutionResult.Status, Queue<Throwable>> getResults() {
+    return results;
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
@@ -1,10 +1,23 @@
 package org.spockframework.runtime;
 
+import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.engine.reporting.ReportEntry;
+import org.opentest4j.MultipleFailuresError;
+import org.opentest4j.TestAbortedException;
 import org.spockframework.runtime.model.FeatureInfo;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.platform.engine.*;
+
+import static java.lang.reflect.Modifier.FINAL;
+import static java.util.stream.Collectors.*;
+import static org.junit.platform.engine.TestExecutionResult.Status.*;
+import static org.spockframework.util.ExceptionUtil.sneakyThrow;
 
 public class ParameterizedFeatureNode extends FeatureNode {
 
@@ -30,6 +43,64 @@ public class ParameterizedFeatureNode extends FeatureNode {
     if (testExecutor.getExecutionCount() < 1) {
      throw new SpockExecutionException("Data provider has no data");
     }
+
+    // do not try to aggregate iteration results if they are reported individually
+    if (featureInfo.isReportIterations()) {
+      return context;
+    }
+
+    if (testExecutor.results.containsKey(FAILED)) {
+      List<Throwable> failures = testExecutor.results
+        .get(FAILED)
+        .stream()
+        .filter(Objects::nonNull)
+        .collect(toList());
+
+      switch (failures.size()) {
+        case 0:
+          throw new SpockAssertionError("At least one iteration failed");
+
+        case 1:
+          sneakyThrow(failures.get(0));
+
+        default:
+          MultipleFailuresError multipleFailuresError = new MultipleFailuresError(null, failures);
+          multipleFailuresError.setStackTrace(failures.get(0).getStackTrace());
+          throw multipleFailuresError;
+      }
+    } else if (!testExecutor.results.containsKey(SUCCESSFUL)) {
+      List<Throwable> abortions = testExecutor.results
+        .get(ABORTED)
+        .stream()
+        .filter(Objects::nonNull)
+        .collect(toList());
+
+      Throwable abortion;
+      switch (abortions.size()) {
+        case 0:
+          abortion = new TestAbortedException("All iterations were aborted");
+          break;
+
+        case 1:
+          abortion = abortions.get(0);
+          break;
+
+        default:
+          abortion = new MultipleFailuresError(null, abortions);
+          abortion.setStackTrace(abortions.get(0).getStackTrace());
+          break;
+      }
+
+      TestAbortedException testAbortedException;
+      if (abortion instanceof TestAbortedException) {
+        testAbortedException = (TestAbortedException) abortion;
+      } else {
+        testAbortedException = new TestAbortedException("All iterations were aborted", abortion);
+        testAbortedException.setStackTrace(abortion.getStackTrace());
+      }
+      throw testAbortedException;
+    }
+
     return context;
   }
 
@@ -42,6 +113,8 @@ public class ParameterizedFeatureNode extends FeatureNode {
 
     private AtomicInteger executionCounter = new AtomicInteger();
 
+    private Map<Status, List<Throwable>> results = new HashMap<>();
+
     private final DynamicTestExecutor delegate;
 
     ChildExecutor(DynamicTestExecutor delegate) {this.delegate = delegate;}
@@ -50,7 +123,83 @@ public class ParameterizedFeatureNode extends FeatureNode {
     public void execute(TestDescriptor testDescriptor) {
       executionCounter.incrementAndGet();
       addChild(testDescriptor);
-      delegate.execute(testDescriptor);
+      if (featureInfo.isReportIterations()) {
+        delegate.execute(testDescriptor);
+      } else {
+        //TODO: replace by result of https://github.com/junit-team/junit5/issues/2188
+        executeReplacingListener(delegate, testDescriptor, new EngineExecutionListener() {
+          @Override
+          public void dynamicTestRegistered(TestDescriptor testDescriptor) {
+          }
+
+          @Override
+          public void executionSkipped(TestDescriptor testDescriptor, String reason) {
+            results
+              .computeIfAbsent(ABORTED, status -> new ArrayList<>())
+              .add(new TestAbortedException(reason));
+          }
+
+          @Override
+          public void executionStarted(TestDescriptor testDescriptor) {
+          }
+
+          @Override
+          public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
+            List<Throwable> failures = results
+              .computeIfAbsent(testExecutionResult.getStatus(), status -> new ArrayList<>());
+            testExecutionResult.getThrowable().ifPresent(failures::add);
+          }
+
+          @Override
+          public void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
+          }
+        });
+      }
+    }
+
+    //TODO: work-around for missing https://github.com/junit-team/junit5/issues/2188
+    private void executeReplacingListener(DynamicTestExecutor delegate, TestDescriptor testDescriptor,
+                                          EngineExecutionListener listener) {
+      try {
+        // get the enclosing NodeTestTask instance of the DynamicTestExecutor
+        Field nodeTestTaskField = delegate.getClass().getDeclaredField("this$0");
+        nodeTestTaskField.setAccessible(true);
+        Object nodeTestTask = nodeTestTaskField.get(delegate);
+
+        // get the NodeTestTaskContext field value of the NodeTestTask
+        Field taskContextField = nodeTestTask.getClass().getDeclaredField("taskContext");
+        taskContextField.setAccessible(true);
+        Object taskContext = taskContextField.get(nodeTestTask);
+
+        // get the EngineExecutionListener field of the NodeTestTaskContext
+        Field listenerField = taskContext.getClass().getDeclaredField("listener");
+        listenerField.setAccessible(true);
+
+        // remove the final modifier from the EngineExecutionListener field
+        Method getDeclaredFields = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
+        getDeclaredFields.setAccessible(true);
+        Field modifiersField = Arrays
+          .stream((Field[]) getDeclaredFields.invoke(Field.class, false))
+          .filter(field -> field.getName().equals("modifiers"))
+          .findAny()
+          .orElseThrow(AssertionError::new);
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(listenerField, listenerField.getModifiers() & ~FINAL);
+
+        // store the original listener
+        Object originalListener = listenerField.get(taskContext);
+        try {
+          // set the custom listener
+          listenerField.set(taskContext, listener);
+          // execute the iterations
+          delegate.execute(testDescriptor);
+        } finally {
+          // restore the original listener
+          listenerField.set(taskContext, originalListener);
+        }
+      } catch (IllegalAccessException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException e) {
+        throw new AssertionError(e);
+      }
     }
 
     @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
@@ -35,7 +35,7 @@ public class ParameterizedFeatureNode extends FeatureNode {
 
   @Override
   public Type getType() {
-    return Type.CONTAINER;
+    return featureInfo.isReportIterations() ? Type.CONTAINER_AND_TEST : Type.TEST;
   }
 
   class ChildExecutor implements DynamicTestExecutor {

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
@@ -1,20 +1,15 @@
 package org.spockframework.runtime;
 
 import org.junit.platform.engine.TestExecutionResult.Status;
-import org.junit.platform.engine.reporting.ReportEntry;
 import org.opentest4j.MultipleFailuresError;
 import org.opentest4j.TestAbortedException;
 import org.spockframework.runtime.model.FeatureInfo;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.platform.engine.*;
 
-import static java.lang.reflect.Modifier.FINAL;
 import static java.util.stream.Collectors.*;
 import static org.junit.platform.engine.TestExecutionResult.Status.*;
 import static org.spockframework.util.ExceptionUtil.sneakyThrow;
@@ -109,7 +104,7 @@ public class ParameterizedFeatureNode extends FeatureNode {
     return featureInfo.isReportIterations() ? Type.CONTAINER_AND_TEST : Type.TEST;
   }
 
-  class ChildExecutor implements DynamicTestExecutor {
+  class ChildExecutor {
 
     private AtomicInteger executionCounter = new AtomicInteger();
 
@@ -119,19 +114,13 @@ public class ParameterizedFeatureNode extends FeatureNode {
 
     ChildExecutor(DynamicTestExecutor delegate) {this.delegate = delegate;}
 
-    @Override
     public void execute(TestDescriptor testDescriptor) {
       executionCounter.incrementAndGet();
       addChild(testDescriptor);
       if (featureInfo.isReportIterations()) {
         delegate.execute(testDescriptor);
       } else {
-        //TODO: replace by result of https://github.com/junit-team/junit5/issues/2188
-        executeReplacingListener(delegate, testDescriptor, new EngineExecutionListener() {
-          @Override
-          public void dynamicTestRegistered(TestDescriptor testDescriptor) {
-          }
-
+        delegate.execute(testDescriptor, new EngineExecutionListener() {
           @Override
           public void executionSkipped(TestDescriptor testDescriptor, String reason) {
             results
@@ -140,69 +129,15 @@ public class ParameterizedFeatureNode extends FeatureNode {
           }
 
           @Override
-          public void executionStarted(TestDescriptor testDescriptor) {
-          }
-
-          @Override
           public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
             List<Throwable> failures = results
               .computeIfAbsent(testExecutionResult.getStatus(), status -> new ArrayList<>());
             testExecutionResult.getThrowable().ifPresent(failures::add);
           }
-
-          @Override
-          public void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
-          }
         });
       }
     }
 
-    //TODO: work-around for missing https://github.com/junit-team/junit5/issues/2188
-    private void executeReplacingListener(DynamicTestExecutor delegate, TestDescriptor testDescriptor,
-                                          EngineExecutionListener listener) {
-      try {
-        // get the enclosing NodeTestTask instance of the DynamicTestExecutor
-        Field nodeTestTaskField = delegate.getClass().getDeclaredField("this$0");
-        nodeTestTaskField.setAccessible(true);
-        Object nodeTestTask = nodeTestTaskField.get(delegate);
-
-        // get the NodeTestTaskContext field value of the NodeTestTask
-        Field taskContextField = nodeTestTask.getClass().getDeclaredField("taskContext");
-        taskContextField.setAccessible(true);
-        Object taskContext = taskContextField.get(nodeTestTask);
-
-        // get the EngineExecutionListener field of the NodeTestTaskContext
-        Field listenerField = taskContext.getClass().getDeclaredField("listener");
-        listenerField.setAccessible(true);
-
-        // remove the final modifier from the EngineExecutionListener field
-        Method getDeclaredFields = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
-        getDeclaredFields.setAccessible(true);
-        Field modifiersField = Arrays
-          .stream((Field[]) getDeclaredFields.invoke(Field.class, false))
-          .filter(field -> field.getName().equals("modifiers"))
-          .findAny()
-          .orElseThrow(AssertionError::new);
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(listenerField, listenerField.getModifiers() & ~FINAL);
-
-        // store the original listener
-        Object originalListener = listenerField.get(taskContext);
-        try {
-          // set the custom listener
-          listenerField.set(taskContext, listener);
-          // execute the iterations
-          delegate.execute(testDescriptor);
-        } finally {
-          // restore the original listener
-          listenerField.set(taskContext, originalListener);
-        }
-      } catch (IllegalAccessException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException e) {
-        throw new AssertionError(e);
-      }
-    }
-
-    @Override
     public void awaitFinished() throws InterruptedException {
       delegate.awaitFinished();
     }

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -16,7 +16,6 @@
 
 package org.spockframework.runtime;
 
-import org.spockframework.runtime.ParameterizedFeatureNode.ChildExecutor;
 import org.spockframework.runtime.model.*;
 
 import java.util.*;
@@ -34,7 +33,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
   }
 
   @Override
-  void runParameterizedFeature(SpockExecutionContext context, ChildExecutor childExecutor) throws InterruptedException {
+  void runParameterizedFeature(SpockExecutionContext context, ParameterizedFeatureChildExecutor childExecutor) throws InterruptedException {
     if (context.getErrorInfoCollector().hasErrors()) {
       return;
     }
@@ -168,7 +167,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
     return result == Integer.MAX_VALUE ? -1 : result;
   }
 
-  private void runIterations(SpockExecutionContext context, ChildExecutor childExecutor, Iterator[] iterators, int estimatedNumIterations) {
+  private void runIterations(SpockExecutionContext context, ParameterizedFeatureChildExecutor childExecutor, Iterator[] iterators, int estimatedNumIterations) {
     if (context.getErrorInfoCollector().hasErrors()) {
       return;
     }

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -16,11 +16,10 @@
 
 package org.spockframework.runtime;
 
+import org.spockframework.runtime.ParameterizedFeatureNode.ChildExecutor;
 import org.spockframework.runtime.model.*;
 
 import java.util.*;
-
-import org.junit.platform.engine.support.hierarchical.Node;
 
 import static java.util.stream.Collectors.toList;
 
@@ -35,7 +34,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
   }
 
   @Override
-  void runParameterizedFeature(SpockExecutionContext context, Node.DynamicTestExecutor dynamicTestExecutor) throws InterruptedException {
+  void runParameterizedFeature(SpockExecutionContext context, ChildExecutor childExecutor) throws InterruptedException {
     if (context.getErrorInfoCollector().hasErrors()) {
       return;
     }
@@ -43,9 +42,9 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
     Object[] dataProviders = createDataProviders(context);
     int numIterations = estimateNumIterations(context, dataProviders);
     Iterator[] iterators = createIterators(context, dataProviders);
-    runIterations(context, dynamicTestExecutor, iterators, numIterations);
+    runIterations(context, childExecutor, iterators, numIterations);
     try {
-      dynamicTestExecutor.awaitFinished();
+      childExecutor.awaitFinished();
     } finally {
       closeDataProviders(dataProviders);
     }
@@ -169,7 +168,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
     return result == Integer.MAX_VALUE ? -1 : result;
   }
 
-  private void runIterations(SpockExecutionContext context, Node.DynamicTestExecutor dynamicTestExecutor, Iterator[] iterators, int estimatedNumIterations) {
+  private void runIterations(SpockExecutionContext context, ChildExecutor childExecutor, Iterator[] iterators, int estimatedNumIterations) {
     if (context.getErrorInfoCollector().hasErrors()) {
       return;
     }
@@ -182,7 +181,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
       if (context.getErrorInfoCollector().hasErrors()) {
         return;
       }
-      dynamicTestExecutor.execute(iterationNode);
+      childExecutor.execute(iterationNode);
 
       // no iterators => no data providers => only derived parameterizations => limit to one iteration
       if (iterators.length == 0) {

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
@@ -16,7 +16,6 @@
 
 package org.spockframework.runtime;
 
-import org.spockframework.runtime.ParameterizedFeatureNode.ChildExecutor;
 import org.spockframework.runtime.extension.*;
 import org.spockframework.runtime.model.*;
 import org.spockframework.util.*;
@@ -249,7 +248,7 @@ public class PlatformSpecRunner {
     return result;
   }
 
-  void runParameterizedFeature(SpockExecutionContext context, ChildExecutor childExecutor) throws InterruptedException  {
+  void runParameterizedFeature(SpockExecutionContext context, ParameterizedFeatureChildExecutor childExecutor) throws InterruptedException  {
     throw new UnsupportedOperationException("This runner cannot run parameterized features");
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
@@ -16,12 +16,12 @@
 
 package org.spockframework.runtime;
 
+import org.spockframework.runtime.ParameterizedFeatureNode.ChildExecutor;
 import org.spockframework.runtime.extension.*;
 import org.spockframework.runtime.model.*;
 import org.spockframework.util.*;
 import spock.lang.Specification;
 
-import org.junit.platform.engine.support.hierarchical.Node;
 
 import java.util.Arrays;
 
@@ -249,7 +249,7 @@ public class PlatformSpecRunner {
     return result;
   }
 
-  void runParameterizedFeature(SpockExecutionContext context, Node.DynamicTestExecutor dynamicTestExecutor) throws InterruptedException  {
+  void runParameterizedFeature(SpockExecutionContext context, ChildExecutor childExecutor) throws InterruptedException  {
     throw new UnsupportedOperationException("This runner cannot run parameterized features");
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollConfiguration.java
@@ -24,9 +24,9 @@ import spock.config.IncludeExcludeCriteria;
  * <p>Example:
  * <pre>
  * unroll {
- *   enabledByDefault false // default true
+ *   unrollByDefault false // default true
  *   defaultPattern '#featureName[#iterationIndex]' // default null
- *   expressionsAsserted false // default true
+ *   validateExpressions false // default true
  * }
  * </pre>
  *
@@ -35,7 +35,7 @@ import spock.config.IncludeExcludeCriteria;
 @Beta
 @ConfigurationObject("unroll")
 public class UnrollConfiguration {
-  public boolean enabledByDefault = true;
+  public boolean unrollByDefault = true;
   public String defaultPattern = null;
-  public boolean expressionsAsserted = true;
+  public boolean validateExpressions = true;
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime.extension.builtin;
+
+import org.spockframework.util.Beta;
+import spock.config.ConfigurationObject;
+import spock.config.IncludeExcludeCriteria;
+
+/**
+ * Configuration settings for the unroll extension.
+ *
+ * <p>Example:
+ * <pre>
+ * unroll {
+ *   enabledByDefault false // default true
+ *   defaultPattern '#featureName[#iterationIndex]' // default null
+ *   expressionsAsserted false // default true
+ * }
+ * </pre>
+ *
+ * @since 2.0
+ */
+@Beta
+@ConfigurationObject("unroll")
+public class UnrollConfiguration {
+  public boolean enabledByDefault = true;
+  public String defaultPattern = null;
+  public boolean expressionsAsserted = true;
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollConfiguration.java
@@ -16,7 +16,6 @@ package org.spockframework.runtime.extension.builtin;
 
 import org.spockframework.util.Beta;
 import spock.config.ConfigurationObject;
-import spock.config.IncludeExcludeCriteria;
 
 /**
  * Configuration settings for the unroll extension.

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollExtension.java
@@ -14,7 +14,6 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import groovy.transform.TailRecursive;
 import org.spockframework.runtime.DataVariablesIterationNameProvider;
 import org.spockframework.runtime.InvalidSpecException;
 import org.spockframework.runtime.extension.AbstractGlobalExtension;

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollExtension.java
@@ -14,6 +14,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
+import groovy.transform.TailRecursive;
 import org.spockframework.runtime.DataVariablesIterationNameProvider;
 import org.spockframework.runtime.InvalidSpecException;
 import org.spockframework.runtime.extension.AbstractGlobalExtension;
@@ -44,7 +45,7 @@ public class UnrollExtension extends AbstractGlobalExtension {
       doUnrollSpec = false;
       specUnrollPattern = "";
     } else {
-      doUnrollSpec = unrollConfiguration.enabledByDefault;
+      doUnrollSpec = unrollConfiguration.unrollByDefault;
       specUnrollPattern = "";
     }
 
@@ -53,6 +54,11 @@ public class UnrollExtension extends AbstractGlobalExtension {
       .stream()
       .filter(FeatureInfo::isParameterized)
       .forEach(feature -> visitFeature(feature, doUnrollSpec, specUnrollPattern));
+
+    SpecInfo superSpec = spec.getSuperSpec();
+    if (superSpec != null) {
+      visitSpec(superSpec);
+    }
   }
 
   private void visitFeature(FeatureInfo feature, boolean doUnrollSpec, String specUnrollPattern) {
@@ -87,16 +93,16 @@ public class UnrollExtension extends AbstractGlobalExtension {
   private NameProvider<IterationInfo> chooseNameProvider(String specUnrollPattern, String featureUnrollPattern,
                                                          FeatureInfo feature) {
     if (!featureUnrollPattern.isEmpty()) {
-      return new UnrollIterationNameProvider(feature, featureUnrollPattern, unrollConfiguration.expressionsAsserted);
+      return new UnrollIterationNameProvider(feature, featureUnrollPattern, unrollConfiguration.validateExpressions);
     }
     if (feature.getName().contains("#")) {
-      return new UnrollIterationNameProvider(feature, feature.getName(), unrollConfiguration.expressionsAsserted);
+      return new UnrollIterationNameProvider(feature, feature.getName(), unrollConfiguration.validateExpressions);
     }
     if (!specUnrollPattern.isEmpty()) {
-      return new UnrollIterationNameProvider(feature, specUnrollPattern, unrollConfiguration.expressionsAsserted);
+      return new UnrollIterationNameProvider(feature, specUnrollPattern, unrollConfiguration.validateExpressions);
     }
     if (unrollConfiguration.defaultPattern != null) {
-      return new UnrollIterationNameProvider(feature, unrollConfiguration.defaultPattern, unrollConfiguration.expressionsAsserted);
+      return new UnrollIterationNameProvider(feature, unrollConfiguration.defaultPattern, unrollConfiguration.validateExpressions);
     }
     return new DataVariablesIterationNameProvider();
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollIterationNameProvider.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UnrollIterationNameProvider.java
@@ -30,13 +30,13 @@ import static org.spockframework.util.RenderUtil.toStringOrDump;
 public class UnrollIterationNameProvider implements NameProvider<IterationInfo> {
   private static final Pattern EXPRESSION_PATTERN = Pattern.compile("#([a-zA-Z_$]([\\w$.]|\\(\\))*)");
 
-  private final boolean expressionsAsserted;
+  private final boolean validateExpressions;
   private final FeatureInfo feature;
   private final Matcher expressionMatcher;
 
-  public UnrollIterationNameProvider(FeatureInfo feature, String namePattern, boolean expressionsAsserted) {
+  public UnrollIterationNameProvider(FeatureInfo feature, String namePattern, boolean validateExpressions) {
     this.feature = feature;
-    this.expressionsAsserted = expressionsAsserted;
+    this.validateExpressions = validateExpressions;
     expressionMatcher = EXPRESSION_PATTERN.matcher(namePattern);
   }
 
@@ -76,7 +76,7 @@ public class UnrollIterationNameProvider implements NameProvider<IterationInfo> 
 
       default:
         if (!dataVariables.containsKey(firstPart)) {
-          if (expressionsAsserted) {
+          if (validateExpressions) {
             throw new SpockAssertionError("Error in @Unroll, could not find matching variable for expression: " + expr);
           }
           return "#Error:" + expr;
@@ -96,7 +96,7 @@ public class UnrollIterationNameProvider implements NameProvider<IterationInfo> 
       }
       return toStringOrDump(result);
     } catch (Exception e) {
-      if (expressionsAsserted) {
+      if (validateExpressions) {
         throw new SpockAssertionError("Error in @Unroll expression: " + expr, e);
       }
       return "#Error:" + expr;

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -23,7 +23,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   private NameProvider<IterationInfo> iterationNameProvider;
   private final List<DataProviderInfo> dataProviders = new ArrayList<>();
 
-  private boolean reportIterations = false;
+  private boolean reportIterations = true;
 
   public SpecInfo getSpec() {
     return getParent();

--- a/spock-core/src/main/java/org/spockframework/runtime/model/IterationInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/IterationInfo.java
@@ -19,8 +19,6 @@ import org.spockframework.util.DataVariableMap;
 import java.lang.reflect.AnnotatedElement;
 import java.util.*;
 
-import static java.util.Collections.unmodifiableMap;
-
 /**
  * Runtime information about an iteration of a feature method.
  */

--- a/spock-core/src/main/java/spock/lang/Rollup.java
+++ b/spock-core/src/main/java/spock/lang/Rollup.java
@@ -28,6 +28,9 @@ import java.lang.annotation.Target;
  * effect as putting it on every data-driven feature method that is not already
  * annotated with {@code Rollup}.
  *
+ * <p>Having {@code @Rollup} on a super spec does not influence the features of sub specs,
+ * that is {@code @Rollup} is not inheritable.
+ *
  * @since 2.0
  */
 @Beta

--- a/spock-core/src/main/java/spock/lang/Rollup.java
+++ b/spock-core/src/main/java/spock/lang/Rollup.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spock.lang;
+
+import org.spockframework.util.Beta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that iterations of a data-driven feature should not be made visible
+ * as separate features to the outside world (IDEs, reports, etc.) but as one atomic test.
+ * The {@code Rollup} annotation can also be put on a spec class. This has the same
+ * effect as putting it on every data-driven feature method that is not already
+ * annotated with {@code Rollup}.
+ *
+ * @since 2.0
+ */
+@Beta
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface Rollup {
+}

--- a/spock-core/src/main/java/spock/lang/Unroll.java
+++ b/spock-core/src/main/java/spock/lang/Unroll.java
@@ -8,7 +8,8 @@ import java.lang.annotation.*;
 /**
  * Indicates that iterations of a data-driven feature should be made visible
  * as separate features to the outside world (IDEs, reports, etc.). By default,
- * the name of an iteration is the feature's name followed by a consecutive number.
+ * the name of an iteration is the feature's name followed by the data variables
+ * and their values and the iteration index.
  * This can be changed by providing a naming pattern after @Unroll. A naming pattern
  * may refer to data variables by prepending their names with #. Example:
  *
@@ -42,7 +43,6 @@ import java.lang.annotation.*;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-@ExtensionAnnotation(UnrollExtension.class)
 public @interface Unroll {
   String value() default "";
 }

--- a/spock-core/src/main/java/spock/lang/Unroll.java
+++ b/spock-core/src/main/java/spock/lang/Unroll.java
@@ -1,8 +1,5 @@
 package spock.lang;
 
-import org.spockframework.runtime.extension.ExtensionAnnotation;
-import org.spockframework.runtime.extension.builtin.UnrollExtension;
-
 import java.lang.annotation.*;
 
 /**
@@ -38,6 +35,9 @@ import java.lang.annotation.*;
  * effect as putting it on every data-driven feature method that is not already
  * annotated with {@code Unroll}. By embedding the naming pattern in the method
  * names, each method can still have its own pattern.
+ *
+ * <p>Having {@code @Unroll} on a super spec does not influence the features of sub specs,
+ * that is {@code @Unroll} is not inheritable.
  *
  * @author Peter Niederwieser
  */

--- a/spock-core/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/spock-core/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,3 +1,4 @@
 org.spockframework.runtime.extension.builtin.IncludeExcludeExtension
 org.spockframework.runtime.extension.builtin.OptimizeRunOrderExtension
+org.spockframework.runtime.extension.builtin.UnrollExtension
 org.spockframework.report.log.ReportLogExtension

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/HandlingOfAssumptionViolatedException.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/HandlingOfAssumptionViolatedException.groovy
@@ -53,7 +53,8 @@ def foo() {
     """
 
     then:
-    result.testsStartedCount == 2
+    result.testsStartedCount == 3
+    result.testsSucceededCount == 1
     result.testsAbortedCount == 2
     result.testsFailedCount == 0
   }

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/HandlingOfAssumptionViolatedException.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/HandlingOfAssumptionViolatedException.groovy
@@ -41,15 +41,12 @@ def foo() {
 
   def "reported in data-driven unrolled feature method"() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def foo() {
-  setup:
-  assumeTrue(false)
+    def result = runner.runFeatureBody """
+setup:
+assumeTrue(false)
 
-  where:
-  i << (1..2)
-}
+where:
+i << (1..2)
     """
 
     then:

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitFixtureMethods.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitFixtureMethods.groovy
@@ -52,7 +52,6 @@ class JUnitFixtureMethods extends JUnitBaseSpec {
     ]
   }
 
-  @Unroll
   def "multiple of #fixtureType"() {
     when:
     runSpecBody """
@@ -70,7 +69,6 @@ class JUnitFixtureMethods extends JUnitBaseSpec {
     fixtureType << ["beforeClass", "before", "after", "afterClass"]
   }
 
-  @Unroll
   def "inheritance for #fixtureType"() {
     when:
     run """
@@ -98,7 +96,6 @@ class JUnitFixtureMethods extends JUnitBaseSpec {
     "afterClass"  | ["child", "parent"]
   }
 
-  @Unroll
   def "inheritance with overriding for #fixtureType"() {
     when:
     run """

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/UseJUnitTestNameRule.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/UseJUnitTestNameRule.groovy
@@ -18,6 +18,7 @@ import org.junit.Rule
 import org.junit.rules.TestName
 
 import spock.lang.Issue
+import spock.lang.Rollup
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -31,6 +32,7 @@ class UseJUnitTestNameRule extends Specification {
     name.methodName == "not data-driven"
   }
 
+  @Rollup
   def "data-driven, not unrolled"() {
     expect:
     name.methodName == "data-driven, not unrolled"
@@ -39,7 +41,6 @@ class UseJUnitTestNameRule extends Specification {
     i << (1..3)
   }
 
-  @Unroll
   def "data-driven, unrolled w/o name pattern"() {
     expect:
     name.methodName == "data-driven, unrolled w/o name pattern [i: $i, #${i-1}]"
@@ -48,7 +49,6 @@ class UseJUnitTestNameRule extends Specification {
     i << (1..3)
   }
 
-  @Unroll
   def "data-driven, unrolled w/ name pattern #pattern"() {
     expect:
     name.methodName == "data-driven, unrolled w/ name pattern $pattern"

--- a/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/DataSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/DataSpec.groovy
@@ -4,7 +4,6 @@ import groovy.sql.Sql
 import groovy.transform.ToString
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class DataSpec extends Specification {
 
@@ -249,7 +248,6 @@ class DataSpec extends Specification {
 // end::data-pipes[]
   }
 
-  @Unroll
 // tag::unrolled-1[]
   def "#person is #person.age years old"() { // property access
 // end::unrolled-1[]
@@ -260,7 +258,6 @@ class DataSpec extends Specification {
     person << [new Person(age: 14, name: 'Phil Cole')]
   }
 
-  @Unroll
 // tag::unrolled-2[]
   def "#person.name.toUpperCase()"() { // zero-arg method call
 // end::unrolled-2[]
@@ -272,9 +269,8 @@ class DataSpec extends Specification {
   }
 
 
-  @Unroll
 // tag::unrolled-3a[]
-  def "#lastName"() { // zero-arg method call
+  def "#lastName"() {
 // end::unrolled-3a[]
     expect:
     person

--- a/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/v4/MathSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/v4/MathSpec.groovy
@@ -1,11 +1,11 @@
 package org.spockframework.docs.datadriven.v4
 
+import spock.lang.Rollup
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class MathSpec extends Specification {
 // tag::example[]
-  @Unroll
+  @Rollup
   def "maximum of two numbers"() {
 // end::example[]
     expect:

--- a/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/v5/MathSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/v5/MathSpec.groovy
@@ -1,11 +1,9 @@
 package org.spockframework.docs.datadriven.v5
 
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class MathSpec extends Specification {
 // tag::example[]
-  @Unroll
   def "maximum of #a and #b is #c"() {
 // end::example[]
     expect:

--- a/spock-specs/src/test/groovy/org/spockframework/example/FeatureUnrolling.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/example/FeatureUnrolling.groovy
@@ -16,6 +16,7 @@
 
 package org.spockframework.example
 
+import spock.lang.Rollup
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -23,6 +24,7 @@ import spock.lang.Unroll
  * @author Peter Niederwieser
  */
 class FeatureUnrolling extends Specification {
+  @Rollup
   def "without unrolling"() {
     expect:
     name.size() == length
@@ -32,7 +34,6 @@ class FeatureUnrolling extends Specification {
     length << [4, 5, 6]
   }
 
-  @Unroll
   def "with unrolling"() {
     expect:
     name.size() == length

--- a/spock-specs/src/test/groovy/org/spockframework/idea/IntelliJIdeaSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/idea/IntelliJIdeaSpec.groovy
@@ -17,6 +17,7 @@
 package org.spockframework.idea
 
 import spock.lang.Ignore
+import spock.lang.Rollup
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -24,6 +25,7 @@ import spock.lang.Unroll
 @Ignore
 class IntelliJIdeaSpec extends Specification {
   // both inference and formatting work
+  @Rollup
   def "single-pipe data tables"() {
     expect:
     Math.max(a, b) == c
@@ -36,6 +38,7 @@ class IntelliJIdeaSpec extends Specification {
   }
 
   // formatting works, inference doesn't
+  @Rollup
   def "double-pipe data tables"() {
     expect:
     Math.max(a, b) == c
@@ -61,7 +64,6 @@ class IntelliJIdeaSpec extends Specification {
   }
 
   // unroll inference doesn't work
-  @Unroll
   def "max of #a and #b is #c"() {
     expect:
     Math.max(a, b) == c
@@ -87,7 +89,6 @@ class IntelliJIdeaSpec extends Specification {
   }
 
   // unroll inference doesn't work
-  @Unroll
   def "max of #a and #b is #c (2)"() {
     expect:
     Math.max(a, b) == c

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/SafeIterationNameProviderSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/SafeIterationNameProviderSpec.groovy
@@ -23,7 +23,7 @@ import org.spockframework.runtime.model.FeatureInfo
 import spock.lang.Specification
 
 class SafeIterationNameProviderSpec extends Specification {
-  def feature = new FeatureInfo()
+  def feature = new FeatureInfo().tap { it.reportIterations = false }
   IterationInfo iteration = Stub {
     getFeature() >> feature
   }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/extension/builtin/UnrollIterationNameProviderSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/extension/builtin/UnrollIterationNameProviderSpec.groovy
@@ -15,20 +15,21 @@
 package org.spockframework.runtime.extension.builtin
 
 import org.spockframework.runtime.SpockAssertionError
-import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.IterationInfo
 import spock.lang.*
-import spock.util.environment.RestoreSystemProperties
 
 class UnrollIterationNameProviderSpec extends Specification {
   @Issue("https://github.com/spockframework/spock/issues/237")
   def "regex-like data values are substituted correctly (i.e. literally)"() {
     given:
-    def feature = new FeatureInfo()
-    feature.addDataVariable("dataVar")
-    def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVar bar")
+    def nameGenerator = new UnrollIterationNameProvider(null, "foo #dataVar bar", false)
+    IterationInfo iterationInfo = Stub {
+      it.iterationIndex >> 0
+      it.dataVariables >> [dataVar: value]
+    }
 
     expect:
-    nameGenerator.nameFor(0, value) == name
+    nameGenerator.getName(iterationInfo) == name
 
     where:
     value                   | name
@@ -38,12 +39,14 @@ class UnrollIterationNameProviderSpec extends Specification {
 
   def "data values are converted to strings in Groovy style"() {
     given:
-    def feature = new FeatureInfo()
-    feature.addDataVariable("dataVar")
-    def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVar bar")
+    def nameGenerator = new UnrollIterationNameProvider(null, "foo #dataVar bar", false)
+    IterationInfo iterationInfo = Stub {
+      it.iterationIndex >> 0
+      it.dataVariables >> [dataVar: value]
+    }
 
     expect:
-    nameGenerator.nameFor(0, value) == name
+    nameGenerator.getName(iterationInfo) == name
 
     where:
     value                   | name
@@ -53,35 +56,35 @@ class UnrollIterationNameProviderSpec extends Specification {
 
   def "missing variables are rendered as #Error:dataVars"() {
     given:
-    def feature = new FeatureInfo()
-    feature.addDataVariable("dataVar")
-    def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVars bar")
+    def nameGenerator = new UnrollIterationNameProvider(null, "foo #dataVars bar", false)
+    IterationInfo iterationInfo = Stub {
+      it.iterationIndex >> 0
+      it.dataVariables >> [dataVar: '1']
+    }
 
     expect:
-    nameGenerator.nameFor(0, '1') == "foo #Error:dataVars bar"
+    nameGenerator.getName(iterationInfo) == "foo #Error:dataVars bar"
   }
 
   def "exceptions during variable eval are rendered as #Error:dataVars"() {
     given:
-    def feature = new FeatureInfo()
-    feature.addDataVariable("dataVar")
-    def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVar.foo bar")
+    def nameGenerator = new UnrollIterationNameProvider(null, "foo #dataVar.foo bar", false)
+    IterationInfo iterationInfo = Stub {
+      it.iterationIndex >> 0
+      it.dataVariables >> [dataVar: '1']
+    }
 
     expect:
-    nameGenerator.nameFor(0, '1') == "foo #Error:dataVar.foo bar"
+    nameGenerator.getName(iterationInfo) == "foo #Error:dataVar.foo bar"
   }
 
   @Issue("https://github.com/spockframework/spock/issues/767")
-  @RestoreSystemProperties
-  def "missing variables throw an exception if spock.throwUnrollExceptions is set to true"() {
+  def "missing variables throw an exception if expressionsAsserted is set to true"() {
     given:
-    System.setProperty('spock.assertUnrollExpressions', 'true')
-    def feature = new FeatureInfo()
-    feature.addDataVariable("dataVar")
-    def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVars bar")
+    def nameGenerator = new UnrollIterationNameProvider(null, "foo #dataVars bar", true)
 
     when:
-    nameGenerator.nameFor(0, '1') == "foo #Error:dataVars bar"
+    nameGenerator.getName(Stub(IterationInfo)) == "foo #Error:dataVars bar"
 
     then:
     def e = thrown(SpockAssertionError)
@@ -90,16 +93,16 @@ class UnrollIterationNameProviderSpec extends Specification {
   }
 
   @Issue("https://github.com/spockframework/spock/issues/767")
-  @RestoreSystemProperties
-  def "exceptions during variable eval throw an exception if spock.throwUnrollExceptions is set to true"() {
+  def "exceptions during variable eval throw an exception if expressionsAsserted is set to true"() {
     given:
-    def feature = new FeatureInfo()
-    System.setProperty('spock.assertUnrollExpressions', 'true')
-    feature.addDataVariable("dataVar")
-    def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVar.foo bar")
+    def nameGenerator = new UnrollIterationNameProvider(null, "foo #dataVar.foo bar", true)
+    IterationInfo iterationInfo = Stub {
+      it.iterationIndex >> 0
+      it.dataVariables >> [dataVar: '1']
+    }
 
     when:
-    nameGenerator.nameFor(0, '1') == "foo #Error:dataVar.foo bar"
+    nameGenerator.getName(iterationInfo) == "foo #Error:dataVar.foo bar"
 
     then:
     def e = thrown(SpockAssertionError)

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/extension/builtin/UnrollIterationNameProviderSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/extension/builtin/UnrollIterationNameProviderSpec.groovy
@@ -79,7 +79,7 @@ class UnrollIterationNameProviderSpec extends Specification {
   }
 
   @Issue("https://github.com/spockframework/spock/issues/767")
-  def "missing variables throw an exception if expressionsAsserted is set to true"() {
+  def "missing variables throw an exception if validateExpressions is set to true"() {
     given:
     def nameGenerator = new UnrollIterationNameProvider(null, "foo #dataVars bar", true)
 
@@ -93,7 +93,7 @@ class UnrollIterationNameProviderSpec extends Specification {
   }
 
   @Issue("https://github.com/spockframework/spock/issues/767")
-  def "exceptions during variable eval throw an exception if expressionsAsserted is set to true"() {
+  def "exceptions during variable eval throw an exception if validateExpressions is set to true"() {
     given:
     def nameGenerator = new UnrollIterationNameProvider(null, "foo #dataVar.foo bar", true)
     IterationInfo iterationInfo = Stub {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/MethodExecutionOrder.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/MethodExecutionOrder.groovy
@@ -24,7 +24,7 @@ import spock.lang.*
 @Stepwise
 class MethodExecutionOrder extends Specification {
   @Shared order = []
-	
+
   def cleanup() {
     getOrder() << "c"
   }
@@ -83,6 +83,6 @@ class MethodExecutionOrder extends Specification {
   def "parameterized feature"() {
     getOrder() << x
     expect: 1
-    where : x << [8, 9, 10]
+    where: x << [8, 9, 10]
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/SpecRecognition.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/SpecRecognition.groovy
@@ -25,7 +25,6 @@ import org.spockframework.EmbeddedSpecification
  * @author Peter Niederwieser
  */
 class SpecRecognition extends EmbeddedSpecification {
-  @Unroll
   def "is properly recognized"() {
     when:
     runner.run """

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreRestExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreRestExtension.groovy
@@ -56,7 +56,6 @@ def baz() {
     ignored << [2            , 1            , 0            ]
   }
 
-  @Unroll
   def "@IgnoreRest in base and/or derived class"() {
     def classes = compiler.compileWithImports("""
 class Base extends Specification {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/PendingFeatureExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/PendingFeatureExtensionSpec.groovy
@@ -123,7 +123,7 @@ class Foo extends Specification {
     result.testsSucceededCount == 3
     result.testsFailedCount == 0
     result.testsSkippedCount == 0
-    result.containersAbortedCount == 1
+    result.testsAbortedCount == 1
   }
 
 
@@ -147,7 +147,7 @@ class Foo extends Specification {
     result.testsSucceededCount == 3
     result.testsFailedCount == 0
     result.testsSkippedCount == 0
-    result.containersAbortedCount == 1
+    result.testsAbortedCount == 1
   }
 
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/PendingFeatureIfExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/PendingFeatureIfExtensionSpec.groovy
@@ -81,11 +81,11 @@ def bar() {
 
     then:
     notThrown(AssertionError)
-    result.testsStartedCount == 1
+    result.testsStartedCount == 2
     result.testsFailedCount == 0
     result.testsSkippedCount == 0
     result.testsAbortedCount == 1
-    result.testsSucceededCount == 0
+    result.testsSucceededCount == 1
   }
 
   def "@PendingFeatureIf marks passing feature as failed if the data variable accessing conditional expression returns true"() {
@@ -129,10 +129,10 @@ def bar() {
 
     then:
     notThrown(AssertionError)
-    result.testsStartedCount == 1
+    result.testsStartedCount == 2
     result.testsFailedCount == 0
     result.testsSkippedCount == 0
     result.testsAbortedCount == 0
-    result.testsSucceededCount == 1
+    result.testsSucceededCount == 2
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
@@ -30,11 +30,14 @@ class RequiresExtension extends EmbeddedSpecification {
     when:
     def results = runner.runClass(RequiresExtensionExamples)
     then:
-    results.testsSucceededCount == 7
+    results.testsSucceededCount == 8
     results.testsFailedCount == 0
-    results.testsSkippedCount == 2
+    results.testsSkippedCount == 3
     results.testEvents().skipped().list().testDescriptor.displayName == [
-      "skips feature if precondition is not satisfied", "allows determinate use of multiple filters"]
+      "skips feature if precondition is not satisfied",
+      "can skip data providers completely if no data variables are accessed",
+      "allows determinate use of multiple filters"
+    ]
   }
 
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryFeatureExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryFeatureExtensionSpec.groovy
@@ -72,8 +72,6 @@ class Foo extends Specification {
     featureCounter.get() == 4
   }
 
-
-  @Unroll
   def "@Retry mode #mode executes setup and cleanup #expectedCount times"(String mode, int expectedCount) {
     given:
     setupCounter.set(0)
@@ -218,7 +216,6 @@ class Foo extends Specification {
 import spock.lang.Retry
 
 class Foo extends Specification {
-  @Unroll
   @Retry
   def bar() {
     org.spockframework.smoke.extension.RetryFeatureExtensionSpec.featureCounter.incrementAndGet()
@@ -265,7 +262,6 @@ class Foo extends Specification {
 import spock.lang.Retry
 
 class Foo extends Specification {
-  @Unroll
   @Retry
   def bar() {
     expect: test
@@ -337,7 +333,6 @@ class Foo extends Specification {
 import spock.lang.Retry
 
 class Foo extends Specification {
-  @Unroll
   @Retry(condition = { failure.message.contains('1') })
   def "bar #message"() {
     org.spockframework.smoke.extension.RetryFeatureExtensionSpec.featureCounter.incrementAndGet()
@@ -363,7 +358,6 @@ class Foo extends Specification {
 import spock.lang.Retry
 
 class Foo extends Specification {
-  @Unroll
   @Retry(exceptions = IllegalArgumentException, condition = { failure.message.contains('1') })
   def "bar #exceptionClass #message"() {
     org.spockframework.smoke.extension.RetryFeatureExtensionSpec.featureCounter.incrementAndGet()
@@ -396,7 +390,6 @@ import spock.lang.Retry
 
 class Foo extends Specification {
   int value
-  @Unroll
   @Retry(condition = { instance.value == 2 })
   def "bar #input"() {
     org.spockframework.smoke.extension.RetryFeatureExtensionSpec.featureCounter.incrementAndGet()

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryFeatureExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryFeatureExtensionSpec.groovy
@@ -177,7 +177,7 @@ class Foo extends Specification {
   def bar() {
     expect:
     throw new IllegalArgumentException()
-    
+
     where:
     ignore << [1, 2]
   }
@@ -206,7 +206,7 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testsSucceededCount == 0
+    result.testsSucceededCount == 1
     result.testsFailedCount == 2
     result.testsSkippedCount == 0
     featureCounter.get() == 8
@@ -231,7 +231,7 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testsSucceededCount == 2
+    result.testsSucceededCount == 3
     result.testsFailedCount == 1
     result.testsSkippedCount == 0
     featureCounter.get() == 4 + 2
@@ -254,7 +254,7 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testsSucceededCount == 3
+    result.testsSucceededCount == 4
     result.testsFailedCount == 0
     result.testsSkippedCount == 0
   }
@@ -277,7 +277,7 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testsSucceededCount == 3
+    result.testsSucceededCount == 4
     result.testsFailedCount == 0
     result.testsSkippedCount == 0
   }
@@ -324,8 +324,8 @@ class Foo extends Specification {
     def duration = System.currentTimeMillis() - start
     duration > 300
     duration < 1000
-    result.testsStartedCount == 3
-    result.testsSucceededCount == 2
+    result.testsStartedCount == 4
+    result.testsSucceededCount == 3
     result.testsFailedCount == 1
     result.testsSkippedCount == 0
     featureCounter.get() == 4 + 2
@@ -351,8 +351,8 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testsStartedCount == 3
-    result.testsSucceededCount == 0
+    result.testsStartedCount == 4
+    result.testsSucceededCount == 1
     result.testsFailedCount == 3
     featureCounter.get() == 4 + 1 + 1
   }
@@ -383,8 +383,8 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testsStartedCount == 6
-    result.testsSucceededCount == 0
+    result.testsStartedCount == 7
+    result.testsSucceededCount == 1
     result.testsFailedCount == 6
     featureCounter.get() == (4 + 1) + (1 + 1) + (1 + 1)
   }
@@ -401,7 +401,7 @@ class Foo extends Specification {
   def "bar #input"() {
     org.spockframework.smoke.extension.RetryFeatureExtensionSpec.featureCounter.incrementAndGet()
     value = input
-    
+
     expect:
     false
 
@@ -412,8 +412,8 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testsStartedCount == 3
-    result.testsSucceededCount == 0
+    result.testsStartedCount == 4
+    result.testsSucceededCount == 1
     result.testsFailedCount == 3
     featureCounter.get() == 1 + 4 + 1
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataProviders.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataProviders.groovy
@@ -36,14 +36,14 @@ where: x << null
 
   def "literal"() {
     expect: x == 1
-    where : x << 1
+    where: x << 1
   }
 
   def "empty list"() {
     when:
     runner.runFeatureBody """
 expect: true
-where : x << []
+where: x << []
     """
 
     then:
@@ -52,64 +52,64 @@ where : x << []
 
   def "single-element list"() {
     expect: x == 1
-    where : x << [1]
+    where: x << [1]
   }
 
   def "multi-element list"() {
     expect: [1, 2, 3].contains x
-    where : x << [3, 2, 1]
+    where: x << [3, 2, 1]
   }
 
   def "array"() {
     expect: [1, 2, 3].contains x
-    where : x << ([3, 2, 1] as int[])
+    where: x << ([3, 2, 1] as int[])
   }
 
   def "map"() {
     expect: x.value == x.key.toUpperCase()
-    where : x << ["vienna":"VIENNA", "tokyo":"TOKYO"]
+    where: x << ["vienna":"VIENNA", "tokyo":"TOKYO"]
   }
 
   def "matcher"() {
     expect: x.startsWith "a"
-    where : x << ("a1a2a3" =~ /a./)
+    where: x << ("a1a2a3" =~ /a./)
   }
 
   def "string"() {
     expect: "abc".contains x
-    where : x << "cba"
+    where: x << "cba"
   }
 
   def "iterator"() {
     expect: [1, 2, 3].contains x
-    where : x << new MyIterator()
+    where: x << new MyIterator()
   }
 
   def "iterable"() {
     expect: [1, 2, 3].contains x
-    where : x << new MyIterable()
+    where: x << new MyIterable()
   }
 
   def "disguised iterable"() {
     expect: [1, 2, 3].contains x
-    where : x << new MyDisguisedIterable()
+    where: x << new MyDisguisedIterable()
   }
 
   def "enumeration"() {
     expect: ["a", "b", "c"].contains x
-    where : x << new StringTokenizer("b c a")
+    where: x << new StringTokenizer("b c a")
   }
 
   def "data providers with same number of values"() {
     expect: x == y
-    where : x << [1, 2, 3]; y << [1, 2, 3]
+    where: x << [1, 2, 3]; y << [1, 2, 3]
   }
 
   def "data providers with different number of values"() {
     when:
     runner.runFeatureBody """
 expect: x == y
-where : $providers
+where: $providers
     """
 
     then:
@@ -139,7 +139,7 @@ y << []
 
   def "different kinds of data providers used together"() {
     expect: a + b + c + d + e == "abcde"
-    where :
+    where:
       a << "a"
       b << ["b"]
       c << ("c" =~ /./)

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -21,8 +21,10 @@ import org.spockframework.runtime.SpockExecutionException
 
 import spock.lang.Ignore
 import spock.lang.Issue
+import spock.lang.Rollup
 import spock.lang.Shared
 
+@Rollup
 class DataTables extends EmbeddedSpecification {
   static staticField = 42
 
@@ -423,7 +425,7 @@ local ; 1
   def "cell references are evaluated correctly in the method's name"() {
     when:
     def result = runner.runSpecBody '''
-      @Unroll def 'a = #a, b = #b'() {
+      def 'a = #a, b = #b'() {
         expect:
         true
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -435,7 +435,7 @@ local ; 1
     '''
 
     then:
-    result.testEvents().finished().list().testDescriptor.displayName == ["a = 0, b = 1", "a = 2, b = 2" ]
+    result.testEvents().finished().list().testDescriptor.displayName == ["a = 0, b = 1", "a = 2, b = 2", "a = #a, b = #b" ]
   }
 
   def "cells can't reference next cells"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -21,10 +21,13 @@ import org.spockframework.EmbeddedSpecification
 import org.spockframework.runtime.SpockExecutionException
 import spock.lang.FailsWith
 import spock.lang.Issue
+import spock.lang.Rollup
+import spock.lang.Unroll
 
 /**
  * @author Peter Niederwieser
  */
+@Rollup
 class MethodParameters extends EmbeddedSpecification {
   def "no parameters"() {
     expect:
@@ -102,6 +105,7 @@ def foo(x, y, z) {
   }
 
   @Issue("https://github.com/spockframework/spock/issues/652")
+  @Unroll
   def "data variable that is not a parameter"() {
     expect:
     runner.runSpecBody """

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/Parameterizations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/Parameterizations.groovy
@@ -20,10 +20,11 @@ import org.spockframework.EmbeddedSpecification
 import org.spockframework.runtime.ConditionNotSatisfiedError
 import spock.lang.*
 
+@Rollup
 class Parameterizations extends EmbeddedSpecification {
   def "multi-parameterization"() {
     expect: a == b
-    where :
+    where:
       [a, b] << [[1, 1], [2, 2], [3, 3]]
   }
 
@@ -39,7 +40,7 @@ where :
 
   def "multi-parameterization with placeholder in first position"() {
     expect: a == b
-    where :
+    where:
       [_, a, b] << [[9, 1, 1], [9, 2, 2], [9, 3, 3]]
   }
 
@@ -52,7 +53,7 @@ where :
 
   def "multi-parameterization with placeholder in second position"() {
     expect: a == b
-    where :
+    where:
       [a, _, b] << [[1, 9, 1], [2, 9, 2], [3, 9, 3]]
   }
 
@@ -65,7 +66,7 @@ where :
 
   def "multi-parameterization with placeholder in last position"() {
     expect: a == b
-    where :
+    where:
       [a, b, _] << [[1, 1, 9], [2, 2, 9], [3, 3, 9]]
   }
 
@@ -79,7 +80,7 @@ where :
   @FailsWith(ConditionNotSatisfiedError)
   def "multi-parameterization with placeholder in wrong position"() {
     expect: a == b
-    where :
+    where:
       [a, b, _] << [[1, 9, 1]]
   }
 
@@ -139,10 +140,10 @@ where:
   def 'arguments may not be used before they have been assigned'() {
     when:
     runner.runFeatureBody '''
-      expect: true
-      where:
-        b = a
-        a = 1
+expect: true
+where:
+  b = a
+  a = 1
     '''
 
     then:

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/ParameterizedFeatureNodeStatuses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/ParameterizedFeatureNodeStatuses.groovy
@@ -21,7 +21,6 @@ import org.opentest4j.TestAbortedException
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.runtime.SpockAssertionError
 import org.spockframework.runtime.SpockComparisonFailure
-import spock.lang.PendingFeature
 
 class ParameterizedFeatureNodeStatuses extends EmbeddedSpecification {
   def setup() {
@@ -29,7 +28,6 @@ class ParameterizedFeatureNodeStatuses extends EmbeddedSpecification {
     runner.throwFailure = false
   }
 
-  @PendingFeature
   def 'should be skipped if all uprolled iterations are skipped'() {
     when:
     def result = runner.runSpecBody """
@@ -67,7 +65,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be successful if some uprolled iterations are successful and some skipped'() {
     when:
     def result = runner.runSpecBody """
@@ -103,7 +100,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be failing if some uprolled iterations are failing and some skipped'() {
     when:
     def result = runner.runSpecBody """
@@ -141,7 +137,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be error if some uprolled iterations are erroring and some skipped'() {
     when:
     def result = runner.runSpecBody """
@@ -180,7 +175,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be successful if all uprolled iterations are successful'() {
     when:
     def result = runner.runSpecBody """
@@ -215,7 +209,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be failing if some uprolled iterations are failing and some successful'() {
     when:
     def result = runner.runSpecBody """
@@ -252,7 +245,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be error if some uprolled iterations are erroring and some successful'() {
     when:
     def result = runner.runSpecBody """
@@ -290,7 +282,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be failing if all uprolled iterations are failing'() {
     when:
     def result = runner.runSpecBody """
@@ -330,7 +321,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be failing if some uprolled iterations are erroring and some failing'() {
     when:
     def result = runner.runSpecBody """
@@ -371,7 +361,6 @@ def 'a feature'() {
     }
   }
 
-  @PendingFeature
   def 'should be failing if all uprolled iterations are erroring'() {
     when:
     def result = runner.runSpecBody """
@@ -414,13 +403,10 @@ def 'a feature'() {
 
   def 'should be successful if all unrolled iterations are skipped'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  throw new TestAbortedException()
-  expect: a in [1, 2]
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+throw new TestAbortedException()
+expect: a in [1, 2]
+where: a << [1, 2]
 """
 
     then:
@@ -449,13 +435,10 @@ def 'a feature'() {
 
   def 'should be successful if some unrolled iterations are successful and some skipped'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  if (a == 1) throw new TestAbortedException()
-  expect: a == 2
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+if (a == 1) throw new TestAbortedException()
+expect: a == 2
+where: a << [1, 2]
 """
 
     then:
@@ -484,13 +467,10 @@ def 'a feature'() {
 
   def 'should be successful if some unrolled iterations are failing and some skipped'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  if (a == 1) throw new TestAbortedException()
-  expect: a == 3
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+if (a == 1) throw new TestAbortedException()
+expect: a == 3
+where: a << [1, 2]
 """
 
     then:
@@ -521,14 +501,11 @@ def 'a feature'() {
 
   def 'should be successful if some unrolled iterations are erroring and some skipped'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  if (a == 1) throw new TestAbortedException()
-  throw new Error()
-  expect: true
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+if (a == 1) throw new TestAbortedException()
+throw new Error()
+expect: true
+where: a << [1, 2]
 """
 
     then:
@@ -559,12 +536,9 @@ def 'a feature'() {
 
   def 'should be successful if all unrolled iterations are successful'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  expect: a in [1, 2]
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+expect: a in [1, 2]
+where: a << [1, 2]
 """
 
     then:
@@ -593,12 +567,9 @@ def 'a feature'() {
 
   def 'should be successful if some unrolled iterations are failing and some successful'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  expect: a == 1
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+expect: a == 1
+where: a << [1, 2]
 """
 
     then:
@@ -629,13 +600,10 @@ def 'a feature'() {
 
   def 'should be successful if some unrolled iterations are erroring and some successful'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  if (a == 1) throw new Error()
-  expect: a == 2
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+if (a == 1) throw new Error()
+expect: a == 2
+where: a << [1, 2]
 """
 
     then:
@@ -666,12 +634,9 @@ def 'a feature'() {
 
   def 'should be successful if all unrolled iterations are failing'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  expect: a == 3
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+expect: a == 3
+where: a << [1, 2]
 """
 
     then:
@@ -702,13 +667,10 @@ def 'a feature'() {
 
   def 'should be successful if some unrolled iterations are erroring and some failing'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  if (a == 1) throw new Error()
-  expect: a == 3
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+if (a == 1) throw new Error()
+expect: a == 3
+where: a << [1, 2]
 """
 
     then:
@@ -739,13 +701,10 @@ def 'a feature'() {
 
   def 'should be successful if all unrolled iterations are erroring'() {
     when:
-    def result = runner.runSpecBody """
-@Unroll
-def 'a feature'() {
-  throw new Error()
-  expect: a in [1, 2]
-  where: a << [1, 2]
-}
+    def result = runner.runFeatureBody """
+throw new Error()
+expect: a in [1, 2]
+where: a << [1, 2]
 """
 
     then:

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/ParameterizedFeatureNodeStatuses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/ParameterizedFeatureNodeStatuses.groovy
@@ -40,8 +40,6 @@ def 'a feature'() {
 
     then:
     verifyAll(result) {
-      testEvents().executions().aborted().stream().forEach { it.terminationInfo.executionResult.throwable.get().printStackTrace() }
-
       dynamicallyRegisteredCount == 0
 
       containersStartedCount == 2
@@ -77,8 +75,6 @@ def 'a feature'() {
 
     then:
     verifyAll(result) {
-      testEvents().executions().aborted().stream().forEach { it.terminationInfo.executionResult.throwable.get().printStackTrace() }
-
       dynamicallyRegisteredCount == 0
 
       containersStartedCount == 2

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/ParameterizedFeatureNodeStatuses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/ParameterizedFeatureNodeStatuses.groovy
@@ -1,0 +1,776 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.parameterization
+
+import org.opentest4j.MultipleFailuresError
+import org.opentest4j.TestAbortedException
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.SpockAssertionError
+import org.spockframework.runtime.SpockComparisonFailure
+import spock.lang.PendingFeature
+
+class ParameterizedFeatureNodeStatuses extends EmbeddedSpecification {
+  def setup() {
+    runner.addClassImport(TestAbortedException)
+    runner.throwFailure = false
+  }
+
+  @PendingFeature
+  def 'should be skipped if all uprolled iterations are skipped'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  throw new TestAbortedException()
+  expect: a in [1, 2]
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      testEvents().executions().aborted().stream().forEach { it.terminationInfo.executionResult.throwable.get().printStackTrace() }
+
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 0
+      testsFailedCount == 0
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 1
+      totalSucceededCount == 2
+      totalFailureCount == 0
+    }
+  }
+
+  @PendingFeature
+  def 'should be successful if some uprolled iterations are successful and some skipped'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  if (a == 1) throw new TestAbortedException()
+  expect: a == 2
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 1
+      testsFailedCount == 0
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 3
+      totalFailureCount == 0
+    }
+  }
+
+  @PendingFeature
+  def 'should be failing if some uprolled iterations are failing and some skipped'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  if (a == 1) throw new TestAbortedException()
+  expect: a == 3
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [SpockComparisonFailure]
+
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 1
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 2
+      totalFailureCount == 1
+    }
+  }
+
+  @PendingFeature
+  def 'should be error if some uprolled iterations are erroring and some skipped'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  if (a == 1) throw new TestAbortedException()
+  throw new Error()
+  expect: true
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [Error]
+
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 1
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 2
+      totalFailureCount == 1
+    }
+  }
+
+  @PendingFeature
+  def 'should be successful if all uprolled iterations are successful'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  expect: a in [1, 2]
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 1
+      testsFailedCount == 0
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 3
+      totalFailureCount == 0
+    }
+  }
+
+  @PendingFeature
+  def 'should be failing if some uprolled iterations are failing and some successful'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  expect: a == 1
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [SpockComparisonFailure]
+
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 1
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 2
+      totalFailureCount == 1
+    }
+  }
+
+  @PendingFeature
+  def 'should be error if some uprolled iterations are erroring and some successful'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  if (a == 1) throw new Error()
+  expect: a == 2
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [Error]
+
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 1
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 2
+      totalFailureCount == 1
+    }
+  }
+
+  @PendingFeature
+  def 'should be failing if all uprolled iterations are failing'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  expect: a == 3
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      with(failures.exception) {
+        it*.getClass() == [MultipleFailuresError]
+        first().failures*.getClass() == [SpockComparisonFailure, SpockComparisonFailure]
+      }
+
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 1
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 2
+      totalFailureCount == 1
+    }
+  }
+
+  @PendingFeature
+  def 'should be failing if some uprolled iterations are erroring and some failing'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  if (a == 1) throw new Error()
+  expect: a == 3
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      with(failures.exception) {
+        it*.getClass() == [MultipleFailuresError]
+        first().failures*.getClass() == [Error, SpockComparisonFailure]
+      }
+
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 1
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 2
+      totalFailureCount == 1
+    }
+  }
+
+  @PendingFeature
+  def 'should be failing if all uprolled iterations are erroring'() {
+    when:
+    def result = runner.runSpecBody """
+@Rollup
+def 'a feature'() {
+  throw new Error()
+  expect: a in [1, 2]
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      with(failures.exception) {
+        it*.getClass() == [MultipleFailuresError]
+        first().failures*.getClass() == [Error, Error]
+      }
+
+      dynamicallyRegisteredCount == 0
+
+      containersStartedCount == 2
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 2
+      containersFailedCount == 0
+
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 1
+
+      totalStartedCount == 3
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 2
+      totalFailureCount == 1
+    }
+  }
+
+  def 'should be successful if all unrolled iterations are skipped'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  throw new TestAbortedException()
+  expect: a in [1, 2]
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 2
+      testsSucceededCount == 1
+      testsFailedCount == 0
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 2
+      totalSucceededCount == 3
+      totalFailureCount == 0
+    }
+  }
+
+  def 'should be successful if some unrolled iterations are successful and some skipped'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  if (a == 1) throw new TestAbortedException()
+  expect: a == 2
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 2
+      testsFailedCount == 0
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 1
+      totalSucceededCount == 4
+      totalFailureCount == 0
+    }
+  }
+
+  def 'should be successful if some unrolled iterations are failing and some skipped'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  if (a == 1) throw new TestAbortedException()
+  expect: a == 3
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [SpockComparisonFailure]
+
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 1
+      testsFailedCount == 1
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 1
+      totalSucceededCount == 3
+      totalFailureCount == 1
+    }
+  }
+
+  def 'should be successful if some unrolled iterations are erroring and some skipped'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  if (a == 1) throw new TestAbortedException()
+  throw new Error()
+  expect: true
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [Error]
+
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 1
+      testsFailedCount == 1
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 1
+      totalSucceededCount == 3
+      totalFailureCount == 1
+    }
+  }
+
+  def 'should be successful if all unrolled iterations are successful'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  expect: a in [1, 2]
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 3
+      testsFailedCount == 0
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 5
+      totalFailureCount == 0
+    }
+  }
+
+  def 'should be successful if some unrolled iterations are failing and some successful'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  expect: a == 1
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [SpockComparisonFailure]
+
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 2
+      testsFailedCount == 1
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 4
+      totalFailureCount == 1
+    }
+  }
+
+  def 'should be successful if some unrolled iterations are erroring and some successful'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  if (a == 1) throw new Error()
+  expect: a == 2
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [Error]
+
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 2
+      testsFailedCount == 1
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 4
+      totalFailureCount == 1
+    }
+  }
+
+  def 'should be successful if all unrolled iterations are failing'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  expect: a == 3
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [SpockComparisonFailure, SpockComparisonFailure]
+
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 1
+      testsFailedCount == 2
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 3
+      totalFailureCount == 2
+    }
+  }
+
+  def 'should be successful if some unrolled iterations are erroring and some failing'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  if (a == 1) throw new Error()
+  expect: a == 3
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [Error, SpockComparisonFailure]
+
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 1
+      testsFailedCount == 2
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 3
+      totalFailureCount == 2
+    }
+  }
+
+  def 'should be successful if all unrolled iterations are erroring'() {
+    when:
+    def result = runner.runSpecBody """
+@Unroll
+def 'a feature'() {
+  throw new Error()
+  expect: a in [1, 2]
+  where: a << [1, 2]
+}
+"""
+
+    then:
+    verifyAll(result) {
+      failures.exception*.getClass() == [Error, Error]
+
+      dynamicallyRegisteredCount == 2
+
+      containersStartedCount == 3
+      containersSkippedCount == 0
+      containersAbortedCount == 0
+      containersSucceededCount == 3
+      containersFailedCount == 0
+
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 0
+      testsSucceededCount == 1
+      testsFailedCount == 2
+
+      totalStartedCount == 5
+      totalSkippedCount == 0
+      totalAbortedCount == 0
+      totalSucceededCount == 3
+      totalFailureCount == 2
+    }
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/UnrolledFeatureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/UnrolledFeatureMethods.groovy
@@ -45,7 +45,7 @@ def foo() {
     """)
 
     then:
-    result.testsSucceededCount == 3
+    result.testsSucceededCount == 4
     result.testsFailedCount == 0
     result.testsSkippedCount == 0
   }
@@ -63,7 +63,7 @@ def foo() {
     """
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == (0..2).collect {"foo [x: ${it + 1}, #$it]" }
+    result.testEvents().started().list().testDescriptor.displayName == ["foo"] + (0..2).collect {"foo [x: ${it + 1}, #$it]" }
   }
 
   def "a feature with an empty data provider causes the same error regardless if it's unrolled or not"() {
@@ -103,7 +103,7 @@ def foo() {
     then:
 
     result.testsSucceededCount == 0
-    result.testsFailedCount == 0
+    result.testsFailedCount == 1
     result.testsSkippedCount == 0
     result.containersStartedCount == 1 + 1 + 1 // engine + spec + unrolled feature
     result.containersFailedCount == 1
@@ -125,9 +125,10 @@ def foo() {
 
     then:
 
-    result.testEvents().started().list().testDescriptor.displayName == ["one a two 1 three",
-                                                                   "one b two 2 three",
-                                                                   "one c two 3 three"]
+    result.testEvents().started().list().testDescriptor.displayName == ["foo",
+                                                                        "one a two 1 three",
+                                                                        "one b two 2 three",
+                                                                        "one c two 3 three"]
   }
 
   def "naming pattern may refer to feature name and iteration index"() {
@@ -144,9 +145,10 @@ def foo() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["one foo two 0 three",
-                                                                   "one foo two 1 three",
-                                                                   "one foo two 2 three"]
+    result.testEvents().started().list().testDescriptor.displayName == ["foo",
+                                                                        "one foo two 0 three",
+                                                                        "one foo two 1 three",
+                                                                        "one foo two 2 three"]
   }
 
   @RestoreSystemProperties
@@ -167,7 +169,8 @@ def foo() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["foo[0]",
+    result.testEvents().started().list().testDescriptor.displayName == ["foo",
+                                                                        "foo[0]",
                                                                         "foo[1]",
                                                                         "foo[2]"]
   }
@@ -192,6 +195,7 @@ def foo() {
     then:
     result.testEvents().started().list().testDescriptor.displayName == ["foo",
                                                                         "foo",
+                                                                        "foo",
                                                                         "foo"]
   }
 
@@ -210,7 +214,8 @@ def foo() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["one 1 two null three"]
+    result.testEvents().started().list().testDescriptor.displayName == ["foo",
+                                                                        "one 1 two null three"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/353")
@@ -227,7 +232,8 @@ def foo() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["one fred two"]
+    result.testEvents().started().list().testDescriptor.displayName == ["foo",
+                                                                        "one fred two"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/353")
@@ -244,7 +250,8 @@ def foo() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["one 4 two"]
+    result.testEvents().started().list().testDescriptor.displayName == ["foo",
+                                                                        "one 4 two"]
   }
 
   def "expressions in naming pattern that can't be evaluated are prefixed with 'Error:'"() {
@@ -260,7 +267,8 @@ def foo() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["#Error:obj ok #Error:obj.bang() #Error:obj.missing() #Error:missing"]
+    result.testEvents().started().list().testDescriptor.displayName == ["foo",
+                                                                        "#Error:obj ok #Error:obj.bang() #Error:obj.missing() #Error:missing"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/353")
@@ -277,7 +285,8 @@ def "one #actor.details.name.size() two"() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["one 4 two"]
+    result.testEvents().started().list().testDescriptor.displayName == ["one #actor.details.name.size() two",
+                                                                        "one 4 two"]
   }
 
 
@@ -295,7 +304,8 @@ def "#actor.details.age"() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["fred"]
+    result.testEvents().started().list().testDescriptor.displayName == ["#actor.details.age",
+                                                                        "fred"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/354")
@@ -325,9 +335,11 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["fred",
-                                                                   "not data-driven",
-                                                                   "30"]
+    result.testEvents().started().list().testDescriptor.displayName == ["#actor.details.name",
+                                                                        "fred",
+                                                                        "not data-driven",
+                                                                        "#actor.details.age",
+                                                                        "30"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/354")
@@ -347,7 +359,8 @@ class Foo extends Specification {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["fred"]
+    result.testEvents().started().list().testDescriptor.displayName == ["method",
+                                                                        "fred"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/390")
@@ -364,7 +377,8 @@ def "an actor (named #actor.getName()) age #actor.getAge()"() {
     """)
 
     then:
-    result.testEvents().started().list().testDescriptor.displayName == ["an actor (named fred) age 30"]
+    result.testEvents().started().list().testDescriptor.displayName == ["an actor (named #actor.getName()) age #actor.getAge()",
+                                                                        "an actor (named fred) age 30"]
 
   }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/UprolledFeatureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/UprolledFeatureMethods.groovy
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.parameterization
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.InvalidSpecException
+import org.spockframework.runtime.SpockExecutionException
+
+class UprolledFeatureMethods extends EmbeddedSpecification {
+  def setup() {
+    runner.addClassImport(Actor)
+  }
+
+  def "iterations of an uprolled feature do not count as separate tests"() {
+    when:
+    def result = runner.runSpecBody("""
+@Rollup
+def foo() {
+  expect: true
+
+  where:
+  x << [1, 2, 3]
+}
+    """)
+
+    then:
+    result.testsStartedCount == 1
+    result.testsAbortedCount == 0
+    result.testsSucceededCount == 1
+    result.testsFailedCount == 0
+    result.testsSkippedCount == 0
+  }
+
+  def "a feature with an empty data provider causes the same error regardless if it's unrolled or not"() {
+    when:
+    runner.runSpecBody """
+$annotation
+def foo() {
+  expect: true
+
+  where:
+  x << []
+}
+    """
+
+    then:
+    SpockExecutionException e = thrown()
+
+    where:
+    annotation << ["", "@Rollup"]
+  }
+
+  def "can roll up a whole class at once"() {
+    when:
+    def result = runner.runWithImports("""
+@Rollup
+class Foo extends Specification {
+  def "#actor.details.name"() {
+    expect: true
+
+    where:
+    actor = new Actor()
+  }
+
+  def "not data-driven"() {
+    expect: true
+  }
+
+  def "#actor.details.age"() {
+    expect: true
+
+    where:
+    actor = new Actor()
+  }
+}
+    """)
+
+    then:
+    result.testEvents().started().list().testDescriptor.displayName == ["#actor.details.name",
+                                                                        "not data-driven",
+                                                                        "#actor.details.age"]
+  }
+
+  def "method-level uproll annotation wins over class-level unroll annotation"() {
+    when:
+    def result = runner.runWithImports("""
+@Unroll("#actor.details.name")
+class Foo extends Specification {
+  @Rollup
+  def method() {
+    expect: true
+
+    where:
+    actor = new Actor()
+  }
+}
+    """)
+
+    then:
+    result.testEvents().started().list().testDescriptor.displayName == ["method"]
+  }
+
+  def "unroll and uproll cannot be combined on the same spec"() {
+    when:
+    runner.runWithImports("""
+@Unroll("#actor.details.name")
+@Rollup
+class Foo extends Specification {
+  def method() {
+    expect: true
+
+    where:
+    actor = new Actor()
+  }
+}
+    """)
+
+    then:
+    thrown(InvalidSpecException)
+  }
+
+  def "unroll and uproll cannot be combined on the same feature"() {
+    when:
+    runner.runSpecBody("""
+@Unroll("#actor.details.name")
+@Rollup
+def method() {
+  expect: true
+
+  where:
+  actor = new Actor()
+}
+    """)
+
+    then:
+    thrown(InvalidSpecException)
+  }
+
+  def "method-level uproll annotation wins over configuration script"() {
+    given:
+    runner.configurationScript {
+      unroll {
+        enabledByDefault true
+      }
+    }
+
+    when:
+    def result = runner.runSpecBody("""
+@Rollup
+def method() {
+  expect: true
+
+  where:
+  actor = new Actor()
+}
+    """)
+
+    then:
+    result.testEvents().started().list().testDescriptor.displayName == ["method"]
+  }
+
+  def "class-level uproll annotation wins over configuration script"() {
+    given:
+    runner.configurationScript {
+      unroll {
+        enabledByDefault true
+      }
+    }
+
+    when:
+    def result = runner.runWithImports("""
+@Rollup
+class Foo extends Specification {
+  def method() {
+    expect: true
+
+    where:
+    actor = new Actor()
+  }
+}
+    """)
+
+    then:
+    result.testEvents().started().list().testDescriptor.displayName == ["method"]
+  }
+
+  static class Actor {
+    Map details = [name: "fred", age: 30]
+  }
+}

--- a/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
+++ b/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
@@ -47,7 +47,7 @@ class SpockHelloWorldTest {
   @Test
   void packageSelectorsAreResolved() {
     assertEquals(7, execute(selectPackage(ExampleTestCase.class.getPackage().getName()))
-      .containers()
+      .containerEvents()
       .filter(event -> event.getType() == EventType.STARTED)
       .filter(event -> "spec".equals(event.getTestDescriptor().getUniqueId().getLastSegment().getType()))
       .count());
@@ -55,7 +55,7 @@ class SpockHelloWorldTest {
 
   @Test
   void verifyUnrollExample() {
-    execute(selectClass(UnrollTestCase.class), stats -> stats.started(16).succeeded(16));
+    execute(selectClass(UnrollTestCase.class), stats -> stats.started(13).succeeded(13));
   }
 
   @Test

--- a/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
+++ b/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
@@ -55,7 +55,7 @@ class SpockHelloWorldTest {
 
   @Test
   void verifyUnrollExample() {
-    execute(selectClass(UnrollTestCase.class), stats -> stats.started(12).succeeded(12));
+    execute(selectClass(UnrollTestCase.class), stats -> stats.started(16).succeeded(16));
   }
 
   @Test

--- a/spock-testkit/src/test/groovy/spock/testkit/testsources/UnrollTestCase.groovy
+++ b/spock-testkit/src/test/groovy/spock/testkit/testsources/UnrollTestCase.groovy
@@ -4,7 +4,6 @@ import spock.lang.*
 
 class UnrollTestCase extends Specification {
 
-  @Unroll
   def "unrollMe"() {
     expect:
     Math.max(a, b) == c
@@ -27,10 +26,8 @@ class UnrollTestCase extends Specification {
     1 | 2 | 2
     2 | 2 | 2
     3 | 2 | 3
-
   }
 
-  @Unroll
   def "Unroll #a #b == #c"() {
     expect:
     Math.max(a, b) == c
@@ -42,7 +39,7 @@ class UnrollTestCase extends Specification {
     3 | 2 | 3
   }
 
-
+  @Rollup
   def "noExtraReporting"() {
     expect:
     Math.max(a, b) == c


### PR DESCRIPTION
Here a first draft of the finished default unrolling and explicit rolling.
Draft because of the hacky reflection listener manipulation that works around the missing junit-team/junit5#2188 implementation.

Besides that, this PR is already reviewable and it actually works fine, but only look at the last commit.
The others are just my other two PRs merged together as parent, as otherwise there would be too many conflicts for no headache. :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1101)
<!-- Reviewable:end -->
