### PR TITLE
Do not prune ErrorSpecNodes

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
@@ -14,6 +14,16 @@ public class ErrorSpecNode extends SpecNode {
   }
 
   @Override
+  public void prune() {
+    // prevent pruning of this node
+    // default logic would prune it as it
+    // - is no test,
+    // - has no test descendents and
+    // - may not register new tests during execution
+    // without this empty override, the node is thrown away and the error is not reported
+  }
+
+  @Override
   public SpockExecutionContext execute(SpockExecutionContext context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
     return ExceptionUtil.sneakyThrow(error);
   }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/ErrorSpecNodeSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/ErrorSpecNodeSpec.groovy
@@ -1,0 +1,23 @@
+package org.spockframework.runtime
+
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.UniqueId
+import spock.lang.Specification
+
+class ErrorSpecNodeSpec extends Specification {
+  def 'should not be pruned'() {
+    given:
+    TestDescriptor parent = Mock()
+    def testee = new ErrorSpecNode(
+      UniqueId.forEngine("test"),
+      new SpecInfoBuilder(getClass()).build(),
+      null)
+    testee.setParent(parent)
+
+    when:
+    testee.prune()
+
+    then:
+    0 * parent.removeChild(*_)
+  }
+}

--- a/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
+++ b/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
@@ -1,5 +1,11 @@
 package spock.platform;
 
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.core.LauncherConfig;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.spockframework.runtime.SpockEngine;
 import spock.testkit.testsources.*;
 
 import java.util.function.Consumer;
@@ -40,7 +46,7 @@ class SpockHelloWorldTest {
 
   @Test
   void packageSelectorsAreResolved() {
-    assertEquals(6, execute(selectPackage(ExampleTestCase.class.getPackage().getName()))
+    assertEquals(7, execute(selectPackage(ExampleTestCase.class.getPackage().getName()))
       .containers()
       .filter(event -> event.getType() == EventType.STARTED)
       .filter(event -> "spec".equals(event.getTestDescriptor().getUniqueId().getLastSegment().getType()))
@@ -54,6 +60,21 @@ class SpockHelloWorldTest {
 
   @Test
   void verifyStepwiseExample() {
+    execute(selectClass(StepwiseTestCase.class), stats -> stats.started(4).succeeded(3).failed(1).skipped(1));
+  }
+
+  @Test
+  void verifyErrorExample() {
+    Launcher launcher = LauncherFactory.create(LauncherConfig.builder()
+      .enableTestEngineAutoRegistration(false)
+      .enableTestExecutionListenerAutoRegistration(false)
+      .addTestEngines(new SpockEngine())
+      .build());
+    TestPlan testPlan = launcher.discover(LauncherDiscoveryRequestBuilder.request()
+      .selectors(selectClass(ErrorTestCase.class))
+      .build());
+    assertEquals(1, testPlan.getChildren(testPlan.getRoots().iterator().next()).size());
+
     execute(selectClass(StepwiseTestCase.class), stats -> stats.started(4).succeeded(3).failed(1).skipped(1));
   }
 

--- a/spock-testkit/src/test/groovy/spock/testkit/testsources/ErrorTestCase.groovy
+++ b/spock-testkit/src/test/groovy/spock/testkit/testsources/ErrorTestCase.groovy
@@ -1,0 +1,11 @@
+package spock.testkit.testsources
+
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+class ErrorTestCase extends Specification {
+  @IgnoreIf({ b })
+  def "error gets reported properly"() {
+    expect: true
+  }
+}


### PR DESCRIPTION
As the `ErrorSpecNode` is neither of type `TEST` or `CONTAINER_AND_TEST` and
does not have test descendents, the default prune algorithm throws it away.

That means, that the whole spec is simply ignored if there was an error, like
when having an exception in an `@IgnoreIf` closure.

When running all tests, the spec simply does not occur, when running the spec or
a feature in the spec that contains the exception you get "no tests found", no
matter whether you run through IntelliJ runner or through Gradle.

By overwriting the `prune()` method with an empty one, the pruning is disabled
for this node as also documented in its JavaDoc and the error will be reported
properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1102)
<!-- Reviewable:end -->
