### PR TITLE
Remove requirement to have data-driven method arguments in the same order as in the where block (#651)

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -812,9 +812,9 @@ When using data driven features (methods with a `where:` block), the user of you
 restrictions, if parameters should be injected by your extension:
 
 * all data variables and all to-be-injected parameters have to be defined as method parameters
-* all method parameters have to be assigned a value in the `where:` block
-* the order of the method parameters has to be identical to the order of the data variables in the `where:` block
-* the to-be-injected parameters have to be set to any value in the `where:` block, for example `null`
+* all method parameters have to be assigned a value in the `where:` block, for example `null`
+* *pre Spock 2.0:* the order of the method parameters has to be identical to the order of the data
+  variables in the `where:` block
 +
 of course you can also make your extension only inject a value if none is set already, as the `where:` block
 assignments happen before the method interceptor is called

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -122,6 +122,9 @@ Spy(constructorArgs: [null as String, (Pattern) null])
 - Accessing previous data table columns was broken in some cases, now it should work properly,
   even cross-table and without being disturbed by previous derived data variables.
 
+- The order of parameters in a data-driven feature does no longer have to be identical to
+  the declaration order in the `where` block. Data variables are now injected by name.
+
 == 2.0-M2 (2020-02-10)
 
 === Groovy-3.0 Support

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -60,6 +60,14 @@ b = a
 ----
 // end::no-access-to-data-variables-in-data-pipes[]
 
+==== For extension developers
+
+- `FeatureInfo#getDataVariables()` and `FeatureInfo#getParameterNames()` used to return the
+  same value, the parameter names, in the order of the method parameters. This can disturb some calculations like method
+  argument determination and so on and is plainly wrong, as some parameters could be injected by extensions like
+  injecting mock objects or test proxies or similar. `FeatureInfo#getDataVariables()` now only returns the actual data
+  variables and in the order how they are defined in the `where` block.
+
 === Misc
 
 - Upgrade JUnit 4 to 4.13

--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -72,6 +72,7 @@ public class AstNodeCache {
   public final ClassNode FieldMetadata = ClassHelper.makeWithoutCaching(FieldMetadata.class);
   public final ClassNode FeatureMetadata = ClassHelper.makeWithoutCaching(FeatureMetadata.class);
   public final ClassNode DataProviderMetadata = ClassHelper.makeWithoutCaching(DataProviderMetadata.class);
+  public final ClassNode DataProcessorMetadata = ClassHelper.makeWithoutCaching(DataProcessorMetadata.class);
   public final ClassNode BlockMetadata = ClassHelper.makeWithoutCaching(BlockMetadata.class);
   public final ClassNode BlockKind = ClassHelper.makeWithoutCaching(BlockKind.class);
 

--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -638,13 +638,14 @@ public class WhereBlockRewriter {
     AnnotationNode ann = new AnnotationNode(resources.getAstNodeCache().DataProcessorMetadata);
     ann.addMember(
       DataProcessorMetadata.DATA_VARIABLES,
-      new ListExpression(
-        dataProcessorVars
-          .stream()
-          .map(VariableExpression::getName)
-          .map(ConstantExpression::new)
-          .collect(toList())
-      ));
+      dataProcessorVars
+        .stream()
+        .map(VariableExpression::getName)
+        .map(ConstantExpression::new)
+        .collect(collectingAndThen(
+          Collectors.<Expression>toList(),
+          ListExpression::new))
+      );
     return ann;
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
@@ -151,6 +151,12 @@ public class SpecInfoBuilder {
 
     if (dataProcessorMethod != null) {
       feature.setDataProcessorMethod(dataProcessorMethod);
+
+      DataProcessorMetadata dataProcessorMetadata = dataProcessorMethod.getAnnotation(DataProcessorMetadata.class);
+      for (String dataVariable : dataProcessorMetadata.dataVariables()) {
+        feature.addDataVariable(dataVariable);
+      }
+
       int providerCount = 0;
       String providerMethodName = InternalIdentifiers.getDataProviderName(method.getName(), providerCount++);
       MethodInfo providerMethod = createMethod(providerMethodName, MethodKind.DATA_PROVIDER);

--- a/spock-core/src/main/java/org/spockframework/runtime/model/DataProcessorMetadata.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/DataProcessorMetadata.java
@@ -1,0 +1,20 @@
+package org.spockframework.runtime.model;
+
+import org.spockframework.util.Beta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @since 2.0
+ */
+@Beta
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DataProcessorMetadata {
+  String DATA_VARIABLES = "dataVariables";
+
+  String[] dataVariables();
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -14,6 +14,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   private int executionOrder;   // per spec inheritance chain
 
   private List<String> parameterNames = new ArrayList<>();
+  private List<String> dataVariables = new ArrayList<>();
   private final List<BlockInfo> blocks = new ArrayList<>();
   private final List<IMethodInterceptor> iterationInterceptors = new ArrayList<>();
 
@@ -58,7 +59,11 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   }
 
   public List<String> getDataVariables() {
-    return parameterNames; // currently the same
+    return dataVariables;
+  }
+
+  public void addDataVariable(String dataVariable) {
+    dataVariables.add(dataVariable);
   }
 
   public List<BlockInfo> getBlocks() {
@@ -99,6 +104,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
 
   public void addDataProvider(DataProviderInfo dataProvider) {
     dataProviders.add(dataProvider);
+
   }
 
   public boolean isParameterized() {

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureMetadata.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureMetadata.java
@@ -29,12 +29,14 @@ public @interface FeatureMetadata {
   String NAME = "name";
   String ORDINAL = "ordinal";
   String LINE = "line";
+  String DATA_VARIABLE_NAMES = "dataVariableNames";
   String PARAMETER_NAMES = "parameterNames";
   String BLOCKS = "blocks";
 
   int ordinal();
   String name();
   int line();
+  String[] dataVariableNames();
   String[] parameterNames();
   BlockMetadata[] blocks();
 }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/extension/builtin/UnrollIterationNameProviderSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/extension/builtin/UnrollIterationNameProviderSpec.groovy
@@ -24,7 +24,7 @@ class UnrollIterationNameProviderSpec extends Specification {
   def "regex-like data values are substituted correctly (i.e. literally)"() {
     given:
     def feature = new FeatureInfo()
-    feature.addParameterName("dataVar")
+    feature.addDataVariable("dataVar")
     def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVar bar")
 
     expect:
@@ -39,7 +39,7 @@ class UnrollIterationNameProviderSpec extends Specification {
   def "data values are converted to strings in Groovy style"() {
     given:
     def feature = new FeatureInfo()
-    feature.addParameterName("dataVar")
+    feature.addDataVariable("dataVar")
     def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVar bar")
 
     expect:
@@ -54,7 +54,7 @@ class UnrollIterationNameProviderSpec extends Specification {
   def "missing variables are rendered as #Error:dataVars"() {
     given:
     def feature = new FeatureInfo()
-    feature.addParameterName("dataVar")
+    feature.addDataVariable("dataVar")
     def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVars bar")
 
     expect:
@@ -64,7 +64,7 @@ class UnrollIterationNameProviderSpec extends Specification {
   def "exceptions during variable eval are rendered as #Error:dataVars"() {
     given:
     def feature = new FeatureInfo()
-    feature.addParameterName("dataVar")
+    feature.addDataVariable("dataVar")
     def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVar.foo bar")
 
     expect:
@@ -77,7 +77,7 @@ class UnrollIterationNameProviderSpec extends Specification {
     given:
     System.setProperty('spock.assertUnrollExpressions', 'true')
     def feature = new FeatureInfo()
-    feature.addParameterName("dataVar")
+    feature.addDataVariable("dataVar")
     def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVars bar")
 
     when:
@@ -95,7 +95,7 @@ class UnrollIterationNameProviderSpec extends Specification {
     given:
     def feature = new FeatureInfo()
     System.setProperty('spock.assertUnrollExpressions', 'true')
-    feature.addParameterName("dataVar")
+    feature.addDataVariable("dataVar")
     def nameGenerator = new UnrollIterationNameProvider(feature, "foo #dataVar.foo bar")
 
     when:

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -19,6 +19,7 @@ package org.spockframework.smoke.parameterization
 import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.compiler.InvalidSpecCompileException
+import spock.lang.Issue
 
 /**
  * @author Peter Niederwieser
@@ -68,7 +69,7 @@ class MethodParameters extends EmbeddedSpecification {
     x << [1, 2]
     y << [1, 2]
   }
-  
+
   def "fewer parameters than data variables"() {
     when:
     compiler.compileSpecBody """
@@ -86,7 +87,6 @@ def foo(x) {
     thrown(InvalidSpecCompileException)
   }
 
-
   def "more parameters than data variables"() {
     when:
     compiler.compileSpecBody """
@@ -103,6 +103,7 @@ def foo(x, y, z) {
     then:
     thrown(InvalidSpecCompileException)
   }
+
 
   def "parameter that is not a data variable"() {
     when:
@@ -167,5 +168,15 @@ def foo(x, ClassLoader y) {
 
     then:
     thrown(GroovyCastException)
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/651")
+  def "data values are injected by name, not order"(y, x) {
+    expect:
+    2 * x == y
+
+    where:
+    x << [1, 2]
+    y << [2, 4]
   }
 }


### PR DESCRIPTION
- Do not fail data provider calling due to different order between data variables and method parameters (#651)
- Inject data variables by name, instead of order and have the correct argument array length initially (#651)

Fixes #651

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1105)
<!-- Reviewable:end -->
