### PR TITLE
Upgrade to JUnit 5.6.1 and 4.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
     cglib: "cglib:cglib-nodep:3.2.10",
     groovy: groovyDependencies,
     h2database: "com.h2database:h2:1.3.176",
-    junit4: "junit:junit:4.12",
+    junit4: "junit:junit:4.13",
     junitBom: "org.junit:junit-bom:5.5.2",
     jupiter: "org.junit.jupiter:junit-jupiter",
     junitPlatform: "org.junit.platform:junit-platform-engine",

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ ext {
     groovy: groovyDependencies,
     h2database: "com.h2database:h2:1.3.176",
     junit4: "junit:junit:4.13",
-    junitBom: "org.junit:junit-bom:5.5.2",
+    junitBom: "org.junit:junit-bom:5.6.1",
     jupiter: "org.junit.jupiter:junit-jupiter",
     junitPlatform: "org.junit.platform:junit-platform-engine",
     junitPlatformTestkit: "org.junit.platform:junit-platform-testkit",

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -17,6 +17,14 @@ With the new behavior, you can have a `Mock` or `Spy` return the same value as a
 subscriber.receive(_) >> _
 ----
 
+==== Upgrade to JUnit 5.6 (and JUnit Platform 1.6)
+
+JUnit Plafform 1.6 (https://junit.org/junit5/docs/5.6.0/release-notes/index.html#deprecations-and-breaking-changes[deprecated]) methods (from experimental API)  in `EngineExecutionResults` that Spock was using. To keep runtime compatibility with JUnit 5.6 and incoming 5.7 the implementation has been switched to the new methods. As a result, Spock 2.0-M3 cannot work with JUnit 5.5 and lower. The problem might only occur if a project overrides default JUnit Platform version provided by Spock.
+
+=== Misc
+
+- Upgrade JUnit 4 to 4.13
+
 == 2.0-M2 (2020-02-10)
 
 === Groovy-3.0 Support

--- a/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
+++ b/spock-core/src/main/groovy/spock/util/EmbeddedSpecRunner.groovy
@@ -139,7 +139,7 @@ class EmbeddedSpecRunner {
       .selectors(*selectors)
       .execute()
     if (throwFailure) {
-      def first = executionResults.all().executions().failed().stream().findFirst()
+      def first = executionResults.allEvents().executions().failed().stream().findFirst()
       if (first.present) {
         throw first.get().terminationInfo.executionResult.throwable.get()
       }
@@ -148,7 +148,7 @@ class EmbeddedSpecRunner {
   }
 
   static class SummarizedEngineExecutionResults implements TestExecutionSummary {
-    @Delegate(deprecated = true) // enable deprecated delegation https://github.com/spockframework/spock/issues/1073
+    @Delegate
     private final EngineExecutionResults results
 
     SummarizedEngineExecutionResults(EngineExecutionResults results) {
@@ -157,34 +157,34 @@ class EmbeddedSpecRunner {
 
     @Deprecated
     int getFailureCount() {
-      return results.tests().failed().count()
+      return results.testEvents().failed().count()
     }
 
     @Deprecated
     int getRunCount() {
-      return results.tests().started().count()
+      return results.testEvents().started().count()
     }
 
     @Deprecated
     int getIgnoreCount() {
-      return results.tests().skipped().count()
+      return results.testEvents().skipped().count()
     }
 
     @Override
     long getTimeStarted() {
-      return results.all().started().stream().findFirst().map{it.timestamp.toEpochMilli()}.orElseGet {0}
+      return results.allEvents().started().stream().findFirst().map{it.timestamp.toEpochMilli()}.orElseGet {0}
     }
 
     @Override
     long getTimeFinished() {
-      return results.all().finished().stream()
+      return results.allEvents().finished().stream()
         .reduce{first, second -> second} // fancy for .last()
         .map{it.timestamp.toEpochMilli()}.orElseGet {0}
     }
 
     @Override
     long getTotalFailureCount() {
-      return results.all().failed().count()
+      return results.allEvents().failed().count()
     }
 
     @Override
@@ -194,27 +194,27 @@ class EmbeddedSpecRunner {
 
     @Override
     long getContainersStartedCount() {
-      return results.containers().started().count()
+      return results.containerEvents().started().count()
     }
 
     @Override
     long getContainersSkippedCount() {
-      return results.containers().skipped().count()
+      return results.containerEvents().skipped().count()
     }
 
     @Override
     long getContainersAbortedCount() {
-      return results.containers().aborted().count()
+      return results.containerEvents().aborted().count()
     }
 
     @Override
     long getContainersSucceededCount() {
-      return results.containers().succeeded().count()
+      return results.containerEvents().succeeded().count()
     }
 
     @Override
     long getContainersFailedCount() {
-      return results.containers().failed().count()
+      return results.containerEvents().failed().count()
     }
 
     @Override
@@ -224,27 +224,27 @@ class EmbeddedSpecRunner {
 
     @Override
     long getTestsStartedCount() {
-      return results.tests().started().count()
+      return results.testEvents().started().count()
     }
 
     @Override
     long getTestsSkippedCount() {
-      return results.tests().skipped().count()
+      return results.testEvents().skipped().count()
     }
 
     @Override
     long getTestsAbortedCount() {
-      return results.tests().aborted().count()
+      return results.testEvents().aborted().count()
     }
 
     @Override
     long getTestsSucceededCount() {
-      return results.tests().succeeded().count()
+      return results.testEvents().succeeded().count()
     }
 
     @Override
     long getTestsFailedCount() {
-      return results.tests().failed().count()
+      return results.testEvents().failed().count()
     }
 
     @Override
@@ -259,7 +259,7 @@ class EmbeddedSpecRunner {
 
     @Override
     List<Failure> getFailures() {
-      return results.all().executions().failed()
+      return results.allEvents().executions().failed()
         .map{ it.terminationInfo.executionResult.throwable.get()}
         .map {new XFailure(it)}
         .collect(Collectors.toList())

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/FeatureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/FeatureMethods.groovy
@@ -46,8 +46,8 @@ def "original name"() { expect: true }
     """)
 
     then:
-    result.tests().started().list() [0].testDescriptor.displayName == "original name"
-    result.tests().finished().list() [0].testDescriptor.displayName == "original name"
+    result.testEvents().started().list() [0].testDescriptor.displayName == "original name"
+    result.testEvents().finished().list() [0].testDescriptor.displayName == "original name"
   }
 
   def "can.have?names#con/tain!ing~any`char(act \\ers?!"() {
@@ -64,8 +64,8 @@ def "can.have?names#con/tain!ing~any`char(act \\\\ers?!"() { expect: true }
 
     then:
 
-    result.tests().started().list() [0].testDescriptor.displayName == "can.have?names#con/tain!ing~any`char(act \\ers?!"
-    result.tests().finished().list() [0].testDescriptor.displayName == "can.have?names#con/tain!ing~any`char(act \\ers?!"
+    result.testEvents().started().list() [0].testDescriptor.displayName == "can.have?names#con/tain!ing~any`char(act \\ers?!"
+    result.testEvents().finished().list() [0].testDescriptor.displayName == "can.have?names#con/tain!ing~any`char(act \\ers?!"
   }
 
   def featureMethod() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/PendingFeatureExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/PendingFeatureExtensionSpec.groovy
@@ -45,7 +45,7 @@ class Foo extends Specification {
     result.testsFailedCount == 0
     result.testsSkippedCount == 0
     result.testsAbortedCount == 1
-    result.tests().aborted().assertEventsMatchExactly(abortedWithReason(message("Feature not yet implemented correctly. Reason: 42")))
+    result.testEvents().aborted().assertEventsMatchExactly(abortedWithReason(message("Feature not yet implemented correctly. Reason: 42")))
   }
 
   def "@PendingFeature marks feature that fails with exception as skipped"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
@@ -32,7 +32,7 @@ class RequiresExtension extends EmbeddedSpecification {
     results.testsSucceededCount == 5
     results.testsFailedCount == 0
     results.testsSkippedCount == 2
-    results.tests().skipped().list().testDescriptor.displayName == [
+    results.testEvents().skipped().list().testDescriptor.displayName == [
       "skips feature if precondition is not satisfied", "allows determinate use of multiple filters"]
   }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -265,16 +265,16 @@ local | 1
       @Unroll def 'a = #a, b = #b'() {
         expect:
         true
-        
+
         where:
         a | b
         0 | a + 1
-        2 | a 
+        2 | a
       }
     '''
 
     then:
-    result.tests().finished().list().testDescriptor.displayName == ["a = 0, b = 1", "a = 2, b = 2" ]
+    result.testEvents().finished().list().testDescriptor.displayName == ["a = 0, b = 1", "a = 2, b = 2" ]
   }
 
   def "cells can't reference next cells"() {
@@ -282,7 +282,7 @@ local | 1
     runner.runFeatureBody '''
       expect:
       false
-      
+
       where:
       a | b
       b | 1
@@ -297,7 +297,7 @@ local | 1
     runner.runFeatureBody '''
       expect:
       false
-      
+
       where:
       a | b
       1 | b + 1
@@ -335,21 +335,21 @@ local | 1
     runner.runFeatureBody '''
       expect:
       g == 12
-  
+
       where:
       a = 1
       b = a + 1
-      
+
       c << [b + 1]
-      
+
       d = c + 1
-      
+
       e         | f
       b + c + d | e + 1
-      
+
       g << [f + 1]
-      
-      h = g + 1       
+
+      h = g + 1
     '''
   }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/UnrolledFeatureMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/UnrolledFeatureMethods.groovy
@@ -62,7 +62,7 @@ def foo() {
     """
 
     then:
-    result.tests().started().list().testDescriptor.displayName == (0..2).collect {"foo[${it}]" }
+    result.testEvents().started().list().testDescriptor.displayName == (0..2).collect {"foo[${it}]" }
   }
 
   def "a feature with an empty data provider causes the same error regardless if it's unrolled or not"() {
@@ -106,7 +106,7 @@ def foo() {
     result.testsSkippedCount == 0
     result.containersStartedCount == 1 + 1 + 1 // engine + spec + unrolled feature
     result.containersFailedCount == 1
-    result.containers().failed().list().testDescriptor.displayName == ["foo"]
+    result.containerEvents().failed().list().testDescriptor.displayName == ["foo"]
   }
 
   def "naming pattern may refer to data variables"() {
@@ -124,7 +124,7 @@ def foo() {
 
     then:
 
-    result.tests().started().list().testDescriptor.displayName == ["one a two 1 three",
+    result.testEvents().started().list().testDescriptor.displayName == ["one a two 1 three",
                                                                    "one b two 2 three",
                                                                    "one c two 3 three"]
   }
@@ -143,7 +143,7 @@ def foo() {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["one foo two 0 three",
+    result.testEvents().started().list().testDescriptor.displayName == ["one foo two 0 three",
                                                                    "one foo two 1 three",
                                                                    "one foo two 2 three"]
   }
@@ -163,7 +163,7 @@ def foo() {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["one 1 two null three"]
+    result.testEvents().started().list().testDescriptor.displayName == ["one 1 two null three"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/353")
@@ -180,7 +180,7 @@ def foo() {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["one fred two"]
+    result.testEvents().started().list().testDescriptor.displayName == ["one fred two"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/353")
@@ -197,7 +197,7 @@ def foo() {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["one 4 two"]
+    result.testEvents().started().list().testDescriptor.displayName == ["one 4 two"]
   }
 
   def "expressions in naming pattern that can't be evaluated are prefixed with 'Error:'"() {
@@ -213,7 +213,7 @@ def foo() {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["#Error:obj ok #Error:obj.bang() #Error:obj.missing() #Error:missing"]
+    result.testEvents().started().list().testDescriptor.displayName == ["#Error:obj ok #Error:obj.bang() #Error:obj.missing() #Error:missing"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/353")
@@ -230,7 +230,7 @@ def "one #actor.details.name.size() two"() {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["one 4 two"]
+    result.testEvents().started().list().testDescriptor.displayName == ["one 4 two"]
   }
 
 
@@ -248,7 +248,7 @@ def "#actor.details.age"() {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["fred"]
+    result.testEvents().started().list().testDescriptor.displayName == ["fred"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/354")
@@ -278,7 +278,7 @@ class Foo extends Specification {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["fred",
+    result.testEvents().started().list().testDescriptor.displayName == ["fred",
                                                                    "not data-driven",
                                                                    "30"]
   }
@@ -300,7 +300,7 @@ class Foo extends Specification {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["fred"]
+    result.testEvents().started().list().testDescriptor.displayName == ["fred"]
   }
 
   @Issue("https://github.com/spockframework/spock/issues/390")
@@ -317,7 +317,7 @@ def "an actor (named #actor.getName()) age #actor.getAge()"() {
     """)
 
     then:
-    result.tests().started().list().testDescriptor.displayName == ["an actor (named fred) age 30"]
+    result.testEvents().started().list().testDescriptor.displayName == ["an actor (named fred) age 30"]
 
   }
 

--- a/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
+++ b/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
@@ -67,7 +67,7 @@ class SpockHelloWorldTest {
 
   private void execute(DiscoverySelector selector, Consumer<EventStatistics> statisticsConsumer) {
     execute(selector)
-      .tests()
+      .testEvents()
       .debug()
       .assertStatistics(statisticsConsumer);
   }


### PR DESCRIPTION
This replaces workaround in M2 for JUnit 5.6 compatibility (fixes #1073). As a side effect Spock will no longer be compatible with JUnit 5.5 (but it is better to be compatible with incoming 5.7).

Some tests in the @Vampire changes with unrolling could be affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1107)
<!-- Reviewable:end -->
