### PR TITLE
Switch maxGroovyVersion to 4.x for snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
   groovyConsoleExtraDependencies = [
     "org.codehaus.groovy:groovy-console:${groovyVersion}"
   ]
-  maxGroovyVersion = snapshotVersion ? "3.9.99" : maxGroovyVersion
+  maxGroovyVersion = snapshotVersion ? "9.9.99" : maxGroovyVersion
   if (System.getProperty("groovyVersion")) {
     groovyVersion = System.getProperty("groovyVersion")
   }


### PR DESCRIPTION
To do not prevent people from playing with Groovy 4.x when alpha is released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1108)
<!-- Reviewable:end -->
