### PR TITLE
Reduce number of Groovy dependencies to just groovy.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,6 @@ ext {
   javaVersions = [1.8, 11] // ensure that latest version is actually build on travis, otherwise no docs get published
   javaVersion = System.getProperty("java.specification.version") as BigDecimal
 
-  if (javaVersion >= 9) {
-    groovyDependencies += ["javax.xml.bind:jaxb-api:2.3.0"]
-  }
-
   libs = [
     jetbrainsAnnotations: "org.jetbrains:annotations:13.0",
     ant: "org.apache.ant:ant:1.10.5",
@@ -68,7 +64,8 @@ ext {
     junitPlatformTestkit: "org.junit.platform:junit-platform-testkit",
     junitPlatformConsole: "org.junit.platform:junit-platform-console",
     log4j: "log4j:log4j:1.2.17",
-    objenesis: "org.objenesis:objenesis:3.0.1"
+    objenesis: "org.objenesis:objenesis:3.0.1",
+    jaxb: "javax.xml.bind:jaxb-api:2.3.0"
   ]
   Date buildTimeAndDate = new Date()
   buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)

--- a/build.gradle
+++ b/build.gradle
@@ -30,17 +30,14 @@ ext {
     throw new InvalidUserDataException("Unknown variant: $variant. Choose one of: $variants")
   }
 
-  groovyDependency = [
+  groovyDependencies = [
     "org.codehaus.groovy:groovy:${groovyVersion}",
-    "org.codehaus.groovy:groovy-json:${groovyVersion}",
-    "org.codehaus.groovy:groovy-nio:${groovyVersion}",
-    "org.codehaus.groovy:groovy-macro:${groovyVersion}",
-    "org.codehaus.groovy:groovy-templates:${groovyVersion}",
-    "org.codehaus.groovy:groovy-test:${groovyVersion}",
-    "org.codehaus.groovy:groovy-sql:${groovyVersion}",
-    "org.codehaus.groovy:groovy-xml:${groovyVersion}",
   ]
-  groovyConsoleExtraDependency = [
+  groovyTestDependencies = [
+    "org.codehaus.groovy:groovy-test:${groovyVersion}", //for @NotYetImplemented
+    "org.codehaus.groovy:groovy-sql:${groovyVersion}",  //for some Spring and Unitils tests
+  ]
+  groovyConsoleExtraDependencies = [
     "org.codehaus.groovy:groovy-console:${groovyVersion}"
   ]
   maxGroovyVersion = snapshotVersion ? "3.9.99" : maxGroovyVersion
@@ -53,7 +50,7 @@ ext {
   javaVersion = System.getProperty("java.specification.version") as BigDecimal
 
   if (javaVersion >= 9) {
-    groovyDependency += ["javax.xml.bind:jaxb-api:2.3.0"]
+    groovyDependencies += ["javax.xml.bind:jaxb-api:2.3.0"]
   }
 
   libs = [
@@ -62,7 +59,7 @@ ext {
     asm: "org.ow2.asm:asm:7.1",
     bytebuddy: "net.bytebuddy:byte-buddy:1.9.11",
     cglib: "cglib:cglib-nodep:3.2.10",
-    groovy: groovyDependency,
+    groovy: groovyDependencies,
     h2database: "com.h2database:h2:1.3.176",
     junit4: "junit:junit:4.12",
     junitBom: "org.junit:junit-bom:5.5.2",

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -29,7 +29,7 @@ dependencies {
     }
   }
 
-  coreConsoleRuntime groovyConsoleExtraDependency
+  coreConsoleRuntime groovyConsoleExtraDependencies
 }
 
 

--- a/spock-specs/specs.gradle
+++ b/spock-specs/specs.gradle
@@ -11,6 +11,8 @@ configurations {
 dependencies {
   testCompile project(":spock-core")
   testCompile project(":spock-junit4")
+  // for groovy.sql.Sql and groovy.transform.NotYetImplemented
+  testCompile groovyTestDependencies
 
   testRuntime libs.asm
   testRuntime libs.bytebuddy

--- a/spock-spring/boot-test/boot-test.gradle
+++ b/spock-spring/boot-test/boot-test.gradle
@@ -23,6 +23,10 @@ dependencies {
   testCompile project(":spock-core")
   testCompile project(":spock-spring")
 
+  if (javaVersion >= 9) {
+    testCompile libs.jaxb
+  }
+
   runtime "com.h2database:h2"
 
 }

--- a/spock-spring/boot2-test/boot2-test.gradle
+++ b/spock-spring/boot2-test/boot2-test.gradle
@@ -30,6 +30,10 @@ dependencies {
   testCompile project(":spock-core")
   testCompile project(":spock-spring")
 
+  if (javaVersion >= 9) {
+    testCompile libs.jaxb
+  }
+
   runtime "com.h2database:h2"
 
 }

--- a/spock-spring/spring.gradle
+++ b/spock-spring/spring.gradle
@@ -22,6 +22,8 @@ dependencies {
   testCompile "org.springframework:spring-jdbc:$springVersion"
   testCompile "org.springframework:spring-tx:$springVersion"
   testCompile "javax.inject:javax.inject:1"
+  // for groovy.sql.Sql
+  testCompile groovyTestDependencies
 
   testRuntime libs.h2database
   testRuntime libs.log4j

--- a/spock-unitils/unitils.gradle
+++ b/spock-unitils/unitils.gradle
@@ -19,6 +19,8 @@ dependencies {
   // otherwise we'll get:
   // java.lang.NoClassDefFoundError: junit/framework/AssertionFailedError
   testCompile libs.junit4
+  // for groovy.sql.Sql
+  testCompile groovyTestDependencies
 
   testRuntime libs.h2database
   testRuntime libs.log4j


### PR DESCRIPTION
Spock shouldn't provide the other to do not pollute the classpath.
It's common practice nowadays to exclude transitive dependencies,
which is not good as "spock-groovy2-compat" is needed with Groovy 2.

Proposed `realase notes` entry:
```
=== Breaking Changes

==== Reduce number of transitive Groovy dependencies to just groovy.jar

Spock started to provide only one Groovy dependency - `groovy.jar`. The others,
in the majority of cases were not needed in the end projects and were only polluting classpath
(or excluded explicitly). If other Groovy dependencies are needed in the project,
they have to be provided explicitly.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1109)
<!-- Reviewable:end -->
