### PR TITLE
Speed up local build greatly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,9 +67,16 @@ ext {
     objenesis: "org.objenesis:objenesis:3.0.1",
     jaxb: "javax.xml.bind:jaxb-api:2.3.0"
   ]
-  Date buildTimeAndDate = new Date()
-  buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
-  buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
+  if (snapshotVersion && System.env.CI != "true") {
+    //build time is not crucial for local SNAPSHOT builds, unless published from CI server
+    //speed up local development by leveraging Gradle caching mechanism
+    buildDate = "1970-01-01"
+    buildTime = "00:00:00.000Z"
+  } else {
+    Date buildTimeAndDate = new Date()
+    buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
+    buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
+  }
 }
 
 allprojects {


### PR DESCRIPTION
In some cases. `buildTime` used in all JARs' manifest caused all subprojects to be rebuilt and retested.

## Results (for Groovy 3):
### Before
```
$ gw clean check
...
BUILD SUCCESSFUL in 1m 20s
70 actionable tasks: 68 executed, 2 up-to-date
```
No changes:
```
$ gw check
...
BUILD SUCCESSFUL in 1m 15s
54 actionable tasks: 32 executed, 22 up-to-date
```
Change in spock-spec (all tests in that module are re-executed):
```
$ gw check
...
BUILD SUCCESSFUL in 1m 19s
54 actionable tasks: 32 executed, 22 up-to-date
```

### After
```
$ gw clean check
...
BUILD SUCCESSFUL in 1m 20s
70 actionable tasks: 68 executed, 2 up-to-date
```
No changes:
```
$ gw check
...
BUILD SUCCESSFUL in 1s
54 actionable tasks: 54 up-to-date
```
Change in spock-spec (all tests in that module are re-executed):
```
$ gw check
...
BUILD SUCCESSFUL in 39s
54 actionable tasks: 2 executed, 52 up-to-date
```

We may change the way how snapshot release build is detected. Currently it's only Travis, but I disabled this optimization for all CI (that set `CI` env var :-) ).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1110)
<!-- Reviewable:end -->
