### PR TITLE
Fix previous data table column access and block access from and to data pipes

### DIFF
--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -278,6 +278,38 @@ to other data variables:
 include::{sourcedir}/datadriven/DataSpec.groovy[tag=sql-data-variable-assignment]
 ----
 
+== Accessing Other Data Variables
+
+There are only two possibilities to access one data variable from the calculation
+of another data variable.
+
+The first possibility are derived data variables like shown in the last section.
+Every data variable that is defined by a direct assignment can access all
+previously defined data variables, including the ones defined through data
+tables or data pipes:
+
+[source,groovy,indent=0]
+----
+    ...
+include::{sourcedir}/datadriven/DataSpec.groovy[tag=data-variable-assignment]
+----
+
+The second possibility is to access previous columns within data tables:
+
+[source,groovy,indent=0]
+----
+    ...
+include::{sourcedir}/datadriven/DataSpec.groovy[tag=previous-column-access]
+----
+
+This also includes columns in previous data tables in the same `where` block:
+
+[source,groovy,indent=0]
+----
+    ...
+include::{sourcedir}/datadriven/DataSpec.groovy[tag=previous-column-access-multi-table]
+----
+
 == Combining Data Tables, Data Pipes, and Variable Assignments
 
 Data tables, data pipes, and variable assignments can be combined as needed:

--- a/docs/migration_guide.adoc
+++ b/docs/migration_guide.adoc
@@ -9,6 +9,8 @@ include::release_notes.adoc[tag=fancy-iteration-naming]
 
 include::release_notes.adoc[tag=renamed-iteration-count-token]
 
+include::release_notes.adoc[tag=no-access-to-data-variables-in-data-pipes]
+
 == 1.0
 
 Specs, Spec base classes and third-party extensions may have be recompiled in order to work with Spock 1.0.

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -29,6 +29,37 @@ If you use it somewhere, you have to manually change it to the new name
 or you will get an `#Error:iterationCount` rendering instead.
 // end::renamed-iteration-count-token[]
 
+// tag::no-access-to-data-variables-in-data-pipes[]
+==== No access to data variables in data pipes anymore
+
+It is not possible anymore to access any data variable from a data pipe or anything else but a previous data table
+column in a data table cell. This access was partly possible, but could easily prematurely drain iterators, access
+data providers sooner as expected, behaved differently depending on the concrete code construct used. All these
+points are more confusing than necessary. If you want to calculate a data variable from others, you can always use
+a derived data variable that has full access to all previous data variables and can also call helper methods for
+more complex logic.
+
+If you switch your tests that are fully green to use Spock 2.0 and get any ``MissingPropertyException``s, you are probably hitting this change, you should then change to a derived data variable there instead of a data pipe.
+
+If you for example had:
+
+[source,groovy]
+----
+where:
+a << [1, 2]
+b << a
+----
+
+what you want instead is
+
+[source,groovy]
+----
+where:
+a << [1, 2]
+b = a
+----
+// end::no-access-to-data-variables-in-data-pipes[]
+
 === Misc
 
 - Upgrade JUnit 4 to 4.13
@@ -79,6 +110,9 @@ a ; b ;; c
 ----
 Spy(constructorArgs: [null as String, (Pattern) null])
 ----
+
+- Accessing previous data table columns was broken in some cases, now it should work properly,
+  even cross-table and without being disturbed by previous derived data variables.
 
 == 2.0-M2 (2020-02-10)
 

--- a/spock-core/src/main/java/org/spockframework/compiler/AstUtil.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstUtil.java
@@ -37,7 +37,8 @@ import org.objectweb.asm.Opcodes;
  */
 public abstract class AstUtil {
   private static final Pattern DATA_TABLE_SEPARATOR = Pattern.compile("_{2,}+");
-  private static String GET_AT_METHOD_NAME = new IntegerArrayGetAtMetaMethod().getName();
+  private static final String GET_METHOD_NAME = "get";
+  private static final String GET_AT_METHOD_NAME = new IntegerArrayGetAtMetaMethod().getName();
 
   /**
    * Tells whether the given node has an annotation of the given type.
@@ -328,29 +329,15 @@ public abstract class AstUtil {
     return type == null || type == ClassHelper.DYNAMIC_TYPE ? ConstantExpression.NULL : new ClassExpression(type);
   }
 
-  public static void fixUpLocalVariables(Variable[] localVariables, VariableScope scope, boolean isClosureScope) {
-    fixUpLocalVariables(Arrays.asList(localVariables), scope, isClosureScope);
-  }
-
   public static MethodCallExpression createGetAtMethod(Expression expression, int index) {
     return new MethodCallExpression(expression,
                                     GET_AT_METHOD_NAME,
                                     new ConstantExpression(index));
   }
 
-  /**
-   * Fixes up scope references to variables that used to be free or class variables,
-   * and have been changed to local variables.
-   */
-  public static void fixUpLocalVariables(List<? extends Variable> localVariables, VariableScope scope, boolean isClosureScope) {
-    for (Variable localVar : localVariables) {
-      Variable scopeVar = scope.getReferencedClassVariable(localVar.getName());
-      if (scopeVar instanceof DynamicVariable) {
-        scope.removeReferencedClassVariable(localVar.getName());
-        scope.putReferencedLocalVariable(localVar);
-        if (isClosureScope)
-          localVar.setClosureSharedVariable(true);
-      }
-    }
+  public static MethodCallExpression createGetMethod(Expression expression, int index) {
+    return new MethodCallExpression(expression,
+                                    GET_METHOD_NAME,
+                                    new ConstantExpression(index));
   }
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
@@ -114,19 +114,8 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
 
   @Override
   protected void doVisitClosureExpression(ClosureExpression expr) {
-    if (resources.getCurrentMethod() instanceof FeatureMethod) {
-      AstUtil.fixUpLocalVariables(resources.getCurrentMethod().getAst().getParameters(), expr.getVariableScope(), true);
-    }
     super.doVisitClosureExpression(expr);
     if (conditionFound || groupConditionFound) defineRecorders(expr, groupConditionFound);
-  }
-
-  @Override
-  public void visitBlockStatement(BlockStatement stat) {
-    super.visitBlockStatement(stat);
-    if (resources.getCurrentMethod() instanceof FeatureMethod) {
-      AstUtil.fixUpLocalVariables(resources.getCurrentMethod().getAst().getParameters(), stat.getVariableScope(), false);
-    }
   }
 
   @Override
@@ -270,11 +259,6 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
     List<Expression> args = AstUtil.getArgumentList(expr);
     VariableExpression oldValue = resources.captureOldValue(args.get(0));
     args.set(0, oldValue);
-
-    if (currClosure != null) {
-      oldValue.setClosureSharedVariable(true);
-      currClosure.getVariableScope().putReferencedLocalVariable(oldValue);
-    }
 
     return true;
   }

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -421,8 +421,8 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     TryCatchStatement tryFinally =
         new TryCatchStatement(
-            new BlockStatement(featureStats, new VariableScope()),
-            new BlockStatement(cleanupStats, new VariableScope()));
+            new BlockStatement(featureStats, null),
+            new BlockStatement(cleanupStats, null));
     tryFinally.addCatch(featureCatchStat);
 
     method.getStatements().add(tryFinally);
@@ -455,7 +455,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     TryCatchStatement tryCatchStat =
         new TryCatchStatement(
-            new BlockStatement(cleanupStats, new VariableScope()),
+            new BlockStatement(cleanupStats, null),
             EmptyStatement.INSTANCE);
 
     tryCatchStat.addCatch(createHandleSuppressedThrowableStatement(featureThrowableVar));
@@ -477,7 +477,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
             Arrays.asList(
               new ExpressionStatement(assignThrowableExpr),
               new ThrowStatement(new VariableExpression(catchParameter))),
-            new VariableScope()));
+          null));
   }
 
   private CatchStatement createHandleSuppressedThrowableStatement(VariableExpression featureThrowableVar) {
@@ -495,13 +495,13 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
       Collections.<Statement>singletonList(new ThrowStatement(new VariableExpression(catchParameter)));
 
     IfStatement ifFeatureNotNullStat = new IfStatement(new BooleanExpression(featureThrowableNotNullExpr),
-      new BlockStatement(addSuppressedStats, new VariableScope()),
-      new BlockStatement(throwFeatureStats, new VariableScope()));
+      new BlockStatement(addSuppressedStats, null),
+      new BlockStatement(throwFeatureStats, null));
 
     return new CatchStatement(catchParameter,
       new BlockStatement(
         Collections.<Statement>singletonList(ifFeatureNotNullStat),
-        new VariableScope()));
+        null));
   }
 
   // IRewriteResources members
@@ -548,7 +548,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     stats.add(
       new TryCatchStatement(
-        new BlockStatement(allStats, new VariableScope()),
+        new BlockStatement(allStats, null),
         new ExpressionStatement(
           AstUtil.createDirectMethodCall(
             new VariableExpression(SpockNames.ERROR_COLLECTOR),
@@ -652,7 +652,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     TryCatchStatement tryCatchStat =
         new TryCatchStatement(
-            new BlockStatement(tryStats, new VariableScope()),
+            new BlockStatement(tryStats, null),
             new BlockStatement());
 
     blockStats.add(tryCatchStat);
@@ -665,7 +665,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
                 new ExpressionStatement(
                   setThrownException(
                     new VariableExpression(SpockNames.SPOCK_EX)))),
-                new VariableScope())));
+              null)));
   }
 
   /*

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -22,6 +22,8 @@ import java.util.*;
 
 import org.junit.platform.engine.support.hierarchical.Node;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * Adds the ability to run parameterized features.
  *
@@ -46,7 +48,6 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
       dynamicTestExecutor.awaitFinished();
     } finally {
       closeDataProviders(dataProviders);
-
     }
   }
 
@@ -56,44 +57,59 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
     }
 
     List<DataProviderInfo> dataProviderInfos = context.getCurrentFeature().getDataProviders();
+    if (dataProviderInfos.isEmpty()) {
+      return new Object[0];
+    }
+
+    List<String> dataProviderVariables = dataProviderInfos
+      .stream()
+      .map(DataProviderInfo::getDataVariables)
+      .flatMap(List::stream)
+      .collect(toList());
+
     Object[] dataProviders = new Object[dataProviderInfos.size()];
 
-    if (!dataProviderInfos.isEmpty()) {
-      for (int i = 0; i < dataProviderInfos.size(); i++) {
-        DataProviderInfo dataProviderInfo = dataProviderInfos.get(i);
+    for (int i = 0, size = dataProviderInfos.size(); i < size; i++) {
+      DataProviderInfo dataProviderInfo = dataProviderInfos.get(i);
+      MethodInfo method = dataProviderInfo.getDataProviderMethod();
 
-        MethodInfo method = dataProviderInfo.getDataProviderMethod();
-        Object[] arguments = Arrays.copyOf(dataProviders, getDataTableOffset(context, dataProviderInfo));
-        Object provider = invokeRaw(context, context.getCurrentInstance(), method, arguments);
+      Object provider = invokeRaw(
+        context, context.getCurrentInstance(), method,
+        getPreviousDataTableProviders(dataProviderVariables, dataProviders, dataProviderInfo));
 
-        if (context.getErrorInfoCollector().hasErrors()) {
-          return null;
-        } else if (provider == null && context.getErrorInfoCollector().isEmpty()) {
-          SpockExecutionException error = new SpockExecutionException("Data provider is null!");
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(method, error));
-          return null;
+      if (context.getErrorInfoCollector().hasErrors()) {
+        if (provider != null) {
+          dataProviders[i] = provider;
         }
-        dataProviders[i] = provider;
+        break;
+      } else if (provider == null) {
+        SpockExecutionException error = new SpockExecutionException("Data provider is null!");
+        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(method, error));
+        break;
       }
+
+      dataProviders[i] = provider;
     }
 
     return dataProviders;
   }
 
-  private int getDataTableOffset(SpockExecutionContext context, DataProviderInfo dataProviderInfo) {
-    int result = 0;
-    for (String variableName : dataProviderInfo.getDataVariables()) {
-      for (String parameterName : context.getCurrentFeature().getParameterNames()) {
-        if (variableName.equals(parameterName)) {
-          return result;
-        } else {
-          result++;
+  private Object[] getPreviousDataTableProviders(List<String> dataProviderVariables, Object[] dataProviders,
+                                                 DataProviderInfo dataProviderInfo) {
+    List<Object> result = new ArrayList<>();
+    previousDataTableVariablesLoop:
+    for (String previousDataTableVariable : dataProviderInfo.getPreviousDataTableVariables()) {
+      for (int i = 0, size = dataProviderVariables.size(); i < size; i++) {
+        String dataProviderVariable = dataProviderVariables.get(i);
+        if (previousDataTableVariable.equals(dataProviderVariable)) {
+          result.add(dataProviders[i]);
+          continue previousDataTableVariablesLoop;
         }
       }
+      throw new IllegalStateException(String.format("Variable name not defined (%s not in %s)!",
+        previousDataTableVariable, dataProviderVariables));
     }
-    throw new IllegalStateException(String.format("Variable name not defined (%s not in %s)!",
-      dataProviderInfo.getDataVariables(),
-      context.getCurrentFeature().getParameterNames()));
+    return result.toArray();
   }
 
   private Iterator[] createIterators(SpockExecutionContext context, Object[] dataProviders) {
@@ -121,7 +137,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
 
   // -1 => unknown
   private int estimateNumIterations(SpockExecutionContext context, Object[] dataProviders) {
-    if (context.getErrorInfoCollector().hasErrors() || dataProviders == null) {
+    if (context.getErrorInfoCollector().hasErrors()) {
       return -1;
     }
     if (dataProviders.length == 0) {

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
@@ -178,6 +178,7 @@ public class SpecInfoBuilder {
     provider.setParent(feature);
     provider.setLine(metadata.line());
     provider.setDataVariables(Arrays.asList(metadata.dataVariables()));
+    provider.setPreviousDataTableVariables(Arrays.asList(metadata.previousDataTableVariables()));
     provider.setDataProviderMethod(method);
     return provider;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/DataProviderInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/DataProviderInfo.java
@@ -10,6 +10,7 @@ import java.util.List;
  */
 public class DataProviderInfo extends NodeInfo<FeatureInfo, AnnotatedElement> {
   private List<String> dataVariables;
+  private List<String> previousDataTableVariables;
   private MethodInfo dataProviderMethod;
 
   @Override
@@ -23,6 +24,14 @@ public class DataProviderInfo extends NodeInfo<FeatureInfo, AnnotatedElement> {
 
   public void setDataVariables(List<String> dataVariables) {
     this.dataVariables = dataVariables;
+  }
+
+  public List<String> getPreviousDataTableVariables() {
+    return previousDataTableVariables;
+  }
+
+  public void setPreviousDataTableVariables(List<String> previousDataTableVariables) {
+    this.previousDataTableVariables = previousDataTableVariables;
   }
 
   public MethodInfo getDataProviderMethod() {

--- a/spock-core/src/main/java/org/spockframework/runtime/model/DataProviderMetadata.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/DataProviderMetadata.java
@@ -10,7 +10,9 @@ import java.lang.annotation.*;
 public @interface DataProviderMetadata {
   String LINE = "line";
   String DATA_VARIABLES = "dataVariables";
-  
+  String PREVIOUS_DATA_TABLE_VARIABLES = "previousDataTableVariables";
+
   int line();
   String[] dataVariables();
+  String[] previousDataTableVariables() default { };
 }

--- a/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/DataSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/DataSpec.groovy
@@ -137,8 +137,6 @@ class DataSpec extends Specification {
 
 // tag::sql-data-variable-assignment[]
     where:
-
-    where:
     row << sql.rows("select * from maxdata")
     // pick apart columns
     a = row.a
@@ -147,20 +145,56 @@ class DataSpec extends Specification {
 // end::sql-data-variable-assignment[]
   }
 
+  def "maximum of two numbers previous column access"() {
+    expect:
+    Math.max(a, b) == b
+
+// tag::previous-column-access[]
+    where:
+    a | b
+    3 | a + 1
+    7 | a + 2
+    0 | a + 3
+// end::previous-column-access[]
+  }
+
+  def "maximum of two numbers previous column access over multiple tables"() {
+    expect:
+    Math.max(a, b) == b
+    Math.max(d, e) == e
+
+// tag::previous-column-access-multi-table[]
+    where:
+    a | b
+    3 | a + 1
+    7 | a + 2
+    0 | a + 3
+
+    and:
+    c = 1
+
+    and:
+    d     | e
+    a * 2 | b * 2
+    a * 3 | b * 3
+    a * 4 | b * 4
+// end::previous-column-access-multi-table[]
+  }
+
   def "maximum of two numbers combined assignment"() {
     expect:
-    Math.max(a, b) == c
+    Math.max(a, c) == d
 
 // tag::combined-variable-assignment[]
     where:
-    a | _
-    1 | _
-    7 | _
-    0 | _
+    a | b
+    1 | a + 1
+    7 | a + 2
+    0 | a + 3
 
-    b << [3, 4, 0]
+    c << [3, 4, 0]
 
-    c = a > b ? a : b
+    d = a > c ? a : c
 // end::combined-variable-assignment[]
   }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -468,16 +468,6 @@ local ; 1
     thrown Exception
   }
 
-  def 'cell references are working with simple parameterization also'() {
-    expect:
-    c == 2
-
-    where:
-    a << [1, 2]
-    b << [3, 4]
-    c << [b - a, b - a]
-  }
-
   def 'data tables can be referenced from following variables'() {
     expect:
     c == 3
@@ -488,30 +478,6 @@ local ; 1
     1 | a + 1
 
     c = b + 1
-  }
-
-  @Ignore
-  def 'data table elements can reference each other'() {
-    expect:
-    runner.runFeatureBody '''
-      expect:
-      g == 12
-
-      where:
-      a = 1
-      b = a + 1
-
-      c << [b + 1]
-
-      d = c + 1
-
-      e         | f
-      b + c + d | e + 1
-
-      g << [f + 1]
-
-      h = g + 1
-    '''
   }
 
   def "rows must have same number of elements as header"() {
@@ -693,6 +659,65 @@ b | _
     then:
     SpockExecutionException see = thrown()
     see.message =~ 'fewer values than previous'
+  }
+
+  def "derived data variables do not break data table previous column references"() {
+    expect:
+    y == z
+
+    where:
+    x = 1
+
+    and:
+    y | z | a
+    1 | y | y + z
+    2 | y | y + z
+  }
+
+  def "data pipe variables do not break data table previous column references"() {
+    expect:
+    y == z
+
+    where:
+    x << [1, 2]
+
+    and:
+    y | z | a
+    3 | y | y + z
+    4 | y | y + z
+  }
+
+  def "data table previous column references work in closures"() {
+    expect:
+    x == y
+    z == 2 * x
+
+    where:
+    x | y       | z
+    1 | { x }() | x + y
+    2 | { x }() | x + y
+  }
+
+  def "data table previous column references work across data tables"() {
+    expect:
+    x == y
+    z == 2 * x
+    a == x
+    b == x
+    c == z
+
+    where:
+    x | y       | z
+    1 | x       | x + y
+    2 | { x }() | x + y
+
+    and:
+    f = 1
+
+    and:
+    a | b       | c
+    1 | { x }() | x + y
+    2 | { x }() | x + y
   }
 
   static class Person {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/InvalidWhereBlocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/InvalidWhereBlocks.groovy
@@ -149,4 +149,99 @@ def foo() {
     "[1, instanceField, 2]" |_
     "{ -> { -> [instanceField] }() }()" |_
   }
+
+  def 'referencing a data variable in a data provider is not allowed'() {
+    when:
+    runner.runFeatureBody """
+expect:
+true
+
+where:
+x << [1, 2].iterator()
+y << x
+"""
+
+    then:
+    thrown(MissingPropertyException)
+  }
+
+  def 'referencing a data variable in a closure in a data provider is not allowed'() {
+    when:
+    runner.runFeatureBody """
+expect:
+true
+
+where:
+x << [1, 2].iterator()
+y << { x }()
+"""
+
+    then:
+    thrown(MissingPropertyException)
+  }
+
+  def 'referencing a data table variable in a data table like data provider is not allowed'() {
+    when:
+    runner.runFeatureBody """
+expect:
+true
+
+where:
+a | b
+1 | 2
+3 | 4
+
+c << [a, 5]
+"""
+
+    then:
+    thrown(MissingPropertyException)
+  }
+
+  def 'referencing a data table parameter in a data table cell is not allowed'() {
+    when:
+    compiler.compileFeatureBody '''
+expect:
+true
+
+where:
+a | b
+1 | $spock_p_a
+'''
+
+    then:
+    thrown(InvalidSpecCompileException)
+  }
+
+  def 'referencing a data table parameter in a closure in a data table cell is not allowed'() {
+    when:
+    compiler.compileFeatureBody '''
+expect:
+true
+
+where:
+a | b
+1 | { $spock_p_a }()
+'''
+
+    then:
+    thrown(InvalidSpecCompileException)
+  }
+
+  def 'referencing a data table parameter in a data provider is not allowed'() {
+    when:
+    runner.runFeatureBody '''
+expect:
+true
+
+where:
+a | _
+1 | _
+
+c << $spock_p_a
+'''
+
+    then:
+    thrown(MissingPropertyException)
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/Parameterizations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/Parameterizations.groovy
@@ -135,4 +135,43 @@ class Parameterizations extends EmbeddedSpecification {
     b = { i, j -> i + j }
     size = { 42 }
   }
+
+  @Issue("https://github.com/spockframework/spock/issues/880")
+  def "variables in helper methods do not interfere with omitted data variables"() {
+    expect:
+    runner.runSpecBody '''
+def "#a <=> #b: #result"() {
+  expect:
+  Math.signum(a <=> b) == result
+
+  where:
+  a          | b          | result
+  "abcdef12" | "abcdef12" | 0
+}
+
+private double[] someOtherMethod() {
+  double[] result = new double[0]
+  return result
+}
+'''
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/880")
+  def "variables in helper methods do not interfere with typed data variables"() {
+    expect:
+    runner.runSpecBody '''
+def "roll #x"(Integer x) {
+    expect:
+    1 == x
+
+    where:
+    x << [1]
+}
+
+private int unused() {
+    String x = "4"
+    return 3
+}
+'''
+  }
 }


### PR DESCRIPTION
The implementation of previous data table column access is a bit sub-optimal.
It has various bugs and hard to grasp quirks.

Some of them are:

- If you had a derived data variable before the table, the injection of the previous data providers didn't work properly,
  as the position was counted from the previous data variables, but for derived data variables there is no data provider,
  so the calculated indexes / lenghts were off by amount of derived data variables before the data table or data pipe

- Referencing the previous columns in a later column only works in some situations, but not in others.
  If you for example use the previous column inside a closure, it is not found, as the reference was not
  properly defined for the closure

- Referencing a previous derived data variable never works from a data table or data pipe

- Referencing a previous data pipe variable or data table variable in a data pipe behaves differently
  depending on where it is used. If you write in a structure that matches the one generated for data table
  columns, the variable is the value for the "current" iteration. If you use it anyhere else, for example
  directly like `y << x` then `x` is the data provider itself

- Referencing an arbitrary previous data provider can lead to its premature consumption if it is a consume-once iterable.
  Accessing the column values to calculate the next column values already queried the data provider at creation time of
  the second data provider and not like documented right before the next iteration and only when needed. It can also
  lead to having half the expected iterations with other values, depending on how the values are used

- Referencing previous data pipe providers in a data table cell or in an according data pipe also causes the
  value to be re-requested from the data provider with `getAt(row)` for every access which might also be bad
  for slow data providers like database access or similar. And it would be horrid for a consume-once provider.

- Referencing a data variable from a multi-variable data pipe also works not like expected at all, as you only have one data provider for both variables and the data processor later splits them up, if you have `[x, y] << [[1, 3], [2, 4]]; x2 << x; y2 << y`, `x2` gets the provider for both and `y` gets the provider for `x2` as it returns the next after the one delivering `x`. For `[x, y] << [[1, 3], [2, 4]]; y2 << y; x2 << x` it is even worse, as `y2` now gets the next data provider after the one the delivers `x` and that is `null` resulting in an exception about a `null` data provider. (see #1104)



This PR changes the strategy for the previous column injection, thereby fixing all issues I found and listed.
It also forbids any access to data variables with the exception of derived data variables that can of course access
all previous data variables and data table cells that can access previous columns, even from previous tables,
as there we control the actual data provider and are sure they behave properly and like expected.

Now the only the data provider producer methods for data table columns get anything injected at all.
Those get only the previous data table columns injected and nothing else.
The data table cell expression are then wrapped in a closure each that starts with
statements that extract the current rows value from the previous column and assigns it to a local variable
with the name of the data variable. This is then available in all constructs the user is coming up with.

My guess would be, that in 98% of the cases where someone used one of the cases that are forbidden now it is something like
```groovy
x << [1, 2]
y << x
```
which should instead really be
```groovy
x << [1, 2]
y = x
```
and only accidentally worked.

I think every case that does not work anymore now can easily be done with a derived data variable instead.
And for less accidental errors, less subtle errors and more clarity, this change should be done.

The documentation also never mentioned that you can access other data variables, except from a derived data variable.
Even accessing previous columns in a data table was not mentioned.

Fixes #1104
Also fixes #880 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1111)
<!-- Reviewable:end -->
