### PR TITLE
 Do not require all data variables as parameters (#652) 

### DIFF
--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -105,11 +105,18 @@ spec, all of which can be kept in the same file. This achieves better isolation 
 
 == Syntactic Variations
 
-The previous code can be tweaked in a few ways. First, since the `where:` block already declares all data variables, the
-method parameters can be omitted.footnote:[The idea behind allowing method parameters is to enable better IDE support.
+The previous code can be tweaked in a few ways.
+
+First, since the `where:` block already declares all data variables, the method parameters can be
+omitted.footnote:[The idea behind allowing method parameters is to enable better IDE support.
 However, recent versions of IntelliJ IDEA recognize data variables automatically, and even infer their types from the
 values contained in the data table.]
+
+You can also omit some parameters and specify others, for example to have them typed.
+The order also is not important, data variables are matched by name to the specified method parameters.
+
 Second, inputs and expected outputs can be separated with a double pipe symbol (`||`) to visually set them apart.
+
 With this, the code becomes:
 
 [source,groovy,indent=0]

--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -773,9 +773,18 @@ If your interceptor should support custom method parameters for wrapped methods,
 annotated with a special annotation or some test helper that injects objects of a specific type that are created and
 prepared for usage automatically.
 
-`invocation.arguments` may be an empty array or an array of arbitrary length, depending on what interceptors were run
-before that maybe also have manipulated this array for parameter injection. So if you for example investigated the
-method parameters with `invocation.method.reflection.parameters` and found that you want to inject the fifth parameter,
+When called from at least Spock 2.0, the `arguments` array will always have the size of the method parameter count,
+so you can directly set the arguments you want to set. You cannot change the size of the `arguments` array either.
+All parameters that did not yet get any value injected, either from data variables or some extension, will have the
+value `MethodInfo.MISSING_ARGUMENT` and if any of those remain, after all interceptors were run, an exception will be
+thrown.
+
+[NOTE]
+--
+When your extension might be used with a version before Spock 2.0, the `arguments` array may be an empty array
+or an array of arbitrary length, depending on what interceptors were run before that maybe also have manipulated
+this array for parameter injection. If you for example investigated the method parameters with
+`invocation.method.reflection.parameters` and found that you want to inject the fifth parameter,
 you should first check whether the `arguments` array is at least five elements long. If not, you should assign it a new
 array that is at least five elements long and copy the contents of the old array into the new one. Then you can assign
 your objects to be injected.
@@ -805,23 +814,23 @@ parameters.each { parameter, i ->
   invocation.arguments[i] = new MyInjectable(parameter)
 }
 ----
+--
 
 [NOTE]
 --
-When using data driven features (methods with a `where:` block), the user of your extension has to follow some
+*Pre Spock 2.0 only:* When using data driven features (methods with a `where:` block), the user of your extension has to follow some
 restrictions, if parameters should be injected by your extension:
 
 * all data variables and all to-be-injected parameters have to be defined as method parameters
 * all method parameters have to be assigned a value in the `where:` block, for example `null`
-* *pre Spock 2.0:* the order of the method parameters has to be identical to the order of the data
-  variables in the `where:` block
-+
+* the order of the method parameters has to be identical to the order of the data variables in the `where:` block
+
 of course you can also make your extension only inject a value if none is set already, as the `where:` block
 assignments happen before the method interceptor is called
-+
+
 for this simply check whether `invocation.arguments[i]` is `null` or not
 
-.Data Driven Feature with Injected Parameter
+.Data Driven Feature with Injected Parameter pre Spock 2.0
 [source, groovy]
 ----
 def 'test parameter injection'(a, b, MyInjectable myInjectable) {
@@ -834,6 +843,19 @@ def 'test parameter injection'(a, b, MyInjectable myInjectable) {
 
   and:
   myInjectable = null
+}
+----
+
+.Data Driven Feature with Injected Parameter post Spock 2.0
+[source, groovy]
+----
+def 'test parameter injection'(MyInjectable myInjectable) {
+  expect: myInjectable
+
+  where:
+  a    | b
+  'a1' | 'b1'
+  'a2' | 'b2'
 }
 ----
 --

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -68,6 +68,10 @@ b = a
   injecting mock objects or test proxies or similar. `FeatureInfo#getDataVariables()` now only returns the actual data
   variables and in the order how they are defined in the `where` block.
 
+- Method arguments in `MethodInfo` now have a value of `MethodInfo.MISSING_ARGUMENT` if no value was set so far,
+  for example by some extensions or from data variables. If any of these is not replaced by some value, an exception
+  will be thrown at runtime.
+
 === Misc
 
 - Upgrade JUnit 4 to 4.13
@@ -124,6 +128,12 @@ Spy(constructorArgs: [null as String, (Pattern) null])
 
 - The order of parameters in a data-driven feature does no longer have to be identical to
   the declaration order in the `where` block. Data variables are now injected by name.
+
+- Data driven features do no longer have the requirement that either none or all data variables are declared as
+  parameters and that all parameters are also data variables. Now you can either declare none, some, or all data
+  variables as parameters and also have additional method parameters that are no data variables.
+  Those additional parameters must be provided by some Spock extension though. If they are not set at execution time,
+  an exception will be thrown.
 
 == 2.0-M2 (2020-02-10)
 

--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -32,7 +32,9 @@ import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.syntax.*;
 import org.objectweb.asm.Opcodes;
 
-import static java.util.Comparator.comparing;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.*;
 import static org.spockframework.compiler.AstUtil.createGetAtMethod;
 import static org.spockframework.compiler.AstUtil.createGetMethod;
@@ -561,13 +563,6 @@ public class WhereBlockRewriter {
 
     if (isDataProcessorVariable(varExpr.getName())) {
       resources.getErrorReporter().error(varExpr, "Duplicate declaration of data variable '%s'", varExpr.getName());
-      return;
-    }
-
-    if (whereBlock.getParent().getAst().getParameters().length > 0 && !(accessedVar instanceof Parameter)) {
-      resources.getErrorReporter().error(varExpr,
-          "Data variable '%s' needs to be declared as method parameter",
-          varExpr.getName());
     }
   }
 
@@ -580,34 +575,29 @@ public class WhereBlockRewriter {
 
   private void handleFeatureParameters() {
     Parameter[] parameters = whereBlock.getParent().getAst().getParameters();
-    if (parameters.length == 0) {
-      addFeatureParameters();
-    } else {
-      checkAllParametersAreDataVariables(parameters);
-      sortFeatureParameters(parameters);
-    }
-  }
+    Map<Boolean, List<Parameter>> declaredParameters = Arrays.stream(parameters).collect(
+      partitioningBy(parameter -> isDataProcessorVariable(parameter.getName())));
 
-  private void checkAllParametersAreDataVariables(Parameter[] parameters) {
-    for (Parameter param : parameters)
-      if (!isDataProcessorVariable(param.getName()))
-        resources.getErrorReporter().error(param, "Parameter '%s' does not refer to a data variable", param.getName());
-  }
-
-  private void sortFeatureParameters(Parameter[] parameters) {
-    List<String> dataVariableNames = dataProcessorVars
+    Map<String, Parameter> declaredDataVariableParameters = declaredParameters
+      .get(TRUE)
       .stream()
-      .map(VariableExpression::getName)
-      .collect(toList());
-    Arrays.sort(parameters, comparing(parameter -> dataVariableNames.indexOf(parameter.getName())));
-    whereBlock.getParent().getAst().setParameters(parameters);
-  }
+      .collect(toMap(Parameter::getName, identity()));
 
-  private void addFeatureParameters() {
-    Parameter[] parameters = new Parameter[dataProcessorVars.size()];
-    for (int i = 0; i < dataProcessorVars.size(); i++)
-      parameters[i] = new Parameter(ClassHelper.DYNAMIC_TYPE, dataProcessorVars.get(i).getName());
-    whereBlock.getParent().getAst().setParameters(parameters);
+    List<Parameter> auxiliaryParameters = declaredParameters.get(FALSE);
+
+    List<Parameter> newParameters = new ArrayList<>(dataProcessorVars.size() + auxiliaryParameters.size());
+    // first all data variables in order of where block
+    for (VariableExpression dataProcessorVar : dataProcessorVars) {
+      String name = dataProcessorVar.getName();
+      Parameter declaredDataVariableParameter = declaredDataVariableParameters.get(name);
+      newParameters.add(declaredDataVariableParameter == null
+        ? new Parameter(ClassHelper.DYNAMIC_TYPE, name)
+        : declaredDataVariableParameter);
+    }
+    // then all auxiliary parameters in declaration order
+    newParameters.addAll(auxiliaryParameters);
+
+    whereBlock.getParent().getAst().setParameters(newParameters.toArray(Parameter.EMPTY_ARRAY));
   }
 
   @SuppressWarnings("unchecked")

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
@@ -24,6 +24,11 @@ import spock.lang.Specification;
 import org.junit.platform.engine.support.hierarchical.Node;
 import org.junit.runner.Description;
 
+import java.util.Arrays;
+
+import static java.lang.System.arraycopy;
+import static org.spockframework.runtime.model.MethodInfo.MISSING_ARGUMENT;
+
 /**
  * Executes a single Spec. Notifies its supervisor about overall execution
  * progress and every invocation of Spec code.
@@ -320,7 +325,16 @@ public class PlatformSpecRunner {
 
     MethodInfo featureIteration = new MethodInfo(context.getCurrentFeature().getFeatureMethod());
     featureIteration.setIteration(context.getCurrentIteration());
-    invoke(context, context.getCurrentInstance(), featureIteration, context.getCurrentIteration().getDataValues());
+
+    Class<?>[] parameterTypes = featureIteration.getReflection().getParameterTypes();
+    int parameterCount = parameterTypes.length;
+    Object[] dataValues = context.getCurrentIteration().getDataValues();
+
+    Object[] iterationArguments = new Object[parameterCount];
+    arraycopy(dataValues, 0, iterationArguments, 0, dataValues.length);
+    Arrays.fill(iterationArguments, dataValues.length, parameterCount, MISSING_ARGUMENT);
+
+    invoke(context, context.getCurrentInstance(), featureIteration, iterationArguments);
   }
 
   void runCleanup(SpockExecutionContext context) {

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IMethodInvocation.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IMethodInvocation.java
@@ -100,7 +100,10 @@ public interface IMethodInvocation {
 
   /**
    * Sets the arguments for this method invocation.
+   *
+   * @deprecated set the fields in the return value of {@link #getArguments()} instead
    */
+  @Deprecated
   void setArguments(Object[] arguments);
 
   /**

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/MethodInvocation.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/MethodInvocation.java
@@ -88,6 +88,10 @@ public class MethodInvocation implements IMethodInvocation {
 
   @Override
   public void setArguments(Object[] arguments) {
+    if (arguments.length != this.arguments.length) {
+      throw new IllegalArgumentException(
+        "length of arguments array must not change from " + this.arguments.length + " to " + arguments.length);
+    }
     this.arguments = arguments;
   }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -18,7 +18,8 @@ package org.spockframework.smoke.parameterization
 
 import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 import org.spockframework.EmbeddedSpecification
-import org.spockframework.compiler.InvalidSpecCompileException
+import org.spockframework.runtime.SpockExecutionException
+import spock.lang.FailsWith
 import spock.lang.Issue
 
 /**
@@ -70,60 +71,40 @@ class MethodParameters extends EmbeddedSpecification {
     y << [1, 2]
   }
 
-  def "fewer parameters than data variables"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x) {
-  expect:
-  x == y
+  @Issue("https://github.com/spockframework/spock/issues/652")
+  def "fewer parameters than data variables"(x) {
+    expect:
+    x == y
 
-  where:
-  x << [1, 2]
-  y << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
+    where:
+    x << [1, 2]
+    y << [1, 2]
   }
 
-  def "more parameters than data variables"() {
+  @Issue("https://github.com/spockframework/spock/issues/652")
+  def "more parameters than data variables throw exception if not injected by some extension"() {
     when:
-    compiler.compileSpecBody """
+    runner.runSpecBody '''
 def foo(x, y, z) {
   expect:
   x == y
+  z == null
 
   where:
   x << [1, 2]
   y << [1, 2]
 }
-    """
+'''
 
     then:
-    thrown(InvalidSpecCompileException)
+    SpockExecutionException see = thrown()
+    see.message == /No argument was provided for parameters: 'z'/
   }
 
-
-  def "parameter that is not a data variable"() {
-    when:
-    compiler.compileSpecBody """
-def foo(x, a) {
-  expect:
-  x == x
-
-  where:
-  x << [1, 2]
-}
-    """
-
-    then:
-    thrown(InvalidSpecCompileException)
-  }
-
+  @Issue("https://github.com/spockframework/spock/issues/652")
   def "data variable that is not a parameter"() {
-    when:
-    compiler.compileSpecBody """
+    expect:
+    runner.runSpecBody """
 def foo(x) {
   expect:
   x == y
@@ -133,13 +114,10 @@ def foo(x) {
 }
     """
 
-    then:
-    thrown(InvalidSpecCompileException)
-
     where:
     parameterizations << [
         "x << [1,2]; y << [1, 2]",
-        "[x, y] << [[1, 2], [1, 2]]",
+        "[x, y] << [[1, 1], [2, 2]]",
         "x << [1, 2]; y = x"
     ]
   }
@@ -178,5 +156,20 @@ def foo(x, ClassLoader y) {
     where:
     x << [1, 2]
     y << [2, 4]
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/652")
+  def "method parameters that are eventually provided by extensions throw an exception at runtime if not set"() {
+    when:
+    runner.runSpecBody '''
+def foo(x, y) {
+  expect:
+  x == y
+}
+  '''
+
+    then:
+    SpockExecutionException see = thrown()
+    see.message == /No argument was provided for parameters: 'x', 'y'/
   }
 }


### PR DESCRIPTION
Fixes #652

Only last commit to be reviewed.

With this PR, you no longer are required to provide all or no data variables as parameters.
You are also no longer required that all parameters are data variables.
So you can now specify some or all data variables in any order and also additional parameters that get injected by some extension eventually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1114)
<!-- Reviewable:end -->
