### PR TITLE
Set source position for return statement in data provider method

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -103,18 +103,22 @@ public class WhereBlockRewriter {
 
     dataProviderExpr = dataProviderExpr.transformExpression(new DataTablePreviousVariableTransformer());
 
+    ExpressionStatement exprStat = new ExpressionStatement(dataProviderExpr);
+    exprStat.setSourcePosition(dataProviderExpr);
+
+    ReturnStatement returnStat = new ReturnStatement(exprStat);
+    returnStat.setSourcePosition(dataProviderExpr);
+
     MethodNode method =
-        new MethodNode(
-            InternalIdentifiers.getDataProviderName(whereBlock.getParent().getAst().getName(), dataProviderCount++),
-            Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
-            ClassHelper.OBJECT_TYPE,
-            getPreviousParameters(nextDataVariableIndex),
-            ClassNode.EMPTY_ARRAY,
-            new BlockStatement(
-              Arrays.<Statement>asList(
-                new ReturnStatement(
-                  new ExpressionStatement(dataProviderExpr))),
-                new VariableScope()));
+      new MethodNode(
+        InternalIdentifiers.getDataProviderName(whereBlock.getParent().getAst().getName(), dataProviderCount++),
+        Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
+        ClassHelper.OBJECT_TYPE,
+        getPreviousParameters(nextDataVariableIndex),
+        ClassNode.EMPTY_ARRAY,
+        new BlockStatement(
+          Arrays.<Statement>asList(returnStat),
+          new VariableScope()));
 
     method.addAnnotation(createDataProviderAnnotation(dataProviderExpr, nextDataVariableIndex));
     whereBlock.getParent().getParent().getAst().addMethod(method);

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataProviders.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataProviders.groovy
@@ -114,7 +114,7 @@ where : $providers
 
     then:
     thrown(SpockExecutionException)
-    
+
     where:
     providers << [
         "x << [1, 2]; y << [1]",
@@ -156,6 +156,21 @@ y << []
       [x, y]
     }()
     b << [0, 1]
+  }
+
+  def 'data pipe consisting of single variable expression has line information in stack trace'() {
+    when:
+    runner.runFeatureBody '''
+expect: true
+where: a << b
+'''
+
+    then:
+    MissingPropertyException mpe = thrown()
+    verifyAll(mpe.stackTrace[0]) {
+      methodName == 'a feature'
+      lineNumber != -1
+    }
   }
 
   static class MyIterator implements Iterator {


### PR DESCRIPTION
They are not necessary for Groovy and there is a problem with missing line numbers in stack traces.
Alternative solution would have been to set the source information on the return statement.

If you for example had
```groovy
  def foo() {
    expect: true
    where: a << b
  }
```
then the `MissingPropertyException` complaining about `b` had no line information in the stack trace.
See also https://issues.apache.org/jira/browse/GROOVY-9440

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1116)
<!-- Reviewable:end -->
