### PR TITLE
Upgrade Groovy to 3.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
       minGroovyVersion = "2.5.0"
       maxGroovyVersion = "2.9.99"
     } else if (variant == 3.0) {
-      groovyVersion = "3.0.0"
+      groovyVersion = "3.0.2"
       minGroovyVersion = "3.0.0"
       maxGroovyVersion = "3.9.99"
     } else {


### PR DESCRIPTION
I realize that there might be 3.0.3 before M3, but with that change people using the snapshot of Spock (or local builds) can have Groovy 3 with [better](http://groovy-lang.org/changelogs/changelog-3.0.1.html) JDK9+ support by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1125)
<!-- Reviewable:end -->
