### PR TITLE
Add Spock GroovyRunner

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/SpockGroovyRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockGroovyRunner.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime;
+
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyRuntimeException;
+import org.apache.groovy.plugin.GroovyRunner;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.LoggingListener;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import spock.lang.Specification;
+
+import java.io.PrintWriter;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+public class SpockGroovyRunner implements GroovyRunner {
+  @Override
+  public boolean canRun(Class<?> scriptClass, GroovyClassLoader loader) {
+    return Specification.class.isAssignableFrom(scriptClass);
+  }
+
+  @Override
+  public Object run(Class<?> scriptClass, GroovyClassLoader loader) {
+    LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder
+      .request()
+      .selectors(selectClass(scriptClass))
+      .build();
+    Launcher launcher = LauncherFactory.create();
+
+    SummaryGeneratingListener listener = new SummaryGeneratingListener();
+    launcher.registerTestExecutionListeners(listener);
+    launcher.registerTestExecutionListeners(LoggingListener.forJavaUtilLogging());
+    launcher.execute(request);
+
+    TestExecutionSummary summary = listener.getSummary();
+    System.out.printf("Spock launcher: passed=%d, failed=%d, skipped=%d, time=%dms%n",
+      summary.getTestsSucceededCount(),
+      summary.getTestsFailedCount(),
+      summary.getTestsSkippedCount(),
+      summary.getTimeFinished() - summary.getTimeStarted());
+    if (!summary.getFailures().isEmpty()) {
+      summary.printFailuresTo(new PrintWriter(System.out, true));
+      throw new GroovyRuntimeException(summary.getFailures().get(0).getException());
+    }
+
+    return null;
+  }
+}

--- a/spock-core/src/main/resources/META-INF/services/org.apache.groovy.plugin.GroovyRunner
+++ b/spock-core/src/main/resources/META-INF/services/org.apache.groovy.plugin.GroovyRunner
@@ -1,0 +1,1 @@
+org.spockframework.runtime.SpockGroovyRunner

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/SpockGroovyRunnerTest.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/SpockGroovyRunnerTest.groovy
@@ -1,0 +1,39 @@
+package org.spockframework.runtime
+
+import spock.lang.Specification
+
+class SpockGroovyRunnerTest extends Specification {
+  def 'running successful specification does not throw exception'() {
+    when:
+    new GroovyShell().run '''
+import spock.lang.Specification
+
+class Foo extends Specification {
+  def foo() {
+    expect:
+    true
+  }
+}
+''', 'foo.groovy'
+
+    then:
+    noExceptionThrown()
+  }
+
+  def 'running failing specification throws exception'() {
+    when:
+    new GroovyShell().run '''
+import spock.lang.Specification
+
+class Foo extends Specification {
+  def foo() {
+    expect:
+    false
+  }
+}
+''', 'foo.groovy'
+
+    then:
+    thrown(ConditionNotSatisfiedError)
+  }
+}


### PR DESCRIPTION
After already half-way finishing this, I found that there indeed is a generic JUnit 5 GroovyRunner that should also be able to run Spock tests.
But the 'problem' is, that it is not included with Groovy by default, but in a separate `groovy-test-junit5` module.
And then it uses serious reflection to do its deed.
With this class added, it just works for Spock and does not need reflection,
as the needed classes are always present when Spock is present.
So with this, you can just write or copy a Spock spec in a Groovy Console again and just run it.