### PR TITLE
Some Java 8 related automatic refactorings

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
@@ -127,10 +127,20 @@ public class SpecParser implements GroovyClassVisitor {
     stats.clear();
 
     String name = method.getName();
-    if (name.equals(SETUP)) spec.setSetupMethod(fixtureMethod);
-    else if (name.equals(CLEANUP)) spec.setCleanupMethod(fixtureMethod);
-    else if (name.equals(SETUP_SPEC_METHOD)) spec.setSetupSpecMethod(fixtureMethod);
-    else spec.setCleanupSpecMethod(fixtureMethod);
+    switch (name) {
+      case SETUP:
+        spec.setSetupMethod(fixtureMethod);
+        break;
+      case CLEANUP:
+        spec.setCleanupMethod(fixtureMethod);
+        break;
+      case SETUP_SPEC_METHOD:
+        spec.setSetupSpecMethod(fixtureMethod);
+        break;
+      default:
+        spec.setCleanupSpecMethod(fixtureMethod);
+        break;
+    }
   }
 
   // IDEA: recognize feature methods by looking at signature only

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -348,11 +348,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
   private void moveInteractions(List<Statement> interactions, ThenBlock block) {
     if (interactions.isEmpty()) return;
 
-    ListIterator<Statement> listIterator = block.getAst().listIterator();
-    while (listIterator.hasNext()) {
-      Statement next = listIterator.next();
-      if (interactions.contains(next)) listIterator.remove();
-    }
+    block.getAst().removeIf(interactions::contains);
 
     List<Statement> statsBeforeWhenBlock = block.getPrevious(WhenBlock.class).getPrevious().getAst();
 

--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -419,7 +419,7 @@ public class WhereBlockRewriter {
     if (rows.isEmpty()) return columns;
 
     for (int i = 0; i < rows.get(0).size(); i++)
-      columns.add(new ArrayList<Expression>());
+      columns.add(new ArrayList<>());
 
     for (List<Expression> row : rows)
       for (int i = 0; i < row.size(); i++)

--- a/spock-core/src/main/java/org/spockframework/compiler/model/Block.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/model/Block.java
@@ -33,7 +33,7 @@ public abstract class Block extends Node<Method, List<Statement>> {
   private Block next;
 
   public Block(Method parent) {
-    super(parent, new ArrayList<Statement>());
+    super(parent, new ArrayList<>());
   }
 
   public List<String> getDescriptions() {

--- a/spock-core/src/main/java/org/spockframework/gentyref/TypeToken.java
+++ b/spock-core/src/main/java/org/spockframework/gentyref/TypeToken.java
@@ -57,7 +57,7 @@ public abstract class TypeToken<T> {
 	 * Gets type token for the given {@code Type} instance.
 	 */
 	public static TypeToken<?> get(Type type) {
-		return new SimpleTypeToken<Object>(type);
+		return new SimpleTypeToken<>(type);
 	}
 
 	private static class SimpleTypeToken<T> extends TypeToken<T> {

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockFactory.java
@@ -48,12 +48,7 @@ public class GroovyMockFactory implements IMockFactory {
           ". Global cannot add additionalInterfaces.");
       }
       GroovyRuntimeUtil.setMetaClass(type, newMetaClass);
-      specification.getSpecificationContext().getCurrentIteration().addCleanup(new Runnable() {
-        @Override
-        public void run() {
-          GroovyRuntimeUtil.setMetaClass(type, oldMetaClass);
-        }
-      });
+      specification.getSpecificationContext().getCurrentIteration().addCleanup(() -> GroovyRuntimeUtil.setMetaClass(type, oldMetaClass));
       return MockInstantiator.instantiate(type, type, configuration.getConstructorArgs(), configuration.isUseObjenesis());
     }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/AsyncRunListener.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/AsyncRunListener.java
@@ -20,11 +20,8 @@ import org.spockframework.util.IStoppable;
 import java.util.concurrent.*;
 
 public class AsyncRunListener implements IRunListener, IStoppable {
-  private static final Runnable STOP = new Runnable() {
-    @Override
-    public void run() {
-      throw new IllegalStateException("should never run");
-    }
+  private static final Runnable STOP = () -> {
+    throw new IllegalStateException("should never run");
   };
 
   private final IRunListener delegate;
@@ -64,92 +61,47 @@ public class AsyncRunListener implements IRunListener, IStoppable {
 
   @Override
   public void beforeSpec(final SpecInfo spec) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.beforeSpec(spec);
-      }
-    });
+    addEvent(() -> delegate.beforeSpec(spec));
   }
 
   @Override
   public void beforeFeature(final FeatureInfo feature) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.beforeFeature(feature);
-      }
-    });
+    addEvent(() -> delegate.beforeFeature(feature));
   }
 
   @Override
   public void beforeIteration(final IterationInfo iteration) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.beforeIteration(iteration);
-      }
-    });
+    addEvent(() -> delegate.beforeIteration(iteration));
   }
 
   @Override
   public void afterIteration(final IterationInfo iteration) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.afterIteration(iteration);
-      }
-    });
+    addEvent(() -> delegate.afterIteration(iteration));
   }
 
   @Override
   public void afterFeature(final FeatureInfo feature) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.afterFeature(feature);
-      }
-    });
+    addEvent(() -> delegate.afterFeature(feature));
   }
 
   @Override
   public void afterSpec(final SpecInfo spec) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.afterSpec(spec);
-      }
-    });
+    addEvent(() -> delegate.afterSpec(spec));
   }
 
   @Override
   public void error(final ErrorInfo error) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.error(error);
-      }
-    });
+    addEvent(() -> delegate.error(error));
   }
 
   @Override
   public void specSkipped(final SpecInfo spec) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.specSkipped(spec);
-      }
-    });
+    addEvent(() -> delegate.specSkipped(spec));
   }
 
   @Override
   public void featureSkipped(final FeatureInfo feature) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        delegate.featureSkipped(feature);
-      }
-    });
+    addEvent(() -> delegate.featureSkipped(feature));
   }
 
   protected void addEvent(Runnable event) {

--- a/spock-core/src/main/java/org/spockframework/runtime/AsyncStandardStreamsListener.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/AsyncStandardStreamsListener.java
@@ -24,21 +24,11 @@ public class AsyncStandardStreamsListener extends AsyncRunListener implements IS
 
   @Override
   public void standardOut(final String message) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        streamsDelegate.standardOut(message);
-      }
-    });
+    addEvent(() -> streamsDelegate.standardOut(message));
   }
 
   @Override
   public void standardErr(final String message) {
-    addEvent(new Runnable() {
-      @Override
-      public void run() {
-        streamsDelegate.standardErr(message);
-      }
-    });
+    addEvent(() -> streamsDelegate.standardErr(message));
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/ExpressionInfoRenderer.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ExpressionInfoRenderer.java
@@ -60,12 +60,7 @@ public class ExpressionInfoRenderer {
   }
 
   private void placeValues() {
-    Comparator<ExpressionInfo> comparator = new Comparator<ExpressionInfo>() {
-      @Override
-      public int compare(ExpressionInfo expr1, ExpressionInfo expr2) {
-        return expr2.getAnchor().getColumn() - expr1.getAnchor().getColumn();
-      }
-    };
+    Comparator<ExpressionInfo> comparator = (expr1, expr2) -> expr2.getAnchor().getColumn() - expr1.getAnchor().getColumn();
 
     for (ExpressionInfo expr : this.expr.inCustomOrder(true, comparator))
       placeValue(expr);

--- a/spock-core/src/main/java/org/spockframework/runtime/ExpressionInfoRenderer.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ExpressionInfoRenderer.java
@@ -21,6 +21,8 @@ import org.spockframework.runtime.model.*;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import static java.util.Comparator.comparingInt;
+
 /**
  * Creates a string representation of an assertion and its recorded values.
  *
@@ -60,10 +62,11 @@ public class ExpressionInfoRenderer {
   }
 
   private void placeValues() {
-    Comparator<ExpressionInfo> comparator = (expr1, expr2) -> expr2.getAnchor().getColumn() - expr1.getAnchor().getColumn();
+    Comparator<ExpressionInfo> comparator =
+      comparingInt((ExpressionInfo exprInfo) -> exprInfo.getAnchor().getColumn()).reversed();
 
-    for (ExpressionInfo expr : this.expr.inCustomOrder(true, comparator))
-      placeValue(expr);
+    for (ExpressionInfo exprInfo : this.expr.inCustomOrder(true, comparator))
+      placeValue(exprInfo);
   }
 
   private void placeValue(ExpressionInfo expr) {

--- a/spock-core/src/main/java/org/spockframework/runtime/RunContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/RunContext.java
@@ -27,7 +27,7 @@ import java.util.*;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 
 public class RunContext implements EngineExecutionContext {
-  private static final ThreadLocal<LinkedList<RunContext>> contextStacks = ThreadLocal.withInitial(() -> new LinkedList<>());
+  private static final ThreadLocal<LinkedList<RunContext>> contextStacks = ThreadLocal.withInitial(LinkedList::new);
 
   private final String name;
   private final File spockUserHome;

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
@@ -95,12 +95,7 @@ public class SpecInfoBuilder {
       spec.addField(fieldInfo);
     }
 
-    Collections.sort(spec.getFields(), new Comparator<FieldInfo>() {
-      @Override
-      public int compare(FieldInfo f1, FieldInfo f2) {
-        return f1.getOrdinal() - f2.getOrdinal();
-      }
-    });
+    spec.getFields().sort(Comparator.comparingInt(FieldInfo::getOrdinal));
   }
 
   private void buildFeatures() {
@@ -111,12 +106,7 @@ public class SpecInfoBuilder {
       spec.addFeature(createFeature(method, metadata));
     }
 
-    Collections.sort(spec.getFeatures(), new IFeatureSortOrder() {
-      @Override
-      public int compare(FeatureInfo m1, FeatureInfo m2) {
-        return m1.getDeclarationOrder() - m2.getDeclarationOrder();
-      }
-    });
+    spec.getFeatures().sort((IFeatureSortOrder) (m1, m2) -> m1.getDeclarationOrder() - m2.getDeclarationOrder());
   }
 
   private FeatureInfo createFeature(Method method, FeatureMetadata featureMetadata) {

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecInfoBuilder.java
@@ -23,6 +23,8 @@ import spock.lang.Specification;
 import java.lang.reflect.*;
 import java.util.*;
 
+import static java.util.Comparator.comparingInt;
+
 /**
  * Builds a SpecInfo from a Class instance.
  *
@@ -95,7 +97,7 @@ public class SpecInfoBuilder {
       spec.addField(fieldInfo);
     }
 
-    spec.getFields().sort(Comparator.comparingInt(FieldInfo::getOrdinal));
+    spec.getFields().sort(comparingInt(FieldInfo::getOrdinal));
   }
 
   private void buildFeatures() {
@@ -106,7 +108,7 @@ public class SpecInfoBuilder {
       spec.addFeature(createFeature(method, metadata));
     }
 
-    spec.getFeatures().sort((IFeatureSortOrder) (m1, m2) -> m1.getDeclarationOrder() - m2.getDeclarationOrder());
+    spec.getFeatures().sort(comparingInt(FeatureInfo::getDeclarationOrder));
   }
 
   private FeatureInfo createFeature(Method method, FeatureMetadata featureMetadata) {

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecRunHistory.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecRunHistory.java
@@ -62,22 +62,19 @@ public class SpecRunHistory implements Comparable<SpecRunHistory> {
   }
 
   public void sortFeatures(SpecInfo spec) {
-    spec.sortFeatures(new IFeatureSortOrder() {
-      @Override
-      public int compare(FeatureInfo f1, FeatureInfo f2) {
-        Integer confidence1 = data.featureConfidences.get(f1.getName());
-        if (confidence1 == null) return -1;
+    spec.sortFeatures((f1, f2) -> {
+      Integer confidence1 = data.featureConfidences.get(f1.getName());
+      if (confidence1 == null) return -1;
 
-        Integer confidence2 = data.featureConfidences.get(f2.getName());
-        if (confidence2 == null) return 1;
+      Integer confidence2 = data.featureConfidences.get(f2.getName());
+      if (confidence2 == null) return 1;
 
-        if (!confidence1.equals(confidence2))
-          return confidence1 - confidence2;
+      if (!confidence1.equals(confidence2))
+        return confidence1 - confidence2;
 
-        long duration1 = data.featureDurations.get(f1.getName()); // never null
-        long duration2 = data.featureDurations.get(f2.getName()); // never null
-        return duration1 < duration2 ? -1 : 1;
-      }
+      long duration1 = data.featureDurations.get(f1.getName()); // never null
+      long duration2 = data.featureDurations.get(f2.getName()); // never null
+      return duration1 < duration2 ? -1 : 1;
     });
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ExpressionInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ExpressionInfo.java
@@ -132,13 +132,10 @@ public class ExpressionInfo implements Iterable<ExpressionInfo> {
   }
 
   public Iterable<ExpressionInfo> inPrefixOrder(final boolean skipIrrelevant) {
-    return new Iterable<ExpressionInfo>() {
-      @Override
-      public Iterator<ExpressionInfo> iterator() {
-        List<ExpressionInfo> list = new ArrayList<>();
-        collectPrefix(list, skipIrrelevant);
-        return list.iterator();
-      }
+    return () -> {
+      List<ExpressionInfo> list = new ArrayList<>();
+      collectPrefix(list, skipIrrelevant);
+      return list.iterator();
     };
   }
 
@@ -151,7 +148,7 @@ public class ExpressionInfo implements Iterable<ExpressionInfo> {
   public Iterable<ExpressionInfo> inCustomOrder(boolean skipIrrelevant, Comparator<ExpressionInfo> comparator) {
     List<ExpressionInfo> list = new ArrayList<>();
     collectPrefix(list, skipIrrelevant);
-    Collections.sort(list, comparator);
+    list.sort(comparator);
     return list;
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
@@ -307,7 +307,7 @@ public class SpecInfo extends SpecElementInfo<NodeInfo, Class<?>> implements IMe
 
   public void sortFeatures(final IFeatureSortOrder order) {
     List<FeatureInfo> features = getAllFeatures();
-    Collections.sort(features, order);
+    features.sort(order);
     for (int i = 0; i < features.size(); i++)
       features.get(i).setExecutionOrder(i);
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
@@ -22,6 +22,8 @@ import org.spockframework.util.*;
 
 import java.util.*;
 
+import static java.util.Comparator.comparingInt;
+
 /**
  * Runtime information about a Spock specification.
  *
@@ -234,7 +236,7 @@ public class SpecInfo extends SpecElementInfo<NodeInfo, Class<?>> implements IMe
 
   public List<FeatureInfo> getAllFeaturesInExecutionOrder() {
     List<FeatureInfo> result = getAllFeatures();
-    result.sort(Comparator.comparingInt(FeatureInfo::getExecutionOrder));
+    result.sort(comparingInt(FeatureInfo::getExecutionOrder));
     return result;
   }
 

--- a/spock-core/src/main/java/org/spockframework/util/AbstractMultiset.java
+++ b/spock-core/src/main/java/org/spockframework/util/AbstractMultiset.java
@@ -42,12 +42,7 @@ public abstract class AbstractMultiset<E> implements IMultiset<E> {
 
   @Override
   public boolean add(E element) {
-    Integer count = elements.get(element);
-    if (count == null) {
-      elements.put(element, 1);
-    } else {
-      elements.put(element, count + 1);
-    }
+    elements.merge(element, 1, Integer::sum);
     return true;
   }
 

--- a/spock-core/src/main/java/org/spockframework/util/CollectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/CollectionUtil.java
@@ -146,22 +146,9 @@ public abstract class CollectionUtil {
     return map;
   }
 
-  public static Map filterNullValues(Map map) {
-    Iterator<Map.Entry> iterator = map.entrySet().iterator();
-    while(iterator.hasNext()) {
-      Map.Entry next = iterator.next();
-      if (next.getValue() == null) {
-        iterator.remove();
-      }
-    }
+  public static <K, V> Map<K, V> filterNullValues(Map<K, V> map) {
+    map.entrySet().removeIf(next -> next.getValue() == null);
     return map;
-  }
-
-  public static Map putAll(Map original, Map... others) {
-    for (Map other : others) {
-      original.putAll(other);
-    }
-    return original;
   }
 
   @SafeVarargs

--- a/spock-core/src/main/java/org/spockframework/util/CollectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/CollectionUtil.java
@@ -73,28 +73,25 @@ public abstract class CollectionUtil {
   }
 
   public static <T> Iterable<T> reverse(final List<T> list) {
-    return new Iterable<T>() {
-      @Override
-      public Iterator<T> iterator() {
-        final ListIterator<T> listIterator = list.listIterator(list.size());
+    return () -> {
+      final ListIterator<T> listIterator = list.listIterator(list.size());
 
-        return new Iterator<T>() {
-          @Override
-          public boolean hasNext() {
-            return listIterator.hasPrevious();
-          }
+      return new Iterator<T>() {
+        @Override
+        public boolean hasNext() {
+          return listIterator.hasPrevious();
+        }
 
-          @Override
-          public T next() {
-            return listIterator.previous();
-          }
+        @Override
+        public T next() {
+          return listIterator.previous();
+        }
 
-          @Override
-          public void remove() {
-            listIterator.remove();
-          }
-        };
-      }
+        @Override
+        public void remove() {
+          listIterator.remove();
+        }
+      };
     };
   }
 
@@ -173,40 +170,35 @@ public abstract class CollectionUtil {
   }
 
   public static <T> Iterable<T> concat(final List<Iterable<? extends T>> iterables) {
-    return new Iterable<T>() {
+    return () -> new Iterator<T>() {
+      Iterator<? extends T> iter;
+      int pos = 0;
+
       @Override
-      public Iterator<T> iterator() {
-        return new Iterator<T>() {
-          Iterator<? extends T> iter;
-          int pos = 0;
+      public boolean hasNext() {
+        while (pos < iterables.size()) {
+          if (iter == null) iter = iterables.get(pos).iterator();
+          if (iter.hasNext()) return true;
+          iter = null;
+          pos++;
+        }
+        return false;
+      }
 
-          @Override
-          public boolean hasNext() {
-            while (pos < iterables.size()) {
-              if (iter == null) iter = iterables.get(pos).iterator();
-              if (iter.hasNext()) return true;
-              iter = null;
-              pos++;
-            }
-            return false;
-          }
+      @Override
+      public T next() {
+        while (pos < iterables.size()) {
+          if (iter == null) iter = iterables.get(pos).iterator();
+          if (iter.hasNext()) return iter.next();
+          iter = null;
+          pos++;
+        }
+        throw new NoSuchElementException();
+      }
 
-          @Override
-          public T next() {
-            while (pos < iterables.size()) {
-              if (iter == null) iter = iterables.get(pos).iterator();
-              if (iter.hasNext()) return iter.next();
-              iter = null;
-              pos++;
-            }
-            throw new NoSuchElementException();
-          }
-
-          @Override
-          public void remove() {
-            throw new UnsupportedOperationException("remove");
-          }
-        };
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException("remove");
       }
     };
   }

--- a/spock-core/src/main/java/org/spockframework/util/Filter.java
+++ b/spock-core/src/main/java/org/spockframework/util/Filter.java
@@ -33,10 +33,7 @@ public class Filter<T> {
   }
 
   public void filterInPlace(List<? extends T> items) {
-    Iterator<? extends T> iter = items.iterator();
-    while (iter.hasNext())
-      if (!matcher.matches(iter.next()))
-        iter.remove();
+    items.removeIf(t -> !matcher.matches(t));
   }
 
   public static <T> Filter<T> create(IMatcher<T> matcher) {

--- a/spock-core/src/main/java/org/spockframework/util/HashMultiset.java
+++ b/spock-core/src/main/java/org/spockframework/util/HashMultiset.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
  */
 public class HashMultiset<E> extends AbstractMultiset<E> {
   public HashMultiset() {
-    super(new HashMap<E, Integer>());
+    super(new HashMap<>());
   }
 
   public HashMultiset(Collection<? extends E> collection) {

--- a/spock-core/src/main/java/org/spockframework/util/LinkedHashMultiset.java
+++ b/spock-core/src/main/java/org/spockframework/util/LinkedHashMultiset.java
@@ -11,7 +11,7 @@ import java.util.LinkedHashMap;
  */
 public class LinkedHashMultiset<E> extends AbstractMultiset<E> {
   public LinkedHashMultiset() {
-    super(new LinkedHashMap<E, Integer>());
+    super(new LinkedHashMap<>());
   }
 
   public LinkedHashMultiset(Collection<? extends E> collection) {

--- a/spock-core/src/main/java/org/spockframework/util/Matchers.java
+++ b/spock-core/src/main/java/org/spockframework/util/Matchers.java
@@ -14,25 +14,17 @@
 
 package org.spockframework.util;
 
+import static java.util.Arrays.stream;
+
 public class Matchers {
   @SafeVarargs
   public static <T> IMatcher<T> and(final IMatcher<? super T>... matchers) {
-    return item -> {
-      for (IMatcher<? super T> matcher : matchers)
-        if (!matcher.matches(item)) return false;
-
-      return true;
-    };
+    return item -> stream(matchers).allMatch(matcher -> matcher.matches(item));
   }
 
   @SafeVarargs
   public static <T> IMatcher<T> or(final IMatcher<? super T>... matchers) {
-    return item -> {
-      for (IMatcher<? super T> matcher : matchers)
-        if (matcher.matches(item)) return true;
-
-      return false;
-    };
+    return item -> stream(matchers).anyMatch(matcher -> matcher.matches(item));
   }
 
   public static <T> IMatcher<T> not(final IMatcher<T> matcher) {

--- a/spock-core/src/main/java/org/spockframework/util/Matchers.java
+++ b/spock-core/src/main/java/org/spockframework/util/Matchers.java
@@ -17,36 +17,25 @@ package org.spockframework.util;
 public class Matchers {
   @SafeVarargs
   public static <T> IMatcher<T> and(final IMatcher<? super T>... matchers) {
-    return new IMatcher<T>() {
-      @Override
-      public boolean matches(T item) {
-        for (IMatcher<? super T> matcher : matchers)
-          if (!matcher.matches(item)) return false;
+    return item -> {
+      for (IMatcher<? super T> matcher : matchers)
+        if (!matcher.matches(item)) return false;
 
-        return true;
-      }
+      return true;
     };
   }
 
   @SafeVarargs
   public static <T> IMatcher<T> or(final IMatcher<? super T>... matchers) {
-    return new IMatcher<T>() {
-      @Override
-      public boolean matches(T item) {
-        for (IMatcher<? super T> matcher : matchers)
-          if (matcher.matches(item)) return true;
+    return item -> {
+      for (IMatcher<? super T> matcher : matchers)
+        if (matcher.matches(item)) return true;
 
-        return false;
-      }
+      return false;
     };
   }
 
   public static <T> IMatcher<T> not(final IMatcher<T> matcher) {
-    return new IMatcher<T>() {
-      @Override
-      public boolean matches(T item) {
-        return !matcher.matches(item);
-      }
-    };
+    return item -> !matcher.matches(item);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/util/Pair.java
+++ b/spock-core/src/main/java/org/spockframework/util/Pair.java
@@ -17,7 +17,7 @@ package org.spockframework.util;
 import java.util.Objects;
 
 /**
- * An immmutable pair of elements.
+ * An immutable pair of elements.
  *
  * @author Peter Niederwieser
  */
@@ -45,10 +45,7 @@ public class Pair<E1, E2> {
 
     Pair tuple2 = (Pair) other;
 
-    if (!Objects.equals(first, tuple2.first)) return false;
-    if (!Objects.equals(second, tuple2.second)) return false;
-
-    return true;
+    return Objects.equals(first, tuple2.first) && Objects.equals(second, tuple2.second);
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/util/Pair.java
+++ b/spock-core/src/main/java/org/spockframework/util/Pair.java
@@ -14,6 +14,8 @@
 
 package org.spockframework.util;
 
+import java.util.Objects;
+
 /**
  * An immmutable pair of elements.
  *
@@ -43,8 +45,8 @@ public class Pair<E1, E2> {
 
     Pair tuple2 = (Pair) other;
 
-    if (first != null ? !first.equals(tuple2.first) : tuple2.first != null) return false;
-    if (second != null ? !second.equals(tuple2.second) : tuple2.second != null) return false;
+    if (!Objects.equals(first, tuple2.first)) return false;
+    if (!Objects.equals(second, tuple2.second)) return false;
 
     return true;
   }

--- a/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
@@ -74,7 +74,7 @@ public abstract class ReflectionUtil {
   }
 
   public static <T extends Annotation> List<T> collectAnnotationRecursive(Class<?> cls, Class<T> annotationClass) {
-    return collectAnnotationRecursive(cls, annotationClass, new ArrayList<T>());
+    return collectAnnotationRecursive(cls, annotationClass, new ArrayList<>());
   }
 
   private static <T extends Annotation> List<T> collectAnnotationRecursive(Class<?> cls, Class<T> annotationClass,

--- a/spock-specs/src/test3.0/groovy/org/spockframework/smoke/lamba/LambdaSpec.groovy
+++ b/spock-specs/src/test3.0/groovy/org/spockframework/smoke/lamba/LambdaSpec.groovy
@@ -2,6 +2,7 @@ package org.spockframework.smoke.lamba
 
 import spock.lang.Specification
 
+import static java.util.Comparator.comparingInt
 import static java.util.stream.Collectors.toList
 
 class LambdaSpec extends Specification {
@@ -18,7 +19,7 @@ class LambdaSpec extends Specification {
 
   def "allow to use method reference in spec"() {
     when:
-    List<String> namesFromShortest = names.stream().sorted(Comparator.comparingInt(String::length).reversed()).collect(toList())
+    List<String> namesFromShortest = names.stream().sorted(comparingInt(String::length).reversed()).collect(toList())
 
     then:
     namesFromShortest == ["Barney", "Wilma", "Betty", "Fred"]


### PR DESCRIPTION
Working on #1128 my eyes was irritated by the (sensible) Idea warnings in `SpecInfoBuilder` related to sorting and the usage of lambdas/method references instead of anonymous classes. As Spock 2 requires Java 8+ it can be improved.

To simplify it and do it in a batch I applied Java 8 (and Java 7 along the way) basic refactorings suggested by Idea in spock-core. I ran through them briefly and they look ok. All tests still pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1138)
<!-- Reviewable:end -->
