### PR TITLE
Add tests for new groovy.test.NotYetImplemented

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
   variants = [2.5, 3.0]
   variant = System.getProperty("variant") as BigDecimal ?: variants.first()
   if (variant == 2.5) {
-      groovyVersion = "2.5.8"
+      groovyVersion = "2.5.11"
       minGroovyVersion = "2.5.0"
       maxGroovyVersion = "2.9.99"
     } else if (variant == 3.0) {

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
       minGroovyVersion = "2.5.0"
       maxGroovyVersion = "2.9.99"
     } else if (variant == 3.0) {
-      groovyVersion = "3.0.2"
+      groovyVersion = "3.0.3"
       minGroovyVersion = "3.0.0"
       maxGroovyVersion = "3.9.99"
     } else {

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -188,6 +188,8 @@ Spy(constructorArgs: [null as String, (Pattern) null])
 def "I'll run everywhere but on Windows"() { ... }
 ----
 
+- Upgrade Groovy to 2.5.11 (improved Java 14+ support) and 3.0.3 (fixes #1127)
+
 - Upgrade JUnit 4 to 4.13 (in `spock-junit4`)
 
 - Upgrade Hamcrest to 2.2 (from 1.3 provided previously by `junit4.jar`)

--- a/spock-junit4/src/test/groovy/org/spockframework/smoke/groovy/UsageOfDeprecatedNotYetImplemented.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/smoke/groovy/UsageOfDeprecatedNotYetImplemented.groovy
@@ -17,17 +17,14 @@ package org.spockframework.smoke.groovy
 
 import groovy.transform.NotYetImplemented
 import junit.framework.AssertionFailedError
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.FailsWith
 
-//TODO: Handle also new groovy.transform.NotYetImplemented in Groovy 3 - https://github.com/spockframework/spock/issues/1127
-class UsageOfNotYetImplemented extends Specification {
-
-  @FailsWith(AssertionFailedError)
-  @NotYetImplemented
-  def "not allowed to pass"() {
-    expect: true
-  }
+//See UsageOfNotYetImplemented for new groovy.test.NotYetImplemented tests
+@Issue("https://github.com/spockframework/spock/issues/1127")
+@Deprecated
+class UsageOfDeprecatedNotYetImplemented extends Specification {
 
   @NotYetImplemented
   def "expected to fail (legacy transformation)"() {

--- a/spock-specs/specs.gradle
+++ b/spock-specs/specs.gradle
@@ -11,6 +11,9 @@ configurations {
 dependencies {
   testCompile project(":spock-core")
   testCompile libs.groovySql  //for groovy.sql.Sql
+  testCompile(libs.groovyTest) {  //for groovy.test.NotYetImplemented
+    exclude group: 'junit'
+  }
 
   testRuntime libs.asm
   testRuntime libs.bytebuddy

--- a/spock-specs/src/test3.0/groovy/org/spockframework/smoke/UsageOfNotYetImplemented.groovy
+++ b/spock-specs/src/test3.0/groovy/org/spockframework/smoke/UsageOfNotYetImplemented.groovy
@@ -1,0 +1,38 @@
+package org.spockframework.smoke
+
+import groovy.test.NotYetImplemented
+import org.opentest4j.AssertionFailedError
+import org.spockframework.runtime.GroovyRuntimeUtil
+import spock.lang.FailsWith
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Specification
+
+//Those tests requires Groovy 3.0.3+, see UsageOfNotYetImplementedJUnit4 for deprecated groovy.transform.NotYetImplemented tests
+@Issue(["https://github.com/spockframework/spock/issues/1127", "https://issues.apache.org/jira/browse/GROOVY-9492"])
+@Requires({ GroovyRuntimeUtil.isGroovy3orNewer() })
+class UsageOfNotYetImplemented extends Specification {
+
+  @NotYetImplemented
+  def "expected to fail"() {
+    expect: false
+  }
+
+  @NotYetImplemented
+  def "allowed to raise arbitrary exception"() {
+    setup:
+    throw new IOException("ouch")
+  }
+
+  @FailsWith(AssertionError)
+  @NotYetImplemented
+  def "not allowed to pass"() {
+    expect: true
+  }
+
+  @FailsWith(AssertionFailedError)
+  @NotYetImplemented(exception = AssertionFailedError)
+  def "not allowed to pass with custom exception type"() {
+    expect: true
+  }
+}


### PR DESCRIPTION
They requires Groovy 3.0.3 to pass, see:
https://issues.apache.org/jira/browse/GROOVY-9492

Fixes #1127. It also closes #1067 which I fixed at the Groovy side in 3.0.3.

To do not generate separate PR I also bumbed Groovy 2.5.8 to 2.5.11 for better Java 14+ support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1150)
<!-- Reviewable:end -->
