### PR TITLE
Ability to disable Groovy version check

### DIFF
--- a/docs/known_issues.adoc
+++ b/docs/known_issues.adoc
@@ -143,3 +143,10 @@ Math.signum(a <=> b) == result
 ----
 
 This issue was introduced by groovy-2.5, previous versions worked fine.
+
+
+== Groovy version compatibility
+
+By default, Spock can only be used with the Groovy version it was compiled with. It means that Spock `2.0-groovy-2.5` can only executed with Groovy 2.5.x, `2.0-groovy-3.0` with 3.0.x, etc. That restriction was introduced to help users find an appropriate Groovy variant and limit number of reported invalid issues caused by the incompatibilities between the major Groovy versions.
+
+However, occasionally it might be useful to be able to play with the next (officially unsupported) Groovy version, especially that usually, in the majority of cases, it should just work fine. Starting with Groovy 2.0 that restriction has been relaxed in the Spock SNAPSHOT versions. In addition, the early adopters can implicitly disable that check - also in the production versions - providing the system property `-Dspock.iKnowWhatImDoing.disableGroovyVersionCheck=true`. **Please bear in mind, however, that it is completely unsupported and might lead to some unexpected errors**.

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -207,6 +207,8 @@ Spy(constructorArgs: [null as String, (Pattern) null])
 def "I'll run everywhere but on Windows"() { ... }
 ----
 
+- Execution with an unsupported Groovy version can allowed with `-Dspock.iKnowWhatImDoing.disableGroovyVersionCheck=true`
+
 - Upgrade Groovy to 2.5.11 (improved Java 14+ support) and 3.0.3 (fixes #1127)
 
 - Upgrade JUnit 4 to 4.13 (in `spock-junit4`)

--- a/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
@@ -40,7 +40,7 @@ import org.codehaus.groovy.transform.*;
 @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
 public class SpockTransform implements ASTTransformation {
   public SpockTransform() {
-    VersionChecker.checkGroovyVersion("compiler plugin");
+    new VersionChecker().checkGroovyVersion("compiler plugin");
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/util/VersionChecker.java
+++ b/spock-core/src/main/java/org/spockframework/util/VersionChecker.java
@@ -14,16 +14,38 @@
 
 package org.spockframework.util;
 
-public class VersionChecker {
-  private static final boolean compatibleGroovyVersion =
-      SpockReleaseInfo.isCompatibleGroovyVersion(GroovyReleaseInfo.getVersion());
+import static java.lang.String.format;
 
-  public static void checkGroovyVersion(String whoIsChecking) {
-    if (!compatibleGroovyVersion) throw new IncompatibleGroovyVersionException(String.format(
-"The Spock %s cannot execute because Spock %s is not compatible with Groovy %s. For more information, see http://docs.spockframework.org\n" +
-"Spock artifact: %s\n" +
-"Groovy artifact: %s",
-        whoIsChecking, SpockReleaseInfo.getVersion(), GroovyReleaseInfo.getVersion(),
-        SpockReleaseInfo.getArtifactPath(), GroovyReleaseInfo.getArtifactPath()));
+public class VersionChecker {
+  //visibility for testing
+  static final String DISABLE_GROOVY_VERSION_CHECK_PROPERTY_NAME = "spock.iKnowWhatImDoing.disableGroovyVersionCheck";
+
+  private static final boolean compatibleGroovyVersion = SpockReleaseInfo.isCompatibleGroovyVersion(GroovyReleaseInfo.getVersion());
+
+  public void checkGroovyVersion(String whoIsChecking) {
+    if (!isCompatibleGroovyVersion()) {
+      if (isVersionCheckDisabled()) {
+        System.err.println(format("Executing Spock %s with NOT compatible Groovy version %s due to set %s system property set. " +
+          "This is unsupported and may result in weird runtime errors!", SpockReleaseInfo.getVersion(),
+          GroovyReleaseInfo.getVersion(), DISABLE_GROOVY_VERSION_CHECK_PROPERTY_NAME));
+      } else {
+        throw new IncompatibleGroovyVersionException(format(
+        "The Spock %s cannot execute because Spock %s is not compatible with Groovy %s. For more information (including enforce mode), " +
+        "see http://docs.spockframework.org (section 'Known Issues').\n" +
+        "Spock artifact: %s\n" +
+        "Groovy artifact: %s",
+                whoIsChecking, SpockReleaseInfo.getVersion(), GroovyReleaseInfo.getVersion(),
+                SpockReleaseInfo.getArtifactPath(), GroovyReleaseInfo.getArtifactPath()));
+      }
+    }
+  }
+
+  //visibility for testing
+  boolean isCompatibleGroovyVersion() {
+    return compatibleGroovyVersion;
+  }
+
+  private boolean isVersionCheckDisabled() {
+    return "true".equals(System.getProperty(DISABLE_GROOVY_VERSION_CHECK_PROPERTY_NAME));
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/GlobalExtensionRegistrySpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/GlobalExtensionRegistrySpec.groovy
@@ -19,10 +19,8 @@ package org.spockframework.runtime
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
 import org.spockframework.runtime.extension.AbstractGlobalExtension
 import org.spockframework.runtime.extension.ExtensionException
-import org.spockframework.runtime.extension.IGlobalExtension
 import org.spockframework.runtime.extension.builtin.IgnoreExtension
 import org.spockframework.runtime.extension.builtin.IncludeExcludeExtension
-import org.spockframework.runtime.model.SpecInfo
 import org.spockframework.util.InternalSpockError
 
 import spock.config.ConfigurationObject

--- a/spock-specs/src/test/groovy/org/spockframework/util/VersionCheckerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/VersionCheckerSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spockframework.util
+
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class VersionCheckerSpec extends Specification {
+
+  private static final String WHO_IS_CHECKING = "test"
+
+  private VersionChecker versionChecker = Spy()
+
+  void "not throw exception on compatible Groovy version"() {
+    when:
+    versionChecker.checkGroovyVersion(WHO_IS_CHECKING)
+
+    then:
+    noExceptionThrown()
+  }
+
+  void "throw exception on incompatible Groovy version"() {
+    given:
+    versionChecker.isCompatibleGroovyVersion() >> false
+
+    when:
+    versionChecker.checkGroovyVersion(WHO_IS_CHECKING)
+
+    then:
+    thrown(IncompatibleGroovyVersionException)
+  }
+
+  @RestoreSystemProperties
+  void "suppress throwing exception on incompatible Groovy version if check is disabled"() {
+    given:
+    versionChecker.isCompatibleGroovyVersion() >> false
+
+    and:
+    System.setProperty(VersionChecker.DISABLE_GROOVY_VERSION_CHECK_PROPERTY_NAME, "true");
+
+    when:
+    versionChecker.checkGroovyVersion(WHO_IS_CHECKING)
+
+    then:
+    noExceptionThrown()
+  }
+}


### PR DESCRIPTION
In production Spock version. For early adopters of the further Groovy
versions (such as 4.x). And to use in the Groovy 4.x build itself - instead of the snapshot version.

Before Spock 2.0-M1 people were able to use only 1.3-SNAPSHOT with Groovy 3, even though, in the majority of cases, it just worked.

If you have a good idea how to test it in a better way, please let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1164)
<!-- Reviewable:end -->
