### PR TITLE
Fix Hamcrest dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     groovySql           : [group: 'org.codehaus.groovy', name: 'groovy-sql', version: groovyVersion], //for some Spring and Unitils tests
     groovyTest          : [group: 'org.codehaus.groovy', name: 'groovy-test', version: groovyVersion], //for @NotYetImplemented
     h2database          : [group: 'com.h2database', name: 'h2', version: '1.4.200'],
-    hamcrest            : [group: 'org.hamcrest', name: 'hamcrest-core', version: '2.2'],
+    hamcrest            : [group: 'org.hamcrest', name: 'hamcrest', version: '2.2'],
     jaxb                : [group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'],
     junit4              : [group: 'junit', name: 'junit', version: '4.13'],
     junitBom            : [group: 'org.junit', name: 'junit-bom', version: '5.7.0-M1'],


### PR DESCRIPTION
The dependency hamcrest-core is deprecated. The right artifact name is just hamcrest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1181)
<!-- Reviewable:end -->
