### PR TITLE
Fix name clashes where variables that are named like method calls destroy the method call (#1200)

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -17,6 +17,8 @@
 package org.spockframework.compiler;
 
 import org.codehaus.groovy.runtime.wrappers.PojoWrapper;
+import org.spockframework.lang.SpecInternals;
+import org.spockframework.mock.runtime.MockController;
 import org.spockframework.runtime.*;
 import org.spockframework.runtime.extension.RepeatedExtensionAnnotations;
 import org.spockframework.runtime.model.*;
@@ -34,9 +36,11 @@ import org.codehaus.groovy.ast.*;
 public class AstNodeCache {
   public final ClassNode SpockRuntime = ClassHelper.makeWithoutCaching(SpockRuntime.class);
   public final ClassNode ValueRecorder = ClassHelper.makeWithoutCaching(ValueRecorder.class);
-  public final ClassNode ErrorCollector = ClassHelper.makeWithoutCaching(org.spockframework.runtime.ErrorCollector.class);
+  public final ClassNode ErrorCollector = ClassHelper.makeWithoutCaching(ErrorCollector.class);
   public final ClassNode Specification = ClassHelper.makeWithoutCaching(Specification.class);
-  public final ClassNode SpecInternals = ClassHelper.makeWithoutCaching(org.spockframework.lang.SpecInternals.class);
+  public final ClassNode SpecInternals = ClassHelper.makeWithoutCaching(SpecInternals.class);
+  public final ClassNode MockController = ClassHelper.makeWithoutCaching(MockController.class);
+  public final ClassNode SpecificationContext = ClassHelper.makeWithoutCaching(SpecificationContext.class);
 
   public final MethodNode SpecInternals_GetSpecificationContext =
       SpecInternals.getDeclaredMethods(Identifiers.GET_SPECIFICATION_CONTEXT).get(0);
@@ -53,6 +57,9 @@ public class AstNodeCache {
   public final MethodNode SpockRuntime_VerifyMethodCondition =
       SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.VERIFY_METHOD_CONDITION).get(0);
 
+  public final MethodNode SpockRuntime_DespreadList =
+      SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.DESPREAD_LIST).get(0);
+
   public final MethodNode ValueRecorder_Reset =
       ValueRecorder.getDeclaredMethods(org.spockframework.runtime.ValueRecorder.RESET).get(0);
 
@@ -68,6 +75,36 @@ public class AstNodeCache {
   public final MethodNode ErrorCollector_Validate =
       ErrorCollector.getDeclaredMethods(org.spockframework.runtime.ErrorCollector.VALIDATE_COLLECTED_ERRORS).get(0);
 
+  public final MethodNode MockController_AddInteraction =
+      MockController.getDeclaredMethods(org.spockframework.mock.runtime.MockController.ADD_INTERACTION).get(0);
+
+  public final MethodNode MockController_EnterScope =
+      MockController.getDeclaredMethods(org.spockframework.mock.runtime.MockController.ENTER_SCOPE).get(0);
+
+  public final MethodNode MockController_AddBarrier =
+      MockController.getDeclaredMethods(org.spockframework.mock.runtime.MockController.ADD_BARRIER).get(0);
+
+  public final MethodNode MockController_LeaveScope =
+      MockController.getDeclaredMethods(org.spockframework.mock.runtime.MockController.LEAVE_SCOPE).get(0);
+
+  public final MethodNode SpecificationContext_GetMockController =
+      SpecificationContext.getDeclaredMethods(org.spockframework.runtime.SpecificationContext.GET_MOCK_CONTROLLER).get(0);
+
+  public final MethodNode SpecificationContext_SetThrownException =
+      SpecificationContext.getDeclaredMethods(org.spockframework.runtime.SpecificationContext.SET_THROWN_EXCEPTION).get(0);
+
+  public final MethodNode SpecificationContext_GetSharedInstance =
+      SpecificationContext.getDeclaredMethods(org.spockframework.runtime.SpecificationContext.GET_SHARED_INSTANCE).get(0);
+
+  public final MethodNode List_Get =
+      ClassHelper.LIST_TYPE.getDeclaredMethods("get").get(0);
+
+  public final MethodNode Class_IsInstance =
+      ClassHelper.CLASS_Type.getDeclaredMethods("isInstance").get(0);
+
+  public final MethodNode Closure_Call =
+      ClassHelper.CLOSURE_TYPE.getDeclaredMethod("call", Parameter.EMPTY_ARRAY);
+
   // annotations and annotation elements
   public final ClassNode RepeatedExtensionAnnotations = ClassHelper.makeWithoutCaching(RepeatedExtensionAnnotations.class);
   public final ClassNode SpecMetadata = ClassHelper.makeWithoutCaching(SpecMetadata.class);
@@ -81,7 +118,50 @@ public class AstNodeCache {
   // mocking API
   public final ClassNode InteractionBuilder = ClassHelper.makeWithoutCaching(org.spockframework.mock.runtime.InteractionBuilder.class);
 
+  public final MethodNode InteractionBuilder_SetRangeCount =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.SET_RANGE_COUNT).get(0);
+  public final MethodNode InteractionBuilder_SetFixedCount =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.SET_FIXED_COUNT).get(0);
+  public final MethodNode InteractionBuilder_AddEqualTarget =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_EQUAL_TARGET).get(0);
+  public final MethodNode InteractionBuilder_AddWildcardTarget =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_WILDCARD_TARGET).get(0);
+  public final MethodNode InteractionBuilder_AddEqualMethodName =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_EQUAL_METHOD_NAME).get(0);
+  public final MethodNode InteractionBuilder_AddRegexMethodName =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_REGEX_METHOD_NAME).get(0);
+  public final MethodNode InteractionBuilder_AddEqualPropertyName =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_EQUAL_PROPERTY_NAME).get(0);
+  public final MethodNode InteractionBuilder_AddRegexPropertyName =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_REGEX_PROPERTY_NAME).get(0);
+  public final MethodNode InteractionBuilder_SetArgListKind_boolean_boolean =
+    InteractionBuilder.getDeclaredMethod(org.spockframework.mock.runtime.InteractionBuilder.SET_ARG_LIST_KIND, new Parameter[] {
+      new Parameter(ClassHelper.boolean_TYPE, "isPositional"),
+      new Parameter(ClassHelper.boolean_TYPE, "isMixed")
+    });
+  public final MethodNode InteractionBuilder_AddArgName =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_ARG_NAME).get(0);
+  public final MethodNode InteractionBuilder_NegateLastArg =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.NEGATE_LAST_ARG).get(0);
+  public final MethodNode InteractionBuilder_TypeLastArg =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.TYPE_LAST_ARG).get(0);
+  public final MethodNode InteractionBuilder_AddCodeArg =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_CODE_ARG).get(0);
+  public final MethodNode InteractionBuilder_AddEqualArg =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_EQUAL_ARG).get(0);
+  public final MethodNode InteractionBuilder_AddIterableResponse =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_ITERABLE_RESPONSE).get(0);
+  public final MethodNode InteractionBuilder_AddCodeResponse =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_CODE_RESPONSE).get(0);
+  public final MethodNode InteractionBuilder_AddConstantResponse =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.ADD_CONSTANT_RESPONSE).get(0);
+  public final MethodNode InteractionBuilder_Build =
+    InteractionBuilder.getDeclaredMethods(org.spockframework.mock.runtime.InteractionBuilder.BUILD).get(0);
+
   // external types
   public final ClassNode Throwable = ClassHelper.makeWithoutCaching(Throwable.class);
   public final ClassNode PojoWrapper = ClassHelper.makeWithoutCaching(PojoWrapper.class);
+
+  public final MethodNode Throwable_AddSuppressed =
+    Throwable.getDeclaredMethods("addSuppressed").get(0);
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
@@ -57,9 +57,7 @@ public class SpockTransform implements ASTTransformation {
       SourceLookup sourceLookup = new SourceLookup(sourceUnit);
 
       try {
-        ModuleNode module = (ModuleNode) nodes[0];
-        @SuppressWarnings("unchecked")
-        List<ClassNode> classes = module.getClasses();
+        List<ClassNode> classes = sourceUnit.getAST().getClasses();
 
         for (ClassNode clazz : classes)
           if (isSpec(clazz)) processSpec(sourceUnit, clazz, errorReporter, sourceLookup);

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/NameClashes.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/NameClashes.groovy
@@ -1,0 +1,250 @@
+package org.spockframework.smoke
+
+import spock.lang.FailsWith
+import spock.lang.Issue
+import spock.lang.Rollup
+import spock.lang.Specification
+
+@Issue("https://github.com/spockframework/spock/issues/1200")
+class NameClashes extends Specification {
+  @Rollup
+  def 'getAt data variable in multi assignment does not clash with getAt method in data processor method'() {
+    expect:
+    true
+
+    where:
+    [getAt, foo] << [[_, _]]
+  }
+
+  def 'isInstance does not clash with rewritten instanceof condition'() {
+    def isInstance = _
+    expect:
+    _ instanceof Object
+  }
+
+  def 'record does not clash with rewritten condition'() {
+    def record = _
+    expect:
+    true
+  }
+
+  def 'startRecordingValue does not clash with rewritten condition'() {
+    def startRecordingValue = _
+    expect:
+    true
+  }
+
+  def 'despreadList does not clash with rewritten condition'() {
+    def despreadList = _
+    expect:
+    _.toString(*[])
+  }
+
+  def 'realizeNas does not clash with rewritten condition'() {
+    def realizeNas = _
+    expect:
+    _.toString()
+  }
+
+  def 'reset does not clash with rewritten condition'() {
+    def reset = _
+    expect:
+    true
+  }
+
+  def 'addInteraction does not clash with rewritten interaction'() {
+    def addInteraction = _
+    _ * _
+    expect:
+    true
+  }
+
+  def 'setRangeCount does not clash with rewritten interaction'() {
+    def setRangeCount = _
+    (0..Integer.MAX_VALUE) * _
+    expect:
+    true
+  }
+
+  def 'setFixedCount does not clash with rewritten interaction'() {
+    def setFixedCount = _
+    _ * _
+    expect:
+    true
+  }
+
+  def 'addEqualTarget does not clash with rewritten interaction'() {
+    def addEqualTarget = _
+    _ * _._()
+    expect:
+    true
+  }
+
+  def 'addWildcardTarget does not clash with rewritten interaction'() {
+    def addWildcardTarget = _
+    _ * _
+    expect:
+    true
+  }
+
+  def 'addEqualMethodName does not clash with rewritten interaction'() {
+    def addEqualMethodName = _
+    _ * _
+    expect:
+    true
+  }
+
+  def 'addRegexMethodName does not clash with rewritten interaction'() {
+    def addRegexMethodName = _
+    _ * _./.+/()
+    expect:
+    true
+  }
+
+  def 'addEqualPropertyName does not clash with rewritten interaction'() {
+    def addEqualPropertyName = _
+    _ * _._
+    expect:
+    true
+  }
+
+  def 'addRegexPropertyName does not clash with rewritten interaction'() {
+    def addRegexPropertyName = _
+    _ * _./.+/
+    expect:
+    true
+  }
+
+  def 'setArgListKind does not clash with rewritten interaction'() {
+    def setArgListKind = _
+    _ * _._()
+    expect:
+    true
+  }
+
+  def 'addArgName does not clash with rewritten interaction'() {
+    def addArgName = _
+    _ * _._(_: _)
+    expect:
+    true
+  }
+
+  def 'negateLastArg does not clash with rewritten interaction'() {
+    def negateLastArg = _
+    _ * _._(!_)
+    expect:
+    true
+  }
+
+  def 'typeLastArg does not clash with rewritten interaction'() {
+    def typeLastArg = _
+    _ * _._(_ as Object)
+    expect:
+    true
+  }
+
+  def 'addCodeArg does not clash with rewritten interaction'() {
+    def addCodeArg = _
+    _ * _._ {}
+    expect:
+    true
+  }
+
+  def 'addEqualArg does not clash with rewritten interaction'() {
+    def addEqualArg = _
+    _ * _._(_)
+    expect:
+    true
+  }
+
+  def 'addIterableResponse does not clash with rewritten interaction'() {
+    def addIterableResponse = _
+    _ >>> _
+    expect:
+    true
+  }
+
+  def 'addCodeResponse does not clash with rewritten interaction'() {
+    def addCodeResponse = _
+    _ >> {}
+    expect:
+    true
+  }
+
+  def 'addConstantResponse does not clash with rewritten interaction'() {
+    def addConstantResponse = _
+    _ >> _
+    expect:
+    true
+  }
+
+  def 'build does not clash with rewritten interaction'() {
+    def build = _
+    _ * _
+    expect:
+    true
+  }
+
+  def 'leaveScope does not clash with rewritten specification'() {
+    def leaveScope = _
+    expect:
+    true
+  }
+
+  def 'enterScope does not clash with rewritten specification'() {
+    def enterScope = _
+    when:
+    _.toString()
+    then:
+    _ * _
+  }
+
+  def 'addBarrier does not clash with rewritten specification'() {
+    def addBarrier = _
+    when:
+    _.toString()
+    then:
+    _ * _
+    then:
+    _ * _
+  }
+
+  @FailsWith(Error)
+  def 'addSuppressed does not clash with rewritten specification'() {
+    def addSuppressed = _
+    expect:
+    throw new Error()
+    cleanup:
+    throw new Exception()
+  }
+
+  def 'getMockController does not clash with rewritten specification'() {
+    def getMockController = _
+    expect:
+    true
+  }
+
+  def 'setThrownException does not clash with rewritten specification'() {
+    def setThrownException = _
+    when:
+    throw new Exception()
+    then:
+    thrown(Exception)
+  }
+
+  @Rollup
+  @FailsWith(Error)
+  def 'validateCollectedErrors does not clash with rewritten specification'() {
+    expect:
+    true
+    throw new Error()
+    where:
+    validateCollectedErrors = _
+  }
+
+  def 'getSpecificationContext does not clash with rewritten specification'() {
+    def getSpecificationContext = _
+    expect:
+    true
+  }
+}

--- a/spock-spring/src/test/groovy/org/spockframework/spring/ScopedBeans.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/ScopedBeans.groovy
@@ -40,7 +40,7 @@ class SpecWithScope extends Specification {
   def "no exception"() {
     expect:
     true
-  }  
+  }
 }
 '''
 
@@ -68,7 +68,7 @@ class SpecWithScopes extends Specification {
   def "this will fail"() {
     expect:
     true
-  }  
+  }
 }
 '''
 
@@ -98,10 +98,10 @@ class SpecWithScopes extends Specification {
   def "this will not fail"() {
     when:
     service.generateQuickBrownFox()
-    
+
     then:
     1 * service.generateQuickBrownFox()
-  }  
+  }
 }
 ''')
 
@@ -113,7 +113,7 @@ class SpecWithScopes extends Specification {
   }
 
 
-  def "scopes to scan can be defined"(){
+  def "  scopes to scan can be defined"(){
     def runner = new EmbeddedSpecRunner()
 
     when:
@@ -135,10 +135,10 @@ class SpecWithScopes extends Specification {
   def "this will not fail"() {
     when:
     service.generateQuickBrownFox()
-    
+
     then:
     1 * service.generateQuickBrownFox()
-  }  
+  }
 }
 ''')
 


### PR DESCRIPTION
This happened due to a buggy VariableScopeVisitor as reported in https://issues.apache.org/jira/browse/GROOVY-9651

fixes #1200 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1201)
<!-- Reviewable:end -->
