### PR TITLE
Add FAQ to documentation

### DIFF
--- a/docs/all_in_one.adoc
+++ b/docs/all_in_one.adoc
@@ -23,4 +23,6 @@ include::release_notes.adoc[leveloffset=+1]
 
 include::migration_guide.adoc[leveloffset=+1]
 
+include::faq.adoc[leveloffset=+1]
+
 include::known_issues.adoc[leveloffset=+1]

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -1,0 +1,24 @@
+= Frequently Asked Questions (FAQ)
+include::include.adoc[]
+
+== What are Spock's optional dependencies used for?
+
+Spock runs fine without optional dependencies, hence the term _optional_. So what are they used for?
+
+  * Objenesis (artifact `org.objenesis:objenesis`) is required for mocking classes without default constructors.
+  * Either CGLIB (artifact `cglib:cglib-nodep`) or ByteBuddy (artifact `net.bytebuddy:byte-buddy`) are required for
+    mocking classes and not just interfaces.
+
+See also <<interaction_based_testing.adoc#_mocking_classes,Mocking Classes>>.
+
+== Why are there two options (CGLIB vs ByteBuddy) for mocking classes?
+
+The main reason is backwards compatibility. CGLIB came first historically, ByteBuddy was added later. Both libraries
+basically provide identical features from a Spock user's perspective.
+
+If you are starting with Spock now, we recommend ByteBuddy as our preferred choice.
+
+As of today there are no plans to remove CGLIB anytime soon, because the maintenance effort is relatively low. So you
+may safely continue to use CGLIB if e.g. your tests use it in another context already. If you have no compelling reasons
+to avoid ByteBuddy, you can just switch from CGLIB to ByteBuddy in an existing project. Your tests should continue to
+run like before.

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -6,19 +6,19 @@ include::include.adoc[]
 Spock runs fine without optional dependencies, hence the term _optional_. So what are they used for?
 
   * Objenesis (artifact `org.objenesis:objenesis`) is required for mocking classes without default constructors.
-  * Either ByteBuddy (artifact `net.bytebuddy:byte-buddy`) or CGLIB (artifact `cglib:cglib-nodep`) are required for
-    mocking classes and not just interfaces.
+  * Either ByteBuddy (artifact `net.bytebuddy:byte-buddy`) or CGLIB (artifact `cglib:cglib-nodep`) are required for mocking classes and not just interfaces.
 
 See also <<interaction_based_testing.adoc#_mocking_classes,Mocking Classes>>.
 
 == Why are there two options (ByteBuddy vs CGLIB) for mocking classes?
 
-The main reason is backwards compatibility. CGLIB came first historically, ByteBuddy was added later. Both libraries
-basically provide identical features from a Spock user's perspective.
+The main reason is backwards compatibility.
+CGLIB came first historically, ByteBuddy was added later.
+Both libraries basically provide identical features from a Spock user's perspective.
 
 If you are starting with Spock now, we recommend ByteBuddy as our preferred choice.
 
-CGLIB is in legacy support mode, we will support it as long as the maintenance effort is relatively low. So you
-may continue to use CGLIB for now if e.g. your tests use it in another context already. If you have no compelling reasons
-to avoid ByteBuddy, you can just switch from CGLIB to ByteBuddy in an existing project. Your tests should continue to
-run like before.
+CGLIB is in legacy support mode, we will support it as long as the maintenance effort is relatively low.
+So you may continue to use CGLIB for now if e.g. your tests use it in another context already.
+If you have no compelling reasons to avoid ByteBuddy, you can just switch from CGLIB to ByteBuddy in an existing project.
+Your tests should continue to run like before.

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -6,7 +6,7 @@ include::include.adoc[]
 Spock runs fine without optional dependencies, hence the term _optional_. So what are they used for?
 
   * Objenesis (artifact `org.objenesis:objenesis`) is required for mocking classes without default constructors.
-  * Either CGLIB (artifact `cglib:cglib-nodep`) or ByteBuddy (artifact `net.bytebuddy:byte-buddy`) are required for
+  * Either ByteBuddy (artifact `net.bytebuddy:byte-buddy`) or CGLIB (artifact `cglib:cglib-nodep`) are required for
     mocking classes and not just interfaces.
 
 See also <<interaction_based_testing.adoc#_mocking_classes,Mocking Classes>>.

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -11,7 +11,7 @@ Spock runs fine without optional dependencies, hence the term _optional_. So wha
 
 See also <<interaction_based_testing.adoc#_mocking_classes,Mocking Classes>>.
 
-== Why are there two options (CGLIB vs ByteBuddy) for mocking classes?
+== Why are there two options (ByteBuddy vs CGLIB) for mocking classes?
 
 The main reason is backwards compatibility. CGLIB came first historically, ByteBuddy was added later. Both libraries
 basically provide identical features from a Spock user's perspective.

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -18,7 +18,7 @@ basically provide identical features from a Spock user's perspective.
 
 If you are starting with Spock now, we recommend ByteBuddy as our preferred choice.
 
-As of today there are no plans to remove CGLIB anytime soon, because the maintenance effort is relatively low. So you
-may safely continue to use CGLIB if e.g. your tests use it in another context already. If you have no compelling reasons
+CGLIB is in legacy support mode, we will support it as long as the maintenance effort is relatively low. So you
+may continue to use CGLIB for now if e.g. your tests use it in another context already. If you have no compelling reasons
 to avoid ByteBuddy, you can just switch from CGLIB to ByteBuddy in an existing project. Your tests should continue to
 run like before.

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -11,6 +11,7 @@ include::include.adoc[]
 . <<modules.adoc#,Modules>>
 . <<release_notes.adoc#,Release Notes>>
 . <<migration_guide.adoc#,Migration Guide>>
+. <<faq.adoc#,Frequently Asked Questions (FAQ)>>
 . <<known_issues.adoc#,Known Issues>>
 
 <<all_in_one.adoc#,Single Page Documentation>>


### PR DESCRIPTION
For now, there are two FAQ items explaining optional dependencies in general and
explaining why there are two class mocking variants ByteBuddy vs. CGLIB.

Closes #1165.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1212)
<!-- Reviewable:end -->
