### PR TITLE
Improve 'TempDir' extension documentation

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -447,10 +447,9 @@ def ignoreMyExceptions
 
 === TempDir
 
-In order to generate a temporary directory for test and delete it after test,
-annotate a member field of type `java.io.File`, `java.nio.file.Path`
-or untyped using `def` in a spec class (`def` will inject a `Path`). If the annotated field is `@Shared`,
-the temporary directory will be shared in the corresponding specification, otherwise every
+In order to generate a temporary directory for test and delete it after test, annotate a member field of type
+`java.io.File`, `java.nio.file.Path` or untyped using `def` in a spec class (`def` will inject a `Path`). If the
+annotated field is `@Shared`, the temporary directory will be shared in the corresponding specification, otherwise every
 feature method and every iteration per parametrized feature method will have their own temporary directories:
 
 [source,groovy,indent=0]
@@ -458,11 +457,10 @@ feature method and every iteration per parametrized feature method will have the
 include::{sourcedir}/extension/TempDirDocSpec.groovy[tag=example]
 ----
 
-If you want to customize the parent directory for temporary directories,
-you can use the <<Spock Configuration File>>.
+If you want to customize the parent directory for temporary directories, you can use the <<Spock Configuration File>>.
 
-If `keep` is set to `true`, Spock will not delete temporary directories after tests.
-The default value is taken from system property `spock.tempDir.keep` or `false`, if undefined.
+If `keep` is set to `true`, Spock will not delete temporary directories after tests. The default value is taken from
+system property `spock.tempDir.keep` or `false`, if undefined.
 
 .Temporary Directory Configuration
 [source,groovy]

--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -447,24 +447,24 @@ def ignoreMyExceptions
 
 === TempDir
 
-To generate a temp directory for test and delete it after test,
+In order to generate a temporary directory for test and delete it after test,
 annotate a member field of type `java.io.File`, `java.nio.file.Path`
-or untyped using `def` in a spec class (`def` will inject a `Path`). If the annotated field is shared,
-the temp directory will be shared in this spec, otherwise every
-iteration will have its own temp directory:
+or untyped using `def` in a spec class (`def` will inject a `Path`). If the annotated field is `@Shared`,
+the temporary directory will be shared in the corresponding specification, otherwise every
+feature method and every iteration per parametrized feature method will have their own temporary directories:
 
 [source,groovy,indent=0]
 ----
 include::{sourcedir}/extension/TempDirDocSpec.groovy[tag=example]
 ----
 
-If you want a customized parent directory to create temp directory,
-you can use the <<Spock Configuration File>> to set it up.
+If you want to customize the parent directory for temporary directories,
+you can use the <<Spock Configuration File>>.
 
-If the `keep` is set `true`, it will keep the temp directory after test,
-default is system property `spock.tempDir.keep` or `false` if it is not set.
+If `keep` is set to `true`, Spock will not delete temporary directories after tests.
+The default value is taken from system property `spock.tempDir.keep` or `false`, if undefined.
 
-.Temp Directory Configuration
+.Temporary Directory Configuration
 [source,groovy]
 ----
 tempdir {

--- a/spock-specs/src/test/groovy/org/spockframework/docs/extension/TempDirDocSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/extension/TempDirDocSpec.groovy
@@ -13,12 +13,12 @@ import java.nio.file.Path
 class TempDirDocSpec extends Specification {
 
 // tag::example[]
-  // all feature will share the same temp directory path1
+  // all features will share the same temp directory path1
   @TempDir
   @Shared
   Path path1
 
-  // every iteration will have its own path2
+  // all features and iterations will have their own path2
   @TempDir
   File path2
 


### PR DESCRIPTION
- Replace "temp directory" by "temporary directory" in plain prose
- Slightly improve wording
- Be more precise about non-@Shared fields resulting in one temp-dir per feature
  and/or iteration
- Update formatting width to 120 characters like in the rest of Spock's ADOCs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spockframework/spock/1213)
<!-- Reviewable:end -->
