### PR TITLE
Bump dependencies for Java 15 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ dist: precise # downgrade to avoid jdk7 SSL Bug https://github.com/docker-librar
 jdk: # if you modify these also modify the `javaVersions` list in build.gradle
   - oraclejdk8
   - openjdk11
-  - openjdk14
+  - openjdk15
 
 env:
   matrix:

--- a/build.gradle
+++ b/build.gradle
@@ -43,13 +43,13 @@ ext {
   }
   fullVersion = baseVersion + ((!snapshotVersion && milestone) ? "-M$milestone" : "") + "-groovy-$variant" + (snapshotVersion ? "-SNAPSHOT" : '')
   variantLessVersion = baseVersion + (snapshotVersion ? "-SNAPSHOT" : (milestone ? "-M$milestone" : ""))
-  javaVersions = [1.8, 11, 14] // ensure that latest version is actually build on travis, otherwise no docs get published
+  javaVersions = [1.8, 11, 15] // ensure that latest version is actually build on travis, otherwise no docs get published
   javaVersion = System.getProperty("java.specification.version") as BigDecimal
 
   libs = [
     jetbrainsAnnotations: [group: "org.jetbrains", name: "annotations", version: "19.0.0"],
-    asm                 : [group: 'org.ow2.asm', name: 'asm', version: '8.0.1'],
-    bytebuddy           : [group: 'net.bytebuddy', name: 'byte-buddy', version: '1.10.10'],
+    asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.0'],
+    bytebuddy           : [group: 'net.bytebuddy', name: 'byte-buddy', version: '1.10.16'],
     cglib               : [group: 'cglib', name: 'cglib-nodep', version: '3.3.0'],
     groovy              : groovyDependencies,
     groovySql           : [group: 'org.codehaus.groovy', name: 'groovy-sql', version: groovyVersion], //for some Spring and Unitils tests
@@ -194,7 +194,7 @@ subprojects {
   }
 
   jacoco {
-    toolVersion = '0.8.5'
+    toolVersion = '0.8.6'
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
     id "net.nemerosa.versioning" version "2.13.1"
     id "de.marcphilipp.nexus-publish" version "0.4.0"
     id "com.github.ben-manes.versions" version "0.28.0"
-    id "biz.aQute.bnd.builder" version "5.1.0"
+    id "biz.aQute.bnd.builder" version "5.1.2"
   }
 }
 

--- a/spock-core/src/main/java/org/spockframework/util/VersionChecker.java
+++ b/spock-core/src/main/java/org/spockframework/util/VersionChecker.java
@@ -25,7 +25,7 @@ public class VersionChecker {
   public void checkGroovyVersion(String whoIsChecking) {
     if (!isCompatibleGroovyVersion()) {
       if (isVersionCheckDisabled()) {
-        System.err.println(format("Executing Spock %s with NOT compatible Groovy version %s due to set %s system property set. " +
+        System.err.println(format("Executing Spock %s with NOT compatible Groovy version %s due to set %s system property. " +
           "This is unsupported and may result in weird runtime errors!", SpockReleaseInfo.getVersion(),
           GroovyReleaseInfo.getVersion(), DISABLE_GROOVY_VERSION_CHECK_PROPERTY_NAME));
       } else {


### PR DESCRIPTION
Also added the correnspnding Travis build.

The build fails with:
```
> Task :spock-core:verifyOSGi FAILED
Resolution failed. Capabilities satisfying the following requirements could not be found:
    [<<INITIAL>>]
      ⇒ osgi.identity: (osgi.identity=spock-core)
          ⇒ [spock-core version=2.0.0.groovy-30-SNAPSHOT]
              ⇒ osgi.wiring.package: (osgi.wiring.package=org.w3c.dom)
```

on OpenJDK 15. @rotty3000 How would it best way to deal with that?

(with the OSGI check disabled it builds fine with updated dependencies)