### PR TITLE
Added configurable interaction matching

### DIFF
--- a/spock-core/src/main/java/spock/config/RunnerConfiguration.java
+++ b/spock-core/src/main/java/spock/config/RunnerConfiguration.java
@@ -29,6 +29,7 @@ package spock.config;
  *     baseClass IntegrationSpec
  *   }
  *   filterStackTrace true // this is the default
+ *   matchFirstInteraction true // this is the default
  * }
  * </pre>
  */
@@ -38,4 +39,5 @@ public class RunnerConfiguration {
   public IncludeExcludeCriteria exclude = new IncludeExcludeCriteria();
   public boolean filterStackTrace = true;
   public boolean optimizeRunOrder = false;
+  public boolean matchFirstInteraction = true;
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/InteractionScopeMatching.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/InteractionScopeMatching.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.mock
+
+import org.spockframework.runtime.RunContext
+import spock.config.RunnerConfiguration
+import spock.lang.Specification
+
+/**
+ *
+ * @author Bouke Nijhuis
+ */
+class InteractionScopeMatching extends Specification {
+  List list = Mock()
+
+  def setup() {
+    list.size() >> 1
+    list.size() >> -1
+  }
+
+  def "RunnerConfiguration.matchFirstInteraction should default to true"() {
+    expect:
+    RunContext.get().getConfiguration(RunnerConfiguration.class).matchFirstInteraction
+  }
+
+  def "interactions should (by default) use the first match algorithm when determining the stubbed reply"() {
+    expect: // it to use the first defined reply of the method
+    list.size() == 1
+  }
+
+  def "interactions should (when specified) use the last match algorithm when determining the stubbed reply"() {
+    RunContext.get().getConfiguration(RunnerConfiguration.class).matchFirstInteraction = false
+
+    expect: // it to use the last defined reply of the method
+    list.size() == -1
+
+    when: // adding an interaction outside of the setup method
+    list.size() >> -2
+
+    then: // I expect it the use the last defined reply of the method
+    list.size() == -2
+
+    cleanup:
+    RunContext.get().getConfiguration(RunnerConfiguration.class).matchFirstInteraction = true
+  }
+}


### PR DESCRIPTION
By default Spock uses a match first algorithm to determine the defined return value of a method. So whenever there are multiple defined return values, it will pick the first (that is not exhausted). This change enables a user to change this to a match last algorithm. So Spock will pick the last defined return value (that is not exhausted). This enables easy overriding of default return values. As requested in issue #26, #251, #321 and #962.

This is a first attempt and will need some work. First I would like to know if you (the maintainers) are interested is this kind of configurable behaviour for interaction matching. If so, I think we should at least discuss the following topics:

- what to do with interactions specified in the then block having preference over the existing ones?
- documentation