### PR TITLE
IDEA settings, vcs.xml: add CommitMessageInspectionProfile

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="RIGHT_MARGIN" value="80" />
+      </inspection_tool>
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="RIGHT_MARGIN" value="80" />
+      </inspection_tool>
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>
-

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,11 +3,11 @@
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
       <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="RIGHT_MARGIN" value="80" />
+        <option name="RIGHT_MARGIN" value="72" />
       </inspection_tool>
       <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="RIGHT_MARGIN" value="80" />
+        <option name="RIGHT_MARGIN" value="50" />
       </inspection_tool>
     </profile>
   </component>


### PR DESCRIPTION
This configures a visible right margin at column 80 and word wrap for the commit
dialogue in IntelliJ IDEA.

![image](https://user-images.githubusercontent.com/1537384/102682019-b8059300-41f8-11eb-856d-a9bf0613f217.png)

![image](https://user-images.githubusercontent.com/1537384/102682024-be940a80-41f8-11eb-9721-ea9c4c2b11a9.png)
