### PR TITLE
vcs.xml: Remove explicit default line length limit 72

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,9 +2,7 @@
 <project version="4">
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
-      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true">
-        <option name="RIGHT_MARGIN" value="72" />
-      </inspection_tool>
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true">
         <option name="RIGHT_MARGIN" value="50" />


### PR DESCRIPTION
This PR is meant to improve the merged PR #1246.

---

I just noticed strange unstaged changes in _vcs.xml_ after I pulled the new master. They seem to originate in your suggested changes and look like this:

![image](https://user-images.githubusercontent.com/1537384/103961646-82b0ed00-5187-11eb-8c42-015ac08b18e6.png)

What the diff basically say is:
  * The commit message word-wrap width of 72 characters is the default, which is why it gets removed by IDEA automatically.
  * The last line feed in the file should be obligatory, but IDEA seems to prefer to always save the file without one.

I did not notice that at first when accepting the changes via GitHub UI or maybe they came up after a recent IDEA update on my machine, but now I cannot switch branches because of uncommitted changes in that file anymore. In my own projects I never commit any IDE config files, but Spock has some, which is why I suggested the changes.

Anyway, it is annoying enough for me to ask you, @leonard84, to accept this PR as an improvement for #1246.