### PR TITLE
Fix ErrorSpecNode throw Exception in `prepare` instead of `execute` ...

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
@@ -25,7 +25,7 @@ public class ErrorSpecNode extends SpecNode {
   }
 
   @Override
-  public SpockExecutionContext execute(SpockExecutionContext context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
+  public SpockExecutionContext prepare(SpockExecutionContext context) throws Exception {
     return ExceptionUtil.sneakyThrow(error);
   }
 }


### PR DESCRIPTION
this fixes an issue that interceptors for `prepare`, `before`, and `around`
were still executed and any Exception they throw would hide the actual cause.