### PR TITLE
Fix handling of `is` as getter for boolean properties on GroovyMocks

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -57,6 +57,8 @@ include::include.adoc[]
 
 - Fix https://github.com/spockframework/spock/issues/1256[#1256] handling of `is` as getter for boolean properties on Mocks
 
+- Fix https://github.com/spockframework/spock/issues/1270[#1270] handling of `is` as getter for boolean properties on GroovyMocks
+
 - Fix `ErrorSpecNode` to re-throw `Exception` in `prepare` instead of `execute`,
   this fixes an issue that interceptors for `prepare`, `before`, and `around`
   were still executed and any Exception they throw would hide the actual cause.

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/BaseMockInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/BaseMockInterceptor.java
@@ -1,0 +1,41 @@
+package org.spockframework.mock.runtime;
+
+import org.spockframework.runtime.GroovyRuntimeUtil;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import groovy.lang.*;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class BaseMockInterceptor implements IProxyBasedMockInterceptor {
+  @Nullable
+  protected String handleGetProperty(GroovyObject target, Object[] args) {
+    // Another hack It should be replaced with something more reliable: https://github.com/spockframework/spock/issues/1076
+    //Groovy 3 started to call go.getProperty("x") method instead of go.getX() directly for go.x
+    String methodName = null;
+    Throwable throwable = new Throwable();
+    StackTraceElement mockCaller = throwable.getStackTrace()[4];
+    // In some strange cases the caller classname is `groovy.lang.GroovyObject$getProperty$0` so we must use starts with here
+    if (!(mockCaller.getClassName().startsWith("groovy.lang.GroovyObject$getProperty") && "call".equals(mockCaller.getMethodName()))) {
+      //HACK: Only explicit getter executions (go.foo and go.getFoo()) should be deeper processed.
+      //go.getProperty("foo") is treated as is (to allow for its stubbing)
+      String propertyName = (String)args[0];
+      MetaClass metaClass = target.getMetaClass();
+      methodName = GroovyRuntimeUtil.propertyToMethodName("get", propertyName);
+      MetaMethod metaMethod = metaClass.getMetaMethod(methodName, GroovyRuntimeUtil.EMPTY_ARGUMENTS);
+      if (metaMethod == null) {
+        MetaMethod booleanVariant = metaClass
+          .getMetaMethod(GroovyRuntimeUtil.propertyToMethodName("is", propertyName), GroovyRuntimeUtil.EMPTY_ARGUMENTS);
+        if (booleanVariant != null && booleanVariant.getReturnType() == boolean.class) {
+          methodName = booleanVariant.getName();
+        }
+      }
+    }
+    return methodName;
+  }
+
+  protected boolean isMethod(Method method, String name, Class<?>... parameterTypes) {
+    return method.getName().equals(name) && Arrays.equals(method.getParameterTypes(), parameterTypes);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/JavaMockInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/JavaMockInterceptor.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 
 import groovy.lang.*;
 
-public class JavaMockInterceptor implements IProxyBasedMockInterceptor {
+public class JavaMockInterceptor extends BaseMockInterceptor {
   private final IMockConfiguration mockConfiguration;
   private Specification specification;
   private MockController fallbackMockController;
@@ -68,27 +68,9 @@ public class JavaMockInterceptor implements IProxyBasedMockInterceptor {
           return GroovyRuntimeUtil.invokeMethod(target, methodName, GroovyRuntimeUtil.asArgumentArray(args[1]));
         }
       }
-
-      // Another hack It should be replaced with something more reliable: https://github.com/spockframework/spock/issues/1076
       if (isMethod(method, "getProperty", String.class)) {
-        //Groovy 3 started to call go.getProperty("x") method instead of go.getX() directly for go.x
-        Throwable throwable = new Throwable();
-        StackTraceElement mockCaller = throwable.getStackTrace()[3];
-        // In some strange cases the caller classname is `groovy.lang.GroovyObject$getProperty$0` so we must use starts with here
-        if (!(mockCaller.getClassName().startsWith("groovy.lang.GroovyObject$getProperty") && "call".equals(mockCaller.getMethodName()))) {
-          //HACK: Only explicit getter executions (go.foo and go.getFoo()) should be deeper processed.
-          //go.getProperty("foo") is treated as is (to allow for its stubbing)
-          String propertyName = (String)args[0];
-          MetaClass metaClass = ((GroovyObject)target).getMetaClass();
-          String methodName = GroovyRuntimeUtil.propertyToMethodName("get", propertyName);
-          MetaMethod metaMethod = metaClass.getMetaMethod(methodName, GroovyRuntimeUtil.EMPTY_ARGUMENTS);
-          if (metaMethod == null) {
-            MetaMethod booleanVariant = metaClass
-              .getMetaMethod(GroovyRuntimeUtil.propertyToMethodName("is", propertyName), GroovyRuntimeUtil.EMPTY_ARGUMENTS);
-            if (booleanVariant != null && booleanVariant.getReturnType() == boolean.class) {
-              methodName = booleanVariant.getName();
-            }
-          }
+        String methodName = handleGetProperty((GroovyObject)target, args);
+        if (methodName != null) {
           return GroovyRuntimeUtil.invokeMethod(target, methodName);
         }
       }
@@ -100,10 +82,6 @@ public class JavaMockInterceptor implements IProxyBasedMockInterceptor {
       specification.getSpecificationContext().getMockController();
 
     return mockController.handle(invocation);
-  }
-
-  private boolean isMethod(Method method, String name, Class<?>... parameterTypes) {
-    return method.getName().equals(name) && Arrays.equals(method.getParameterTypes(), parameterTypes);
   }
 
   @Override

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocksForGroovyClasses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocksForGroovyClasses.groovy
@@ -241,6 +241,83 @@ class GroovyMocksForGroovyClasses extends Specification {
     1 * person.setMetaClass(null)
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/1270")
+  def "Mock object boolean (is) accessor via dot-notation" () {
+    given:
+    ExampleData mockData = GroovyMock(ExampleData)
+
+    when: "query via property syntax"
+    def result = mockData.current ? "Data is current" : "Data is not current"
+
+    then: "calls mock"
+    1 * mockData.isCurrent() >> true
+
+    and:
+    result == "Data is current"
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/1270")
+  def "Mock object boolean (get) accessor via dot-notation" () {
+    given:
+    ExampleData mockData = GroovyMock(ExampleData)
+
+    when: "query via property syntax"
+    def result = mockData.enabled ? "Data is current" : "Data is not current"
+
+    then: "calls mock"
+    1 * mockData.getEnabled() >> true
+
+    and:
+    result == "Data is current"
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/1270")
+  def "Mock object boolean (get + is) accessor via dot-notation" () {
+    given:
+    ExampleData mockData = GroovyMock(ExampleData)
+
+    when: "query via property syntax"
+    def result = mockData.active ? "Data is current" : "Data is not current"
+
+    then: "calls mock, preferring 'get' to 'is' for boolean getters (surprise!)"
+    1 * mockData.getActive() >> true
+    0 * mockData.isActive()
+
+    and:
+    result == "Data is current"
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/1270")
+  def "Mock object non-boolean (get + is) accessor via dot-notation" () {
+    given:
+    ExampleData mockData = GroovyMock(ExampleData)
+
+    when: "query via property syntax"
+    def result = mockData.name ? "Data is current" : "Data is not current"
+
+    then: "calls mock, preferring 'get' to 'is' for non-boolean getters"
+    1 * mockData.getName() >> "X"
+    0 * mockData.isName()
+
+    and:
+    result == "Data is current"
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/1270")
+  def "Mock object boolean accessor via method" () {
+    given:
+    ExampleData mockData = GroovyMock(ExampleData)
+
+    when: "query via method syntax"
+    def result = mockData.isCurrent() ? "is enabled" : "is not enabled"
+
+    then: "calls mock"
+    1 * mockData.isCurrent() >> true
+
+    and:
+    result == "is enabled"
+  }
+
   static class Person {
     void sing(String song) { throw new UnsupportedOperationException("sing") }
     String getName() { throw new UnsupportedOperationException("getName") }


### PR DESCRIPTION
fixes #1270