### PR TITLE
Update Rule and ClassRule documentation with Junit 4 module link.

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -596,13 +596,13 @@ include::{sourcedir}/extension/SubjectDocSpec.groovy[tag=example-c]
 
 === Rule
 
-Spock understands `@org.junit.Rule` annotations on non-`@Shared` instance fields. The according rules are run at the
+Spock understands `@org.junit.Rule` annotations on non-`@Shared` instance fields when the <<modules.adoc#junit-4,JUnit 4 module>> is included. The according rules are run at the
 iteration interception point in the Spock lifecycle. This means that the rules before-actions are done before the
 execution of `setup` methods and the after-actions are done after the execution of `cleanup` methods.
 
 === ClassRule
 
-Spock understands `@org.junit.ClassRule` annotations on `@Shared` fields. The according rules are run at the
+Spock understands `@org.junit.ClassRule` annotations on `@Shared` fields when the <<modules.adoc#junit-4,JUnit 4 module>> is included. The according rules are run at the
 specification interception point in the Spock lifecycle. This means that the rules before-actions are done before the
 execution of `setupSpec` methods and the after-actions are done after the execution of `cleanupSpec` methods.
 

--- a/docs/modules.adoc
+++ b/docs/modules.adoc
@@ -1,6 +1,7 @@
 = Modules
 include::include.adoc[]
 
+[[junit-4]]
 == JUnit 4 Module
 
 Integration with JUnit 4 features for Spock 2+ (which internally uses JUnit Platform - part of JUnit 5).


### PR DESCRIPTION
Including the junit 4 module seemed to be required for us to upgrade our project to Spock 2.0.