### PR TITLE
Added configurable interaction matching.

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/IMockConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IMockConfiguration.java
@@ -89,6 +89,14 @@ public interface IMockConfiguration {
   IDefaultResponse getDefaultResponse();
 
   /**
+   * Tells whether this mock object supports last defined return value.
+   * By default Spock uses a match first algorithm to determine the defined return value of a method.
+   *
+   * @return whether this mock object supports last matched response
+   */
+  boolean useLastMatchResponseStrategy();
+
+  /**
    * Tells whether a mock object stands in for all objects of the mocked type, or just for itself.
    * This is an optional feature that may not be supported by a particular {@link MockImplementation}.
    *

--- a/spock-core/src/main/java/org/spockframework/mock/IMockObject.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IMockObject.java
@@ -66,6 +66,14 @@ public interface IMockObject extends SpecificationAttachable {
   IDefaultResponse getDefaultResponse();
 
   /**
+   * Tells whether this mock object supports last defined return value.
+   * By default Spock uses a match first algorithm to determine the defined return value of a method.
+   *
+   * @return whether this mock object supports last matched response
+   */
+  boolean useLastMatchResponseStrategy();
+
+  /**
    * Returns the specification that this mock object is attached to.
    *
    * @return the specification that this mock object is attached to

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockInterceptor.java
@@ -37,7 +37,8 @@ public class GroovyMockInterceptor extends BaseMockInterceptor {
   @Override
   public Object intercept(Object target, Method method, Object[] arguments, IResponseGenerator realMethodInvoker) {
     IMockObject mockObject = new MockObject(mockConfiguration.getName(), mockConfiguration.getExactType(), target,
-      mockConfiguration.isVerified(), mockConfiguration.isGlobal(), mockConfiguration.getDefaultResponse(), specification, this);
+      mockConfiguration.isVerified(), mockConfiguration.isGlobal(), mockConfiguration.getDefaultResponse(),
+      mockConfiguration.useLastMatchResponseStrategy(), specification, this);
 
     if (method.getDeclaringClass() == ISpockMockObject.class) {
       return mockObject;

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockMetaClass.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockMetaClass.java
@@ -116,7 +116,8 @@ public class GroovyMockMetaClass extends DelegatingMetaClass implements Specific
   private IMockInvocation createMockInvocation(MetaMethod metaMethod, Object target,
       String methodName, Object[] arguments, boolean isStatic) {
     IMockObject mockObject = new MockObject(configuration.getName(), configuration.getExactType(), target,
-        configuration.isVerified(), configuration.isGlobal(), configuration.getDefaultResponse(), specification, this);
+        configuration.isVerified(), configuration.isGlobal(), configuration.getDefaultResponse(),
+        configuration.useLastMatchResponseStrategy(), specification, this);
     IMockMethod mockMethod;
     if (metaMethod != null) {
       List<Type> parameterTypes = Arrays.<Type>asList(metaMethod.getNativeParameterTypes());

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/InteractionScope.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/InteractionScope.java
@@ -83,6 +83,14 @@ public class InteractionScope implements IInteractionScope {
 
   @Override
   public IMockInteraction match(IMockInvocation invocation) {
+    final IMockObject mockObject = invocation.getMockObject();
+    if (mockObject.useLastMatchResponseStrategy())
+      return lastMatchStrategy(invocation);
+
+    return firstMatchStrategy(invocation);
+  }
+
+  private IMockInteraction firstMatchStrategy(IMockInvocation invocation) {
     IMockInteraction firstMatch = null;
     for (IMockInteraction interaction : interactions)
       if (interaction.matches(invocation)) {
@@ -91,6 +99,17 @@ public class InteractionScope implements IInteractionScope {
       }
 
     return firstMatch;
+  }
+
+  private IMockInteraction lastMatchStrategy(IMockInvocation invocation) {
+    IMockInteraction lastMatch = null;
+    for (IMockInteraction interaction : interactions)
+      if (interaction.matches(invocation)) {
+        if (!interaction.isExhausted() || lastMatch == null)
+          lastMatch = interaction;
+      }
+
+    return lastMatch;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/JavaMockInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/JavaMockInterceptor.java
@@ -38,7 +38,8 @@ public class JavaMockInterceptor extends BaseMockInterceptor {
   @Override
   public Object intercept(Object target, Method method, Object[] arguments, IResponseGenerator realMethodInvoker) {
     IMockObject mockObject = new MockObject(mockConfiguration.getName(), mockConfiguration.getExactType(),
-      target, mockConfiguration.isVerified(), false, mockConfiguration.getDefaultResponse(), specification, this);
+      target, mockConfiguration.isVerified(), false, mockConfiguration.getDefaultResponse(),
+      mockConfiguration.useLastMatchResponseStrategy(), specification, this);
 
     if (method.getDeclaringClass() == ISpockMockObject.class) {
       return mockObject;

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockConfiguration.java
@@ -31,6 +31,7 @@ public class MockConfiguration implements IMockConfiguration {
   private final List<Object> constructorArgs;
   private final List<Class<?>> additionalInterfaces;
   private final IDefaultResponse defaultResponse;
+  private final boolean useLastMatchResponseStrategy;
   private final boolean global;
   private final boolean verified;
   private final boolean useObjenesis;
@@ -51,6 +52,7 @@ public class MockConfiguration implements IMockConfiguration {
     this.constructorArgs = getOptionAsList(options, "constructorArgs");
     this.additionalInterfaces = getOption(options, "additionalInterfaces", List.class, Collections.emptyList());
     this.defaultResponse = getOption(options, "defaultResponse", IDefaultResponse.class, this.nature.getDefaultResponse());
+    this.useLastMatchResponseStrategy = getOption(options, "useLastMatchResponseStrategy", Boolean.class, false);
     this.global = getOption(options, "global", Boolean.class, false);
     this.verified = getOption(options, "verified", Boolean.class, this.nature.isVerified());
     this.useObjenesis = getOption(options, "useObjenesis", Boolean.class, this.nature.isUseObjenesis());
@@ -101,6 +103,11 @@ public class MockConfiguration implements IMockConfiguration {
   @Override
   public IDefaultResponse getDefaultResponse() {
     return defaultResponse;
+  }
+
+  @Override
+  public boolean useLastMatchResponseStrategy() {
+    return useLastMatchResponseStrategy;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockObject.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockObject.java
@@ -30,18 +30,21 @@ public class MockObject implements IMockObject {
   private final boolean verified;
   private final boolean global;
   private final IDefaultResponse defaultResponse;
+  private final boolean useLastMatchResponseStrategy;
   private final SpecificationAttachable mockInterceptor;
 
   private Specification specification;
 
   public MockObject(@Nullable String name, Type type, Object instance, boolean verified, boolean global,
-      IDefaultResponse defaultResponse, Specification specification, SpecificationAttachable mockInterceptor) {
+      IDefaultResponse defaultResponse, boolean useLastMatchResponseStrategy, Specification specification,
+      SpecificationAttachable mockInterceptor) {
     this.name = name;
     this.type = type;
     this.instance = instance;
     this.verified = verified;
     this.global = global;
     this.defaultResponse = defaultResponse;
+    this.useLastMatchResponseStrategy = useLastMatchResponseStrategy;
     this.specification = specification;
     this.mockInterceptor = mockInterceptor;
   }
@@ -75,6 +78,11 @@ public class MockObject implements IMockObject {
   @Override
   public IDefaultResponse getDefaultResponse() {
     return defaultResponse;
+  }
+
+  @Override
+  public boolean useLastMatchResponseStrategy() {
+    return useLastMatchResponseStrategy;
   }
 
   @Override

--- a/spock-core/src/main/java/spock/mock/MockingApi.java
+++ b/spock-core/src/main/java/spock/mock/MockingApi.java
@@ -170,6 +170,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -222,6 +223,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -390,6 +392,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -443,6 +446,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -502,6 +506,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -568,6 +573,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -619,6 +625,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -726,6 +733,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -783,6 +791,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -848,6 +857,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class)
     })
@@ -899,6 +909,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -951,6 +962,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1011,6 +1023,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1078,6 +1091,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1130,6 +1144,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1182,6 +1197,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1242,6 +1258,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1309,6 +1326,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1361,6 +1379,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1413,6 +1432,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1471,6 +1491,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)
@@ -1537,6 +1558,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
+      @NamedParam(value = "useLastMatchResponseStrategy", type = Boolean.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class)

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/InteractionScopeMatching.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/InteractionScopeMatching.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.mock
+
+import spock.lang.Specification
+
+/**
+ *
+ * @author Kamil Jędrzejuk
+ */
+class InteractionScopeMatching extends Specification {
+  List defaultMockBehaviour = Mock()
+  List withOverrideLastResponse = Mock([useLastMatchResponseStrategy:true])
+
+  def setup() {
+    defaultMockBehaviour.size() >> 1
+    withOverrideLastResponse.size() >> 1
+  }
+
+  def "interactions should use response matching algorithm depends on passed useLastMatchResponseStrategy flag when determining the stubbed reply"() {
+    given:
+    defaultMockBehaviour.size() >> 2
+    withOverrideLastResponse.size() >> 2
+
+    and:
+    withOverrideLastResponse.size() >> 3
+
+    expect:
+    defaultMockBehaviour.size() == 1
+    withOverrideLastResponse.size() == 3
+  }
+}

--- a/spock-spring/src/main/java/org/spockframework/spring/mock/DelegatingInterceptor.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/mock/DelegatingInterceptor.java
@@ -117,6 +117,11 @@ public class DelegatingInterceptor implements IProxyBasedMockInterceptor {
     }
 
     @Override
+    public boolean useLastMatchResponseStrategy() {
+      return false;
+    }
+
+    @Override
     public Specification getSpecification() {
       return null;
     }


### PR DESCRIPTION
Added 'last match algorithm' to determine the defined return value of a
method. This enables easy overriding of default return values. As
requested in issue #26, #251, #321 and #962.

