### PR TITLE
Fix NPE if variable is initialized using a method with the same...

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/smoke/CleanupBlocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/CleanupBlocks.groovy
@@ -181,4 +181,20 @@ def feature() {
     assert d == 1d
     assert bool
   }
+
+  @Issue("https://github.com/spockframework/spock/issues/1266")
+  def "cleanup blocks don't destroy method reference when invocation is assigned to variable with the same name"() {
+    when:
+    def foobar = foobar()
+
+    then:
+    println(foobar)
+
+    cleanup:
+    foobar.size()
+  }
+
+  def foobar() {
+    return "foo"
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/CleanupBlocksAstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/CleanupBlocksAstSpec.groovy
@@ -1,0 +1,70 @@
+package org.spockframework.smoke.ast
+
+import org.spockframework.EmbeddedSpecification
+import spock.lang.Issue
+import spock.util.Show
+
+class CleanupBlocksAstSpec extends EmbeddedSpecification {
+
+  @Issue("https://github.com/spockframework/spock/issues/1266")
+  def "cleanup rewrite keeps correct method reference"() {
+    when:
+    def result = compiler.transpileSpecBody('''
+def "cleanup blocks don't destroy method reference when invocation is assigned to variable with the same name"() {
+  when:
+  def foobar = foobar()
+
+  then:
+  println(foobar)
+
+  cleanup:
+  foobar.size()
+}
+
+def foobar() {
+  return "foo"
+}''', EnumSet.of(Show.METHODS))
+    then:
+    result.source == '''\
+public java.lang.Object foobar() {
+    return 'foo'
+}
+
+public void $spock_feature_0_0() {
+    org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
+    org.spockframework.runtime.ValueRecorder $spock_valueRecorder = new org.spockframework.runtime.ValueRecorder()
+    java.lang.Object foobar
+    java.lang.Throwable $spock_feature_throwable
+    try {
+        foobar = this.foobar()
+        try {
+            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'println(foobar)', 6, 3, null, this, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), 'println'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), foobar)}, $spock_valueRecorder.realizeNas(4, false), false, 3)
+        }
+        catch (java.lang.Throwable throwable) {
+            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'println(foobar)', 6, 3, null, throwable)}
+        finally {
+        }
+    }
+    catch (java.lang.Throwable $spock_tmp_throwable) {
+        $spock_feature_throwable = $spock_tmp_throwable
+        throw $spock_tmp_throwable
+    }
+    finally {
+        try {
+            foobar.size()
+        }
+        catch (java.lang.Throwable $spock_tmp_throwable) {
+            if ( $spock_feature_throwable != null) {
+                $spock_feature_throwable.addSuppressed($spock_tmp_throwable)
+            } else {
+                throw $spock_tmp_throwable
+            }
+        }
+        finally {
+        }
+    }
+    this.getSpecificationContext().getMockController().leaveScope()
+}'''
+
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec.groovy
@@ -1,0 +1,46 @@
+package org.spockframework.smoke.ast.condition
+
+import org.spockframework.EmbeddedSpecification
+import spock.lang.Issue
+import spock.util.Show
+
+class ExceptionConditionsAstSpec extends EmbeddedSpecification {
+
+  @Issue("https://github.com/spockframework/spock/issues/1266")
+  def "thrown rewrite keeps correct method reference"() {
+    when:
+    def result = compiler.transpileSpecBody('''
+def "cleanup blocks don't destroy method reference when invocation is assigned to variable with the same name"() {
+  when:
+  def foobar = foobar()
+
+  then:
+  thrown(IllegalStateException)
+}
+
+def foobar() {
+  throw new IllegalStateException("foo")
+}''', EnumSet.of(Show.METHODS))
+    then:
+    result.source == '''\
+public java.lang.Object foobar() {
+    throw new java.lang.IllegalStateException('foo')
+}
+
+public void $spock_feature_0_0() {
+    java.lang.Object foobar
+    this.getSpecificationContext().setThrownException(null)
+    try {
+        foobar = this.foobar()
+    }
+    catch (java.lang.Throwable $spock_ex) {
+        this.getSpecificationContext().setThrownException($spock_ex)
+    }
+    finally {
+    }
+    this.thrownImpl(null, null, java.lang.IllegalStateException)
+    this.getSpecificationContext().getMockController().leaveScope()
+}'''
+
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionConditions.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ExceptionConditions.groovy
@@ -269,4 +269,17 @@ thrown() == e
     x == 3
     y == 4
   }
+
+  @Issue("https://github.com/spockframework/spock/issues/1266")
+  def "thrown conditions don't destroy method reference when invocation is assigned to variable with the same name"() {
+    when:
+    def foobar = foobar()
+
+    then:
+    thrown(IllegalStateException)
+  }
+
+  def foobar() {
+    throw new IllegalStateException("foo")
+  }
 }


### PR DESCRIPTION
in features with cleanup blocks or using thrown condition

fixes #1266, fixes #1313