### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-and-verify:
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'spockframework/spock' && github.ref == 'refs/heads/master'
+    if: github.repository == 'spockframework/spock'
     strategy:
       fail-fast: false
       matrix:
@@ -69,11 +69,6 @@ jobs:
     needs: [ 'build-and-verify' ]
     # Use always() and check needs result manually since we skip the 'build-and-verify' execution on a tag,
     # but still want to depend on it on the main branch
-    if: |
-      always()
-      && (needs.build-and-verify.result == 'success' || needs.build-and-verify.result == 'skipped')
-      && github.event_name == 'push'
-      && github.repository == 'spockframework/spock'
     strategy:
       matrix:
         os: [ 'ubuntu-latest' ]
@@ -149,23 +144,3 @@ jobs:
       - name: 'Stop Daemon'
         run: |
           ./gradlew --stop
-
-  create-release:
-    runs-on: ubuntu-latest
-    needs: ['release-spock']
-    if: github.repository == 'spockframework/spock' && startsWith(github.ref, 'refs/tags/spock-')
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            TODO: Add a link to the real release notes
-          draft: true
-          prerelease: false

--- a/build.gradle
+++ b/build.gradle
@@ -269,9 +269,10 @@ if (gradle.startParameter.taskNames == ["ghActionsPublish"] || gradle.startParam
      */
     if (snapshotVersion || isTag) {
       gradle.startParameter.taskNames += ["publish"]
-    } else {
-      gradle.startParameter.taskNames += ["tagRelease"]
-    }
+    } // else {
+      // disable tag release for now as this is done with a token, that doesn't trigger other workflows
+      // gradle.startParameter.taskNames += ["tagRelease"]
+      // }
   }
 
   if (originalStartParameterTaskNames == ["ghActionsDocs"] && (snapshotVersion || isTag)) {


### PR DESCRIPTION
Remove build avoidance, as we now have build-caching with gradle enterprise the build on the tag should be fast.
Disable tagging and pushing for the time being as the automatic GITHUB_TOKEN won't trigger workflows,
for now we will use manual tags.

fixes #1304