### PR TITLE
Use ClosureReferenceExpression instead of workaround ...

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/ClosureReferenceExpression.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ClosureReferenceExpression.java
@@ -1,0 +1,15 @@
+package org.spockframework.compiler;
+
+import groovyjarjarasm.asm.*;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.classgen.BytecodeExpression;
+
+class ClosureReferenceExpression extends BytecodeExpression {
+
+  ClosureReferenceExpression() {super(ClassHelper.CLOSURE_TYPE);}
+
+  @Override
+  public void visit(MethodVisitor methodVisitor) {
+    methodVisitor.visitVarInsn(Opcodes.ALOAD,0);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
@@ -226,16 +226,7 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
     MethodCallExpression methodCall = AstUtil.getExpression(stat, MethodCallExpression.class);
     if (methodCall == null) return;
 
-    MethodCallExpression target = referenceToCurrentClosure();
-    methodCall.setObjectExpression(target);
-  }
-
-  private MethodCallExpression referenceToCurrentClosure() {
-    return new MethodCallExpression(
-      new VariableExpression("this"),
-      new ConstantExpression("find"),
-      NO_ARGUMENTS
-    );
+    methodCall.setObjectExpression(new ClosureReferenceExpression());
   }
 
   private boolean handleMockCall(MethodCallExpression expr) {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/WithBlocks.groovy
@@ -147,6 +147,17 @@ class WithBlocks extends Specification {
     }
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/1339")
+  def "implicit collection method call on a set"() {
+    given:
+    Set<String> x = ["a"]
+
+    expect:
+    with(x) {
+      find() == 'a'
+    }
+  }
+
   int size() {
     42
   }


### PR DESCRIPTION
to obtain a reference to the closure this object.

fix #1339