### PR TITLE
Set the owner for condition closures on spec annotations

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConditionalExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConditionalExtension.java
@@ -49,7 +49,7 @@ public abstract class ConditionalExtension<T extends Annotation> implements IAnn
   @Override
   public void visitSpecAnnotation(T annotation, SpecInfo spec) {
     Closure condition = createCondition(annotation);
-    Object result = evaluateCondition(condition);
+    Object result = evaluateCondition(condition, spec.getReflection());
     specConditionResult(GroovyRuntimeUtil.isTruthy(result), annotation, spec);
   }
 
@@ -79,10 +79,6 @@ public abstract class ConditionalExtension<T extends Annotation> implements IAnn
     } catch (Exception e) {
       throw new ExtensionException("Failed to instantiate condition", e);
     }
-  }
-
-  private static Object evaluateCondition(Closure condition) {
-    return evaluateCondition(condition, null, emptyMap(), null);
   }
 
   private static Object evaluateCondition(Closure condition, Object instance,

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
@@ -156,7 +156,7 @@ class Foo extends Specification {
   }
 
   static boolean shouldNotRun() {
-    ${shouldRun}
+    !${shouldRun}
   }
 }
 """
@@ -171,8 +171,8 @@ class Foo extends Specification {
 
     where:
     shouldRun | testStartAndSucceededCount | specSkippedCount
-    false     | 1                          | 0
-    true      | 0                          | 1
+    true      | 1                          | 0
+    false     | 0                          | 1
   }
 
   def "fails if condition cannot be instantiated"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreIfExtension.groovy
@@ -34,7 +34,7 @@ class IgnoreIfExtension extends EmbeddedSpecification {
 
   @IgnoreIf({
     jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 || jvm.java13 || jvm.java14 || jvm.java15 || jvm.java16 || jvm.java17 ||
-      jvm.java18 || jvm.java19  || jvm.java20 || jvm.java21 || jvm.java22  || jvm.java23
+      jvm.java18 || jvm.java19 || jvm.java20 || jvm.java21 || jvm.java22 || jvm.java23
   })
   def "provides JVM information"() {
     expect: false
@@ -57,14 +57,17 @@ class IgnoreIfExtension extends EmbeddedSpecification {
 
   @IgnoreIf({ a == 1 })
   def 'can evaluate for single iterations if data variables are accessed'() {
-    expect: a == 2
-    where: a << [1, 2]
+    expect:
+    a == 2
+    where:
+    a << [1, 2]
   }
 
   @IgnoreIf({ true })
   def 'can skip data providers completely if no data variables are accessed'() {
     expect: false
-    where: a = { throw new RuntimeException() }.call()
+    where:
+    a = { throw new RuntimeException() }.call()
   }
 
   def 'fails directly when referencing an unknown variable'() {
@@ -100,7 +103,7 @@ def foo() {
   @Issue("https://github.com/spockframework/spock/issues/535")
   @Requires({ false })
   @IgnoreIf({ false })
-  def "allows determinate use of multiple filters" () {
+  def "allows determinate use of multiple filters"() {
     expect: false
   }
 
@@ -140,6 +143,36 @@ class Foo extends Specification {
     result.testsSkippedCount == 0
     result.testsAbortedCount == 0
     result.testsSucceededCount == 1
+  }
+
+
+  def "spec usage with static class access"() {
+    when:
+    def result = runner.runWithImports """
+@IgnoreIf({ shouldNotRun() })
+class Foo extends Specification {
+  def "basic usage"() {
+    expect: true
+  }
+
+  static boolean shouldNotRun() {
+    ${shouldRun}
+  }
+}
+"""
+
+    then:
+    result.testsStartedCount == testStartAndSucceededCount
+    result.testsFailedCount == 0
+    result.testsSkippedCount == 0
+    result.testsAbortedCount == 0
+    result.testsSucceededCount == testStartAndSucceededCount
+    result.containersSkippedCount == specSkippedCount
+
+    where:
+    shouldRun | testStartAndSucceededCount | specSkippedCount
+    false     | 1                          | 0
+    true      | 0                          | 1
   }
 
   def "fails if condition cannot be instantiated"() {
@@ -188,21 +221,24 @@ def foo() {
   @IgnoreIf({ false })
   def "feature is ignored if data variable accessing IgnoreIf annotation is true"() {
     expect: false
-    where: a = 1
+    where:
+    a = 1
   }
 
   @IgnoreIf({ a == 1 })
   @IgnoreIf({ a != 1 })
   def "feature is ignored if at least one data variable accessing IgnoreIf annotation is true"() {
     expect: false
-    where: a = 1
+    where:
+    a = 1
   }
 
   @IgnoreIf({ true })
   @IgnoreIf({ a != 1 })
   def "feature is ignored if non data variable accessing IgnoreIf annotation is true"() {
     expect: false
-    where: a = 1
+    where:
+    a = 1
   }
 
   def "@IgnoreIf provides condition access to Specification instance shared fields"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
@@ -92,6 +92,35 @@ class Foo extends Specification {
     result.testsSucceededCount == 1
   }
 
+  def "spec usage with static class access"() {
+    when:
+    def result = runner.runWithImports """
+@Requires({ shouldRun() })
+class Foo extends Specification {
+  def "basic usage"() {
+    expect: true
+  }
+
+  static boolean shouldRun() {
+    ${shouldRun}
+  }
+}
+"""
+
+    then:
+    result.testsStartedCount == testStartAndSucceededCount
+    result.testsFailedCount == 0
+    result.testsSkippedCount == 0
+    result.testsAbortedCount == 0
+    result.testsSucceededCount == testStartAndSucceededCount
+    result.containersSkippedCount == specSkippedCount
+
+    where:
+    shouldRun | testStartAndSucceededCount | specSkippedCount
+    true      | 1                          | 0
+    false     | 0                          | 1
+  }
+
   def "spec usage with false"() {
     when:
     def result = runner.runWithImports """
@@ -257,14 +286,17 @@ class Foo extends Specification {
 
     @Requires({ a == 2 })
     def 'can evaluate for single iterations if data variables are accessed'() {
-      expect: a == 2
-      where: a << [1, 2]
+      expect:
+      a == 2
+      where:
+      a << [1, 2]
     }
 
     @Requires({ false })
     def 'can skip data providers completely if no data variables are accessed'() {
       expect: false
-      where: a = { throw new RuntimeException() }.call()
+      where:
+      a = { throw new RuntimeException() }.call()
     }
 
     @Issue("https://github.com/spockframework/spock/issues/535")
@@ -276,14 +308,14 @@ class Foo extends Specification {
 
     @Requires({ false })
     @Requires({ true })
-    def "feature is ignored if at least one Requires annotation is false" () {
+    def "feature is ignored if at least one Requires annotation is false"() {
       expect: false
     }
 
     @Requires({ true })
     @Requires({ true })
     @FailsWith(ConditionNotSatisfiedError)
-    def "feature is not ignored if all Requires annotations are true" () {
+    def "feature is not ignored if all Requires annotations are true"() {
       expect: false
     }
   }


### PR DESCRIPTION
This allows access to static methods when `@IgnoreIf`, `@Requires` and `@PendingFeatureIf` is used on a Specification.

We already set the owner when a Feature is annotated.