### PR TITLE
Prevent removal of ErrorSpecNode from execution hierarchy

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
@@ -25,6 +25,13 @@ public class ErrorSpecNode extends SpecNode {
   }
 
   @Override
+  public void removeFromHierarchy() {
+    // prevent removal of this node
+    // As the ErrorSpecNode does not have children it would get removed when trying to select specific tests methods.
+    // For example, gradle will report that no test were found, and not report the actual error.
+  }
+
+  @Override
   public SpockExecutionContext prepare(SpockExecutionContext context) throws Exception {
     return ExceptionUtil.sneakyThrow(error);
   }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/ErrorSpecNodeSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/ErrorSpecNodeSpec.groovy
@@ -3,22 +3,34 @@ package org.spockframework.runtime
 import spock.lang.Specification
 
 import org.junit.platform.engine.*
+import spock.lang.Subject
 
 class ErrorSpecNodeSpec extends Specification {
-  def 'should not be pruned'() {
-    given:
-    TestDescriptor parent = Mock()
-    def testee = new ErrorSpecNode(
-      UniqueId.forEngine("test"),
-      null,
-      new SpecInfoBuilder(getClass()).build(),
-      null)
-    testee.setParent(parent)
+  TestDescriptor tdParent = Mock()
 
+  @Subject
+  def errorSpecNode = new ErrorSpecNode(
+    UniqueId.forEngine("test"),
+    null,
+    new SpecInfoBuilder(getClass()).build(),
+    null).tap {
+    parent = tdParent
+  }
+
+
+  def 'should not be pruned'() {
     when:
-    testee.prune()
+    errorSpecNode.prune()
 
     then:
-    0 * parent.removeChild(*_)
+    0 * tdParent.removeChild(*_)
+  }
+
+  def 'should prevent removal of ErrorSpecNode'() {
+    when:
+    errorSpecNode.removeFromHierarchy()
+
+    then:
+    0 * tdParent.removeChild(*_)
   }
 }


### PR DESCRIPTION
As the ErrorSpecNode does not have children it would get removed
when trying to select specific tests methods
For example, gradle will report that no test were found,
and not report the actual error.