### PR TITLE
Fix JUnit rule run order

### DIFF
--- a/spock-junit4/src/main/java/org/spockframework/junit4/AbstractRuleInterceptor.java
+++ b/spock-junit4/src/main/java/org/spockframework/junit4/AbstractRuleInterceptor.java
@@ -23,13 +23,18 @@ import org.spockframework.runtime.extension.IMethodInterceptor;
 import org.spockframework.runtime.extension.IMethodInvocation;
 import org.spockframework.runtime.model.FieldInfo;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public abstract class AbstractRuleInterceptor implements IMethodInterceptor {
   protected final List<FieldInfo> ruleFields;
 
   public AbstractRuleInterceptor(List<FieldInfo> ruleFields) {
-    this.ruleFields = ruleFields;
+    // we need to reverse here as we create the Statements in reversed order
+    ArrayList<FieldInfo> reversedFields = new ArrayList<>(ruleFields);
+    Collections.reverse(reversedFields);
+    this.ruleFields = reversedFields;
   }
 
   protected Statement createBaseStatement(final IMethodInvocation invocation) {

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitClassRules.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitClassRules.groovy
@@ -20,7 +20,8 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import org.spockframework.runtime.InvalidSpecException
-
+import spock.lang.Issue
+import spock.lang.ResourceLock
 import spock.lang.Shared
 
 class JUnitClassRules extends JUnitBaseSpec {
@@ -30,6 +31,7 @@ class JUnitClassRules extends JUnitBaseSpec {
   def setup() {
     runner.addClassImport(ClassRule)
     runner.addClassImport(TestName)
+    runner.addClassImport(OrderTracker)
   }
 
   def "are instantiated automatically by default"() {
@@ -77,6 +79,41 @@ class JUnitClassRules extends JUnitBaseSpec {
     e.message.contains("must be @Shared")
   }
 
+  @ResourceLock("OrderTracker")
+  @Issue("https://github.com/spockframework/spock/issues/1050")
+  def "rules from parent fields should run before rules in child specs"() {
+    given:
+    OrderTracker.invocations = []
+    when:
+    runner.runWithImports """
+abstract class Parent extends Specification {
+      @Shared @ClassRule OrderTracker parent1 = new OrderTracker("parent-1")
+      @Shared @ClassRule OrderTracker parent2 = new OrderTracker("parent-2")
+
+}
+class Child extends Parent {
+      @Shared @ClassRule OrderTracker child1 = new OrderTracker("child-1")
+      @Shared @ClassRule OrderTracker child2 = new OrderTracker("child-2")
+
+    def "test"() {
+        expect: true
+    }
+}
+    """
+
+    then:
+    OrderTracker.invocations == [
+      "before parent-1",
+      "before parent-2",
+      "before child-1",
+      "before child-2",
+      "after child-2",
+      "after child-1",
+      "after parent-2",
+      "after parent-1",
+    ]
+  }
+
   static @ClassRule TestName staticRule
 
   def "static class rules are not detected"() {
@@ -98,6 +135,28 @@ class JUnitClassRules extends JUnitBaseSpec {
         @Override
         void evaluate() {
           base.evaluate()
+        }
+      }
+    }
+  }
+
+  static class OrderTracker implements TestRule {
+    static List<String> invocations = []
+
+    private final String identifier
+
+    OrderTracker(String identifier) {
+      this.identifier = identifier
+    }
+
+    @Override
+    Statement apply(Statement base, Description description) {
+      new Statement() {
+        @Override
+        void evaluate() {
+          invocations << "before $identifier".toString()
+          base.evaluate()
+          invocations << "after $identifier".toString()
         }
       }
     }

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitMethodRuleOrder.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitMethodRuleOrder.groovy
@@ -27,17 +27,17 @@ class JUnitMethodRuleOrder extends Specification {
 
   def setup() {
     // expect: setup is called during base.evaluate()
-    assert log == ["testRule2: before", "testRule1: before"]
+    assert log == ["testRule1: before", "testRule2: before"]
   }
 
-  def "rules declared later wrap around rules declared earlier"() {
+  def "rules declared earlier wrap around rules declared later"() {
     expect:
-    log == ["testRule2: before", "testRule1: before"]
+    log == ["testRule1: before", "testRule2: before"]
   }
 
   def cleanup() {
     // expect: cleanup is called before base.evaluate() leaves
-    assert log == ["testRule2: before", "testRule1: before"]
+    assert log == ["testRule1: before", "testRule2: before"]
   }
 
   static class LoggingRule implements MethodRule {

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitTestRuleOrder.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitTestRuleOrder.groovy
@@ -27,17 +27,17 @@ class JUnitTestRuleOrder extends Specification {
 
   def setup() {
     // expect: setup is called during base.evaluate()
-    assert log == ["testRule2: before", "testRule1: before"]
+    assert log == ["testRule1: before", "testRule2: before"]
   }
 
-  def "rules declared later wrap around rules declared earlier"() {
+  def "rules declared earlier wrap around rules declared later"() {
     expect:
-    log == ["testRule2: before", "testRule1: before"]
+    log == ["testRule1: before", "testRule2: before"]
   }
 
   def cleanup() {
     // expect: cleanup is called before base.evaluate() leaves
-    assert log == ["testRule2: before", "testRule1: before"]
+    assert log == ["testRule1: before", "testRule2: before"]
   }
 
   static class LoggingRule implements TestRule {


### PR DESCRIPTION
Prior to this commit the rules were executed in the wrong order.
When rules we used in both parent and child classes,
then the rules in the child classes were executed before those of the parent class.

Fixes #1050