### PR TITLE
Use actions/setup-java@v2 built-in caching for gradle

### DIFF
--- a/.github/workflows/branches-and-prs.yml
+++ b/.github/workflows/branches-and-prs.yml
@@ -36,18 +36,11 @@ jobs:
         with:
           # Codecov needs fetch-depth > 1
           fetch-depth: 2
-      - name: Cache Gradle wrapper and dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/dists
-          key: test-${{ runner.os }}-variant-${{ matrix.variant }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
-          restore-keys: |
-            test-${{ runner.os }}-variant-${{ matrix.variant }}-
       - name: 'Set up JDK'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
+          cache: 'gradle'
           java-version: ${{ matrix.java }}
       - name: 'Gradle Version'
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,8 +31,10 @@ jobs:
 
       # Manually added:  Install and setup JDK
       - name: Setup JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
+          cache: 'gradle'
           java-version: 8
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,18 +35,11 @@ jobs:
         with:
           # Codecov needs fetch-depth > 1
           fetch-depth: 2
-      - name: Cache Gradle wrapper and dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/dists
-          key: test-${{ runner.os }}-variant-${{ matrix.variant }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
-          restore-keys: |
-            test-${{ runner.os }}-variant-${{ matrix.variant }}-
       - name: 'Set up JDK'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
+          cache: 'gradle'
           java-version: ${{ matrix.java }}
       - name: 'Gradle Version'
         run: |
@@ -76,18 +69,11 @@ jobs:
         java: [ '8' ]               # publish needs the min supported java version
     steps:
       - uses: actions/checkout@v2
-      - name: Cache Gradle wrapper and dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/dists
-          key: test-${{ runner.os }}-variant-${{ matrix.variant }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
-          restore-keys: |
-            test-${{ runner.os }}-variant-${{ matrix.variant }}-
       - name: 'Set up JDK'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
+          cache: 'gradle'
           java-version: ${{ matrix.java }}
       - name: 'Gradle Version'
         run: |
@@ -117,18 +103,11 @@ jobs:
         java: ['15']          # docs need the highest java version
     steps:
       - uses: actions/checkout@v2
-      - name: Cache Gradle wrapper and dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/dists
-          key: test-${{ runner.os }}-variant-${{ matrix.variant }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
-          restore-keys: |
-            test-${{ runner.os }}-variant-${{ matrix.variant }}-
       - name: 'Set up JDK'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
+          cache: 'gradle'
           java-version: ${{ matrix.java }}
       - name: 'Gradle Version'
         run: |


### PR DESCRIPTION
This simplifies the caching configuration, but is less specific and looses the separation between 2.5 and 3.0 builds. WDYT?