### PR TITLE
Fix @TempDir not working for @Shared "inherited" fields

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TempDirExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TempDirExtension.java
@@ -33,7 +33,7 @@ public class TempDirExtension implements IAnnotationDrivenExtension<TempDir> {
     // attach interceptor
     SpecInfo specInfo = field.getParent();
     if (field.isShared()) {
-      specInfo.addInterceptor(interceptor);
+      specInfo.getBottomSpec().addInterceptor(interceptor);
     } else {
       for (FeatureInfo featureInfo : specInfo.getBottomSpec().getAllFeatures()) {
         featureInfo.addIterationInterceptor(interceptor);

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/TempDirExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/TempDirExtensionSpec.groovy
@@ -122,13 +122,20 @@ def method1() {
 
 abstract class TempDirBaseSpec extends Specification {
   @TempDir Path tmp
+  @TempDir @Shared Path sharedTmp
 }
 
-@Issue("https://github.com/spockframework/spock/issues/1229")
 class TempDirInheritedSpec extends TempDirBaseSpec {
+  @Issue("https://github.com/spockframework/spock/issues/1229")
   void "TempDir works for inherited fields"() {
     expect:
     tmp != null
+  }
+
+  @Issue("https://github.com/spockframework/spock/pull/1373")
+  void "TempDir works for inherited shared fields"() {
+    expect:
+    sharedTmp != null
   }
 }
 


### PR DESCRIPTION
I've bumped into that in one of my projects.

A variant of previously fixed:
https://github.com/spockframework/spock/issues/1229

Btw, I assume that support for regular `static` fields hasn't been implemented in that extension purposely, right?