### PR TITLE
Fix selector ordering issue

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/ClassSelectorResolver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ClassSelectorResolver.java
@@ -39,23 +39,23 @@ class ClassSelectorResolver implements SelectorResolver {
 
   private Resolution resolveClass(Class<?> specClass, Context context) {
     if (SpecUtil.isRunnableSpec(specClass) && classNameFilter.test(specClass.getName())) {
-      SpecInfo specInfo = new SpecInfoBuilder(specClass).build();
       return context
         .addToParent(parent -> {
+          SpecInfo specInfo = new SpecInfoBuilder(specClass).build();
           specInfo.getAllFeatures().forEach(featureInfo -> featureInfo.setExcluded(true));
           UniqueId uniqueId = parent.getUniqueId().append("spec", specInfo.getReflection().getName());
           return Optional.of(new SpecNode(uniqueId,
             runContext.getConfiguration(RunnerConfiguration.class),
             specInfo));
         })
-        .map(specNode -> toResolution(specInfo, specNode))
+        .map(this::toResolution)
         .orElse(Resolution.unresolved());
     }
     return Resolution.unresolved();
   }
 
-  private Resolution toResolution(SpecInfo specInfo, SpecNode specNode) {
-    return Resolution.match(Match.exact(specNode, features(specInfo)));
+  private Resolution toResolution(SpecNode specNode) {
+    return Resolution.match(Match.exact(specNode, features(specNode.getNodeInfo())));
   }
 
   private Supplier<Set<? extends DiscoverySelector>> features(SpecInfo specInfo) {

--- a/spock-testkit/src/test/groovy/spock/platform/SpockEngineBase.java
+++ b/spock-testkit/src/test/groovy/spock/platform/SpockEngineBase.java
@@ -6,6 +6,7 @@ import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
 import org.junit.platform.testkit.engine.EventStatistics;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -13,25 +14,32 @@ import java.util.function.Consumer;
 public class SpockEngineBase {
 
   private static final Filter<?>[] FILTERS = new Filter<?>[0];
+  private static final DiscoverySelector[] SELECTORS = new DiscoverySelector[0];
 
   protected void execute(DiscoverySelector selector, Consumer<EventStatistics> statisticsConsumer) {
     execute(selector, statisticsConsumer, Collections.emptyList());
   }
+  protected void execute(List<DiscoverySelector> selector, Consumer<EventStatistics> statisticsConsumer) {
+    execute(selector, statisticsConsumer, Collections.emptyList());
+  }
   protected void execute(DiscoverySelector selector, Consumer<EventStatistics> statisticsConsumer, List<Filter<?>> filters) {
+    execute(Collections.singletonList(selector), statisticsConsumer, filters);
+  }
+  protected void execute(List<DiscoverySelector> selector, Consumer<EventStatistics> statisticsConsumer, List<Filter<?>> filters) {
     execute(selector, filters)
       .testEvents()
       .debug()
       .assertStatistics(statisticsConsumer);
   }
 
-  protected EngineExecutionResults execute(DiscoverySelector selector) {
-    return execute(selector, Collections.emptyList());
+  protected EngineExecutionResults execute(DiscoverySelector... selector) {
+    return execute(Arrays.asList(selector), Collections.emptyList());
   }
 
-  protected EngineExecutionResults execute(DiscoverySelector selector, List<Filter<?>> filters) {
+  protected EngineExecutionResults execute(List<DiscoverySelector> selectors, List<Filter<?>> filters) {
     return EngineTestKit
       .engine("spock")
-      .selectors(selector)
+      .selectors(selectors.toArray(SELECTORS))
       .filters(filters.toArray(FILTERS))
       .execute();
   }

--- a/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
+++ b/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
@@ -45,8 +45,9 @@ class SpockHelloWorldTest extends SpockEngineBase {
     execute(selectMethod(ExampleTestCase.class, "$spock_feature_0_2"), assertions);
     execute(selectMethod(ExampleTestCase.class, "ignoreMe"), assertions);
   }
+
   @Test
-  void selectorIssue() {
+  void mixedDiscoveryOfClassAndUniqueIdSelectorsIsSupportedRegardlessOfOrder() {
     UniqueId classUniqueId = UniqueId.forEngine("spock").append("spec", StepwiseTestCase.class.getName());
 
     Consumer<EventStatistics> assertions = stats -> stats.started(4).succeeded(3).failed(1).skipped(1);
@@ -58,7 +59,6 @@ class SpockHelloWorldTest extends SpockEngineBase {
       selectUniqueId(classUniqueId.append("feature", "$spock_feature_0_0")),
       selectClass(StepwiseTestCase.class)
       ), assertions);
-//    execute(selectMethod(ExampleTestCase.class, "$spock_feature_0_0"), assertions);
   }
 
   @Test

--- a/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
+++ b/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
@@ -8,6 +8,7 @@ import org.junit.platform.launcher.core.LauncherFactory;
 import org.spockframework.runtime.SpockEngine;
 import spock.testkit.testsources.*;
 
+import java.util.Arrays;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.engine.*;
 import org.junit.platform.testkit.engine.*;
 
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.*;
 
@@ -42,6 +44,21 @@ class SpockHelloWorldTest extends SpockEngineBase {
     execute(selectUniqueId(classUniqueId.append("feature", "$spock_feature_0_2")), assertions);
     execute(selectMethod(ExampleTestCase.class, "$spock_feature_0_2"), assertions);
     execute(selectMethod(ExampleTestCase.class, "ignoreMe"), assertions);
+  }
+  @Test
+  void selectorIssue() {
+    UniqueId classUniqueId = UniqueId.forEngine("spock").append("spec", StepwiseTestCase.class.getName());
+
+    Consumer<EventStatistics> assertions = stats -> stats.started(4).succeeded(3).failed(1).skipped(1);
+    execute(asList(
+      selectClass(StepwiseTestCase.class),
+      selectUniqueId(classUniqueId.append("feature", "$spock_feature_0_0"))
+      ), assertions);
+    execute(asList(
+      selectUniqueId(classUniqueId.append("feature", "$spock_feature_0_0")),
+      selectClass(StepwiseTestCase.class)
+      ), assertions);
+//    execute(selectMethod(ExampleTestCase.class, "$spock_feature_0_0"), assertions);
   }
 
   @Test


### PR DESCRIPTION
Prior to this commit the callback that is called when an entire test
class is selected enabled all feature methods on the wrong `SpecInfo`
instance which was part of the closure.