### PR TITLE
Add support for selecting individual iterations

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -183,7 +183,9 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
       if (context.getErrorInfoCollector().hasErrors()) {
         return;
       }
-      childExecutor.execute(iterationNode);
+      if (iterationInfo.getFeature().getIterationFilter().isAllowed(iterationInfo.getIterationIndex())) {
+        childExecutor.execute(iterationNode);
+      }
 
       // no iterators => no data providers => only derived parameterizations => limit to one iteration
       if (iterators.length == 0) {

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -27,6 +27,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
   private MethodInfo dataProcessorMethod;
   private NameProvider<IterationInfo> iterationNameProvider;
   private final List<DataProviderInfo> dataProviders = new ArrayList<>();
+  private final IterationFilter iterationFilter = new IterationFilter();
 
   private boolean reportIterations = true;
 
@@ -150,6 +151,10 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
 
   public void setIterationNameProvider(NameProvider<IterationInfo> provider) {
     iterationNameProvider = provider;
+  }
+
+  public IterationFilter getIterationFilter() {
+    return iterationFilter;
   }
 
   /**

--- a/spock-core/src/main/java/org/spockframework/runtime/model/IterationFilter.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/IterationFilter.java
@@ -1,0 +1,29 @@
+package org.spockframework.runtime.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class IterationFilter {
+
+  private final Set<Integer> allowed = new HashSet<>();
+  private Mode mode = Mode.EXPLICIT;
+
+  public void allow(int index) {
+    if (this.mode == Mode.EXPLICIT) {
+      this.allowed.add(index);
+    }
+  }
+
+  public void allowAll() {
+    this.mode = Mode.ALLOW_ALL;
+    this.allowed.clear();
+  }
+
+  public boolean isAllowed(int index) {
+    return allowed.isEmpty() || allowed.contains(index);
+  }
+
+  private enum Mode {
+    EXPLICIT, ALLOW_ALL
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/model/IterationFilterSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/model/IterationFilterSpec.groovy
@@ -1,0 +1,35 @@
+package org.spockframework.runtime.model
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class IterationFilterSpec extends Specification {
+
+  @Subject
+  def filter = new IterationFilter()
+
+  def "allows all indexes by default"() {
+    expect:
+    filter.isAllowed(0)
+    filter.isAllowed(1)
+  }
+
+  def "allows only selected indexes after one has been allowed explicitly"() {
+    when:
+    filter.allow(0)
+
+    then:
+    filter.isAllowed(0)
+    !filter.isAllowed(1)
+  }
+
+  def "allows all indexes after configured to do so"() {
+    when:
+    filter.allow(0)
+    filter.allowAll()
+
+    then:
+    filter.isAllowed(0)
+    filter.isAllowed(1)
+  }
+}

--- a/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
+++ b/spock-testkit/src/test/groovy/spock/platform/SpockHelloWorldTest.java
@@ -71,8 +71,34 @@ class SpockHelloWorldTest extends SpockEngineBase {
   }
 
   @Test
+  void iterationsAreResolved() {
+    UniqueId featureMethodUniqueId = UniqueId.forEngine("spock")
+      .append("spec", UnrollTestCase.class.getName())
+      .append("feature", "$spock_feature_0_0");
+
+    execute(
+      selectUniqueId(featureMethodUniqueId.append("iteration", "1")),
+      stats -> stats.started(2).succeeded(1).failed(1)
+    );
+    execute(
+      asList(
+        selectUniqueId(featureMethodUniqueId.append("iteration", "0")),
+        selectUniqueId(featureMethodUniqueId.append("iteration", "2"))
+      ),
+      stats -> stats.started(3).succeeded(3)
+    );
+    execute(
+      asList(
+        selectUniqueId(featureMethodUniqueId.append("iteration", "0")),
+        selectUniqueId(featureMethodUniqueId)
+      ),
+      stats -> stats.started(4).succeeded(3).failed(1)
+    );
+  }
+
+  @Test
   void verifyUnrollExample() {
-    execute(selectClass(UnrollTestCase.class), stats -> stats.started(13).succeeded(13));
+    execute(selectClass(UnrollTestCase.class), stats -> stats.started(13).succeeded(12).failed(1));
   }
 
   @Test

--- a/spock-testkit/src/test/groovy/spock/testkit/testsources/UnrollTestCase.groovy
+++ b/spock-testkit/src/test/groovy/spock/testkit/testsources/UnrollTestCase.groovy
@@ -11,7 +11,7 @@ class UnrollTestCase extends Specification {
     where:
     a | b | c
     1 | 2 | 2
-    2 | 2 | 2
+    2 | 2 | 0
     3 | 2 | 3
   }
 


### PR DESCRIPTION
Individual iterations can now be selected via their unique ID.

Co-authored-by: Leonard Brünings <lbruenings@gradle.com>