### PR TITLE
Fix issue with JavaDoc generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,16 +107,14 @@ subprojects {
     }
   }
 
-  if (javaVersion >= 9) {
-    tasks.withType(JavaCompile) {
-      javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(8)
-      }
-      options.encoding = 'UTF-8'
+  tasks.withType(JavaCompile) {
+    javaCompiler = javaToolchains.compilerFor {
+      languageVersion = JavaLanguageVersion.of(8)
     }
-    tasks.withType(GroovyCompile) {
-      options.encoding = 'UTF-8'
-    }
+    options.encoding = 'UTF-8'
+  }
+  tasks.withType(GroovyCompile) {
+    options.encoding = 'UTF-8'
   }
 
   sourceSets.all { ss ->
@@ -387,10 +385,8 @@ def configureJavadoc(task) {
   configure(task) {
     include "spock/**"
     configure(options) {
-      if (javaVersion >= 8) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-        options.noTimestamp()
-      }
+      options.addStringOption('Xdoclint:none', '-quiet')
+      options.noTimestamp()
       options.addStringOption('source', '1.8')
       links "https://docs.oracle.com/javase/8/docs/api/"
       links "https://docs.groovy-lang.org/docs/groovy-$groovyVersion/html/gapi/"


### PR DESCRIPTION
With the changes related to JDK17 compatibility, JavaDoc configuration
has been moved from allprojects to subprojects which stopped configuring
a custom javadoc task in the root project. It [broke](https://github.com/spockframework/spock/runs/3818931140#step:8:479) JavaDoc generation
for master branch on CI.

What is strange there was no CI build for the previous [commit](https://github.com/spockframework/spock/commit/b0e5f62aa911103779169b0ea66c3e5aea23b0be):
https://github.com/spockframework/spock/actions?query=branch%3Amaster+

Just the next one, which was not related.