### PR TITLE
Fix potential variable name conflict for throwable

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
@@ -50,6 +50,7 @@ import static org.spockframework.compiler.AstUtil.createDirectMethodCall;
  */
 public class ConditionRewriter extends AbstractExpressionConverter<Expression> implements GroovyCodeVisitorCompat {
   private static final Pattern COMMENTS_PATTERN = Pattern.compile("/\\*.*?\\*/|//.*$");
+  private static final String THROWABLE = "$spock_condition_throwable";
 
   private final IRewriteResources resources;
 
@@ -678,7 +679,7 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> i
 
     tryCatchStatement.addCatch(
         new CatchStatement(
-            new Parameter(new ClassNode(Throwable.class), "throwable"),
+            new Parameter(new ClassNode(Throwable.class), THROWABLE),
             new ExpressionStatement(
                 createDirectMethodCall(
                     new ClassExpression(resources.getAstNodeCache().SpockRuntime),
@@ -690,7 +691,7 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> i
                         new ConstantExpression(condition.getLineNumber()),            // line
                         new ConstantExpression(condition.getColumnNumber()),          // column
                         message == null ? ConstantExpression.NULL : message,          // message
-                        new VariableExpression("throwable")                           // throwable
+                        new VariableExpression(THROWABLE)                             // throwable
                     ))
                 )
             )
@@ -707,14 +708,14 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> i
 
     tryCatchStatement.addCatch(
       new CatchStatement(
-        new Parameter(new ClassNode(Throwable.class), "throwable"),
+        new Parameter(new ClassNode(Throwable.class), THROWABLE),
         new ExpressionStatement(
           createDirectMethodCall(
             new ClassExpression(resources.getAstNodeCache().SpockRuntime),
             resources.getAstNodeCache().SpockRuntime_GroupConditionFailedWithException,
             new ArgumentListExpression(Arrays.<Expression>asList(
               new VariableExpression(errorCollectorName),
-              new VariableExpression("throwable")                                     // throwable
+              new VariableExpression(THROWABLE)                                     // throwable
             ))
           )
         )

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/CleanupBlocksAstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/CleanupBlocksAstSpec.groovy
@@ -40,8 +40,8 @@ public void $spock_feature_0_0() {
         try {
             org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'println(foobar)', 6, 3, null, this, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), 'println'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), foobar)}, $spock_valueRecorder.realizeNas(4, false), false, 3)
         }
-        catch (java.lang.Throwable throwable) {
-            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'println(foobar)', 6, 3, null, throwable)}
+        catch (java.lang.Throwable $spock_condition_throwable) {
+            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'println(foobar)', 6, 3, null, $spock_condition_throwable)}
         finally {
         }
     }
@@ -102,8 +102,8 @@ public void $spock_feature_0_0() {
         try {
             org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'println(foobar)', 6, 3, null, this, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), 'println'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), foobar)}, $spock_valueRecorder.realizeNas(4, false), false, 3)
         }
-        catch (java.lang.Throwable throwable) {
-            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'println(foobar)', 6, 3, null, throwable)}
+        catch (java.lang.Throwable $spock_condition_throwable) {
+            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'println(foobar)', 6, 3, null, $spock_condition_throwable)}
         finally {
         }
     }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataProviders.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataProviders.groovy
@@ -125,8 +125,8 @@ public java.lang.Object $spock_feature_0_0prov0() {
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder1.reset(), 'true', 2, 29, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true))
         }
-        catch (java.lang.Throwable throwable) {
-            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 2, 29, null, throwable)}
+        catch (java.lang.Throwable $spock_condition_throwable) {
+            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 2, 29, null, $spock_condition_throwable)}
         finally {
         }
     }]
@@ -179,8 +179,8 @@ public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0) {
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder1.reset(), 'true', 3, 31, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true))
         }
-        catch (java.lang.Throwable throwable) {
-            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 3, 31, null, throwable)}
+        catch (java.lang.Throwable $spock_condition_throwable) {
+            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 3, 31, null, $spock_condition_throwable)}
         finally {
         }
     }) as java.lang.Object)


### PR DESCRIPTION
Prior to this commit, Spock would generate try-catch blocks with the
catch variable being named `throwable`, this would lead to strange
compilation errors when users tried to use a variable named `throwable`
in their code.