### PR TITLE
Declare repositories in settings.gradle instead of allProjects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,10 +88,6 @@ allprojects {
       }
     }
   }
-
-  repositories {
-    mavenCentral()
-  }
 }
 
 apply from: script("ide")

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,12 @@ plugins {
   id "com.gradle.common-custom-user-data-gradle-plugin"
 }
 
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+  }
+}
+
 def gradleEnterpriseServer = "https://ge.spockframework.org"
 def isCiServer = System.env["CI"] || System.env["GITHUB_ACTIONS"]
 def spockBuildCacheUsername = ext.has('spockBuildCacheUsername') ? ext['spockBuildCacheUsername'] : null


### PR DESCRIPTION
Since allProjects is the classical way of defining build logic that
should not be used anymore, this moves the repository declaration for
mavenCentral to dependencyResolutionManagement in the settings script.
This makes the repository available in all modules.