### PR TITLE
Add single space into CannotCreateMockException message

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/CannotCreateMockException.java
+++ b/spock-core/src/main/java/org/spockframework/mock/CannotCreateMockException.java
@@ -32,6 +32,6 @@ public class CannotCreateMockException extends RuntimeException {
   }
 
   public CannotCreateMockException(Class<?> mockType, String message, Throwable cause) {
-    super(String.format("Cannot create mock for %s%s", mockType, message), cause);
+    super(String.format("Cannot create mock for %s %s", mockType, message), cause);
   }
 }


### PR DESCRIPTION
I faced occurrence of `CannotCreateMockException` in my project.
Its error message was like `Cannot create mock for class myPackage.MyClassnull`.
I think `MyClassnull` in the message should be split into two words, `MyClass` and `null` for understandability.