### PR TITLE
ci: add randomized test matrix for better test coverage

### DIFF
--- a/.github/workflows/branches-and-prs.yml
+++ b/.github/workflows/branches-and-prs.yml
@@ -9,32 +9,39 @@ on:
     branches:
       - '*'
 
+concurrency:
+  # On master/release, we don't want any jobs cancelled so the sha is used to name the group
+  # On PR branches, we cancel the job if new commits are pushed
+  # More info: https://stackoverflow.com/a/68422069/253468
+  group: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release' ) && format('ci-main-{0}', github.sha) || format('ci-main-{0}', github.ref) }}
+  cancel-in-progress: true
+
 jobs:
+  matrix_prep:
+    name: Matrix Preparation
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      MATRIX_JOBS: 7
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - id: set-matrix
+        run: |
+          node .github/workflows/matrix.js
+
   build-and-verify:
+    needs: matrix_prep
+    name: '${{ matrix.name }}'
     runs-on: ${{ matrix.os }}
+    env:
+      TZ: ${{ matrix.tz }}
     strategy:
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
       fail-fast: false
-      matrix:
-        os: ['ubuntu-latest']
-        variant: ['2.5', '3.0']
-        java: ['8', '11', '17']
-        exclude:
-          - os: 'ubuntu-latest'
-            variant: '2.5'
-            java: '17'
-        include:
-          - os: 'windows-latest'
-            variant: '2.5'
-            java: '8'
-          - os: 'windows-latest'
-            variant: '3.0'
-            java: '8'
-          - os: 'macos-latest'
-            variant: '2.5'
-            java: '8'
-          - os: 'macos-latest'
-            variant: '3.0'
-            java: '8'
+      # max-parallel: 4
     steps:
       - uses: actions/checkout@v2
         with:
@@ -44,7 +51,7 @@ jobs:
         uses: actions/setup-java@v2
         if: matrix.java != 8
         with:
-          distribution: 'adopt'
+          distribution: ${{ matrix.java_distribution }}
           java-version: ${{ matrix.java }}
       - name: 'Prepare JDK${{ matrix.java }} env var'
         shell: bash
@@ -54,7 +61,7 @@ jobs:
         with:
           java-version: 8
           cache: 'gradle'
-          distribution: 'adopt'
+          distribution: ${{ matrix.java8_distribution }}
       - name: Prepare JDK8 env var
         shell: bash
         run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
@@ -68,6 +75,7 @@ jobs:
           ORG_GRADLE_PROJECT_spockBuildCacheUsername: ${{ secrets.SPOCK_BUILD_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_spockBuildCachePassword: ${{ secrets.SPOCK_BUILD_CACHE_PASSWORD }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          _JAVA_OPTIONS: ${{ matrix.testExtraJvmArgs }}
         run: |
           ./gradlew --no-parallel --stacktrace ghActionsBuild "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}"
       - name: 'Stop Daemon'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,13 @@ on:
   schedule:
     - cron: '0 15 * * 2'
 
+concurrency:
+  # On master/release, we don't want any jobs cancelled so the sha is used to name the group
+  # On PR branches, we cancel the job if new commits are pushed
+  # More info: https://stackoverflow.com/a/68422069/253468
+  group: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release' ) && format('ci-main-{0}', github.sha) || format('ci-main-{0}', github.ref) }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -1,0 +1,148 @@
+// The script generates a random subset of valid jdk, os, timezone, and other axes.
+// You can preview the results by running "node matrix.js"
+// See https://github.com/vlsi/github-actions-random-matrix
+let {MatrixBuilder} = require('./matrix_builder');
+const matrix = new MatrixBuilder();
+matrix.addAxis({
+  name: 'java_distribution',
+  values: [
+    'zulu',
+    'temurin',
+    'liberica',
+    'microsoft',
+  ]
+});
+
+matrix.addAxis({
+  name: 'java8_distribution',
+  values: [
+    'zulu',
+    'temurin',
+    'liberica',
+  ]
+});
+
+// TODO: support different JITs (see https://github.com/actions/setup-java/issues/279)
+matrix.addAxis({name: 'jit', title: '', values: ['hotspot']});
+
+matrix.addAxis({
+  name: 'java',
+  // Strings allow versions like 18-ea
+  values: [
+    '8',
+    '11',
+    '17',
+  ]
+});
+
+matrix.addAxis({
+  name: 'tz',
+  values: [
+    'America/New_York',
+    'Pacific/Chatham',
+    'UTC'
+  ]
+});
+
+matrix.addAxis({
+  name: 'os',
+  title: x => x.replace('-latest', ''),
+  values: [
+    'ubuntu-latest',
+    'windows-latest',
+    'macos-latest'
+  ]
+});
+
+matrix.addAxis({
+  name: 'variant',
+  values: [
+    '2.5',
+    '3.0',
+  ]
+});
+
+// Test cases when Object#hashCode produces the same results
+// It allows capturing cases when the code uses hashCode as a unique identifier
+matrix.addAxis({
+  name: 'hash',
+  values: [
+    {value: 'regular', title: '', weight: 42},
+    {value: 'same', title: 'same hashcode', weight: 1}
+  ]
+});
+matrix.addAxis({
+  name: 'locale',
+  title: x => x.language + '_' + x.country,
+  values: [
+    {language: 'de', country: 'DE'},
+    {language: 'fr', country: 'FR'},
+    // TODO: fix :src:dist-check:batchBUG_62847
+    // Fails with "ERROR o.a.j.u.JMeterUtils: Could not find resources for 'ru_EN'"
+    // {language: 'ru', country: 'RU'},
+    {language: 'tr', country: 'TR'},
+  ]
+});
+
+matrix.setNamePattern(['java', 'java_distribution', 'hash', 'os', 'tz', 'locale']);
+
+// Microsoft Java has no distribution for 8
+matrix.exclude({java_distribution: 'microsoft', java: 8});
+matrix.exclude({java: 17, variant: '2.5', os: 'ubuntu-latest'});
+// Ensure at least one job with "same" hashcode exists
+matrix.generateRow({hash: {value: 'same'}});
+// Ensure at least one Windows and at least one Linux job is present (macOS is almost the same as Linux)
+matrix.generateRow({os: 'windows-latest'});
+matrix.generateRow({os: 'ubuntu-latest'});
+// Ensure there will be at least one job with Java 8
+matrix.generateRow({java: 8});
+// Ensure there will be at least one job with Java 11
+matrix.generateRow({java: 11});
+// Ensure there will be at least one job with Java 17
+matrix.generateRow({java: 17});
+const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
+if (include.length === 0) {
+  throw new Error('Matrix list is empty');
+}
+include.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}));
+include.forEach(v => {
+  let jvmArgs = [];
+  if (v.hash.value === 'same') {
+    jvmArgs.push('-XX:+UnlockExperimentalVMOptions', '-XX:hashCode=2');
+  }
+  // Gradle does not work in tr_TR locale, so pass locale to test only: https://github.com/gradle/gradle/issues/17361
+  jvmArgs.push(`-Duser.country=${v.locale.country}`);
+  jvmArgs.push(`-Duser.language=${v.locale.language}`);
+  if (v.jit === 'hotspot' && Math.random() > 0.5) {
+    // The following options randomize instruction selection in JIT compiler
+    // so it might reveal missing synchronization in TestNG code
+    v.name += ', stress JIT';
+    jvmArgs.push('-XX:+UnlockDiagnosticVMOptions');
+    if (v.java >= 8) {
+      // Randomize instruction scheduling in GCM
+      // share/opto/c2_globals.hpp
+      jvmArgs.push('-XX:+StressGCM');
+      // Randomize instruction scheduling in LCM
+      // share/opto/c2_globals.hpp
+      jvmArgs.push('-XX:+StressLCM');
+    }
+    /*
+    TODO: gradle is launched with Java 8 always, so we should pass the options via test task execution
+    if (v.java >= 16) {
+      // Randomize worklist traversal in IGVN
+      // share/opto/c2_globals.hpp
+      jvmArgs.push('-XX:+StressIGVN');
+    }
+    if (v.java >= 17) {
+      // Randomize worklist traversal in CCP
+      // share/opto/c2_globals.hpp
+      jvmArgs.push('-XX:+StressCCP');
+    }
+    */
+  }
+  v.testExtraJvmArgs = jvmArgs.join(' ');
+  delete v.hash;
+});
+
+console.log(include);
+console.log('::set-output name=matrix::' + JSON.stringify({include}));

--- a/.github/workflows/matrix_builder.js
+++ b/.github/workflows/matrix_builder.js
@@ -1,0 +1,158 @@
+// License: Apache-2.0
+// Copyright Vladimir Sitnikov, 2021
+// See https://github.com/vlsi/github-actions-random-matrix
+
+class Axis {
+  constructor({name, title, values}) {
+    this.name = name;
+    this.title = title;
+    this.values = values;
+    // If all entries have same weight, the axis has uniform distribution
+    this.uniform = values.reduce((a, b) => a === (b.weight || 1) ? a : 0, values[0].weight || 1) !== 0
+    this.totalWeigth = this.uniform ? values.length : values.reduce((a, b) => a + (b.weight || 1), 0);
+  }
+
+  static matches(row, filter) {
+    if (typeof filter === 'function') {
+      return filter(row);
+    }
+    if (Array.isArray(filter)) {
+      // e.g. row={os: 'windows'}; filter=[{os: 'linux'}, {os: 'linux'}]
+      return filter.find(v => Axis.matches(row, v));
+    }
+    if (typeof filter === 'object') {
+      // e.g. row={jdk: {name: 'openjdk', version: 8}}; filter={jdk: {version: 8}}
+      for (const [key, value] of Object.entries(filter)) {
+        if (!row.hasOwnProperty(key) || !Axis.matches(row[key], value)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return row == filter;
+  }
+
+  pickValue(filter) {
+    let values = this.values;
+    if (filter) {
+      values = values.filter(v => Axis.matches(v, filter));
+    }
+    if (values.length == 0) {
+      const filterStr = typeof filter === 'string' ? filter.toString() : JSON.stringify(filter);
+      throw Error(`No values produces for axis '${this.name}' from ${JSON.stringify(this.values)}, filter=${filterStr}`);
+    }
+    if (values.length == 1) {
+      return values[0];
+    }
+    if (this.uniform) {
+      return values[Math.floor(Math.random() * values.length)];
+    }
+    const totalWeight = !filter ? this.totalWeigth : values.reduce((a, b) => a + (b.weight || 1), 0);
+    let weight = Math.random() * totalWeight;
+    for (let i = 0; i < values.length; i++) {
+      const value = values[i];
+      weight -= value.weight || 1;
+      if (weight <= 0) {
+        return value;
+      }
+    }
+    return values[values.length - 1];
+  }
+}
+
+class MatrixBuilder {
+  constructor() {
+    this.axes = [];
+    this.axisByName = {};
+    this.rows = [];
+    this.duplicates = {};
+    this.excludes = [];
+    this.includes = [];
+  }
+
+  /**
+   * Specifies include filter (all the generated rows would comply with all the include filters)
+   * @param filter
+   */
+  include(filter) {
+    this.includes.push(filter);
+  }
+
+  /**
+   * Specifies exclude filter (e.g. exclude a forbidden combination)
+   * @param filter
+   */
+  exclude(filter) {
+    this.excludes.push(filter);
+  }
+
+  addAxis({name, title, values}) {
+    const axis = new Axis({name, title, values});
+    this.axes.push(axis);
+    this.axisByName[name] = axis;
+    return axis;
+  }
+
+  setNamePattern(names) {
+    this.namePattern = names;
+  }
+
+  /**
+   * Adds a row that matches the given filter to the resulting matrix.
+   * filter values could be
+   *  - literal values: filter={os: 'windows-latest'}
+   *  - arrays: filter={os: ['windows-latest', 'linux-latest']}
+   *  - functions: filter={os: x => x!='windows-latest'}
+   * @param filter object with keys matching axes names
+   * @returns {*}
+   */
+  generateRow(filter) {
+    let res;
+    if (filter) {
+      // If matching row already exists, no need to generate more
+      res = this.rows.find(v => Axis.matches(v, filter));
+      if (res) {
+        return res;
+      }
+    }
+    for (let i = 0; i < 142; i++) {
+      res = this.axes.reduce(
+        (prev, next) =>
+          Object.assign(prev, {
+            [next.name]: next.pickValue(filter ? filter[next.name] : undefined)
+          }),
+        {}
+      );
+      if (this.excludes.length > 0 && this.excludes.find(f => Axis.matches(res, f)) ||
+        this.includes.length > 0 && !this.includes.find(f => Axis.matches(res, f))) {
+        continue;
+      }
+      const key = JSON.stringify(res);
+      if (!this.duplicates.hasOwnProperty(key)) {
+        this.duplicates[key] = true;
+        res.name =
+          this.namePattern.map(axisName => {
+            let value = res[axisName];
+            const title = value.title;
+            if (typeof title != 'undefined') {
+              return title;
+            }
+            const computeTitle = this.axisByName[axisName].title;
+            return computeTitle ? computeTitle(value) : value;
+          }).filter(Boolean).join(", ");
+        this.rows.push(res);
+        return res;
+      }
+    }
+    throw Error(`Unable to generate row. Please check include and exclude filters`);
+  }
+
+  generateRows(maxRows, filter) {
+    for (let i = 0; this.rows.length < maxRows && i < maxRows; i++) {
+      this.generateRow(filter);
+    }
+    return this.rows;
+  }
+}
+
+module.exports = {Axis, MatrixBuilder};


### PR DESCRIPTION
This enables significantly improve test coverage while still keeping test feedback fast and easy configuration.

For example, this matrix captures locale-dependent issues like https://github.com/spockframework/spock/issues/1414
Here's how the matrix looks in my fork: https://github.com/vlsi/spock/actions/runs/1702274076


The idea is that you declare test axis like `os`, `java`, `java_distribution`, `timezone`, `locale`, etc, and `matrix.js` produces several jobs for you.

Note: I do not understand what `variant=2.5` and `variant=3.0` mean, and I do not understand why did you exclude `{java: 17, variant: '2.5', os: 'ubuntu-latest'}`.
If the only reason to exclude `2.5 with java 17 on ubuntu` was performance, then you might remove that exclusion from `matrix.js`.

See https://github.com/vlsi/github-actions-random-matrix

If you want to test matrix changes locally, you can launch `node matrix.js` and it prints something like

```
...
  {
    java_distribution: 'liberica',
    java8_distribution: 'liberica',
    jit: 'hotspot',
    java: '17',
    tz: 'America/New_York',
    os: 'ubuntu-latest',
    variant: '3.0',
    locale: { language: 'de', country: 'DE' },
    name: '17, liberica, ubuntu, America/New_York, de_DE, stress JIT',
    testExtraJvmArgs: '-Duser.country=DE -Duser.language=de -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM'
  },
  {
    java_distribution: 'zulu',
    java8_distribution: 'liberica',
    jit: 'hotspot',
    java: '17',
    tz: 'America/New_York',
    os: 'ubuntu-latest',
    variant: '3.0',
    locale: { language: 'tr', country: 'TR' },
    name: '17, zulu, same hashcode, ubuntu, America/New_York, tr_TR, stress JIT',
    testExtraJvmArgs: '-XX:+UnlockExperimentalVMOptions -XX:hashCode=2 -Duser.country=TR -Duser.language=tr -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM'
  }
]
::set-output name=matrix::{"include":[{"java_distribution":"liberica","java8_distribution":"temurin","jit":"hotspot","java":"8","tz":"UTC","os":"windows-latest","variant":"3.0","locale":{"language":"fr","country":"FR"},"name":"8, liberica, windows, UTC, fr_FR, stress JIT","testExtraJvmArgs":"-Duser.country=FR -Duser.language=fr -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM"},{"java_distribution":"temurin","java8_distribution":"zulu","jit":"hotspot","java":"11","tz":"America/New_York","os":"ubuntu-latest","variant":"2.5","locale":{"language":"de","country":"DE"},"name":"11, temurin, ubuntu, America/New_York, de_DE","testExtraJvmArgs":"-Duser.country=DE -Duser.language=de"},{"java_distribution":"liberica","java8_distribution":"liberica","jit":"hotspot","java":"17","tz":"UTC","os":"macos-latest","variant":"3.0","locale":{"language":"de","country":"DE"},"name":"17, liberica, macos, UTC, de_DE","testExtraJvmArgs":"-Duser.country=DE -Duser.language=de"},{"java_distribution":"liberica","java8_distribution":"liberica","jit":"hotspot","java":"17","tz":"America/New_York","os":"ubuntu-latest","variant":"3.0","locale":{"language":"de","country":"DE"},"name":"17, liberica, ubuntu, America/New_York, de_DE, stress JIT","testExtraJvmArgs":"-Duser.country=DE -Duser.language=de -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM"},{"java_distribution":"zulu","java8_distribution":"liberica","jit":"hotspot","java":"17","tz":"America/New_York","os":"ubuntu-latest","variant":"3.0","locale":{"language":"tr","country":"TR"},"name":"17, zulu, same hashcode, ubuntu, America/New_York, tr_TR, stress JIT","testExtraJvmArgs":"-XX:+UnlockExperimentalVMOptions -XX:hashCode=2 -Duser.country=TR -Duser.language=tr -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM"}]}
```