### PR TITLE
Mention extension module artifacts in documentation

### DIFF
--- a/docs/module_spring.adoc
+++ b/docs/module_spring.adoc
@@ -2,7 +2,7 @@
 include::include.adoc[]
 
 The Spring module enables integration with http://docs.spring.io/spring/docs/4.1.5.RELEASE/spring-framework-reference/html/testing.html#testcontext-framework[Spring TestContext Framework].
-It supports the following spring annotations `@ContextConfiguration` and `@ContextHierarchy`. Furthermore, it supports the meta-annotation `@BootstrapWith` and so any annotation that is annotated with `@BootstrapWith` will also work, such as `@SpringBootTest`, `@WebMvcTest`.
+It supports the following spring annotations `@ContextConfiguration` and `@ContextHierarchy`. Furthermore, it supports the meta-annotation `@BootstrapWith` and so any annotation that is annotated with `@BootstrapWith` will also work, such as `@SpringBootTest`, `@WebMvcTest`. Please add dependency https://search.maven.org/artifact/org.spockframework/spock-spring[`org.spockframework:spock-spring`] to your project.
 
 == Mocks
 

--- a/docs/modules.adoc
+++ b/docs/modules.adoc
@@ -4,7 +4,7 @@ include::include.adoc[]
 [[junit-4]]
 == JUnit 4 Module
 
-Integration with JUnit 4 features for Spock 2+ (which internally uses JUnit Platform - part of JUnit 5).
+Integration with JUnit 4 features for Spock 2+ (which internally uses JUnit Platform - part of JUnit 5). Please add dependency https://search.maven.org/artifact/org.spockframework/spock-junit4[`org.spockframework:spock-junit4`] to your project.
 
 The module is required for:
 
@@ -16,7 +16,7 @@ NOTE: This module does its best to support old features from JUnit 4, however, u
 
 == Guice Module
 
-Integration with the http://code.google.com/p/google-guice/[Guice] IoC container. For examples see the specs in the
+Integration with the http://code.google.com/p/google-guice/[Guice] IoC container. Please add dependency https://search.maven.org/artifact/org.spockframework/spock-guice[`org.spockframework:spock-guice`] to your project. For examples see the specs in the
 https://github.com/spockframework/spock/tree/master/spock-guice/src/test/groovy/org/spockframework/guice[codebase].
 
 With Spock 1.2+ detached mocks are automatically attached to the `Specification` if they are injected via `@Inject`.
@@ -26,18 +26,18 @@ include::module_spring.adoc[leveloffset=+1]
 
 == Tapestry Module
 
-Integration with the http://tapestry.apache.org/tapestry5/[Tapestry5] IoC container. For examples see the specs in the
+Integration with the http://tapestry.apache.org/tapestry5/[Tapestry5] IoC container. Please add dependency https://search.maven.org/artifact/org.spockframework/spock-tapestry[`org.spockframework:spock-tapestry`] to your project. For examples see the specs in the
 https://github.com/spockframework/spock/tree/master/spock-tapestry/src/test/groovy/org/spockframework/tapestry[codebase].
 
 
 == Unitils Module
 
-Integration with the http://www.unitils.org/[Unitils] library. For examples see the specs in the
+Integration with the http://www.unitils.org/[Unitils] library. Please add dependency https://search.maven.org/artifact/org.spockframework/spock-unitils[`org.spockframework:spock-unitils`] to your project. For examples see the specs in the
 https://github.com/spockframework/spock/tree/master/spock-unitils/src/test/groovy/org/spockframework/unitils[codebase].
 
 
 == Grails Module
 
-The Grails plugin has moved to its own https://github.com/spockframework/spock-grails[GitHub project].
+The Grails plugin has moved to its own https://github.com/spockframework/spock-grails[GitHub project]. It has legacy status and was last released for https://search.maven.org/artifact/org.spockframework/spock-grails[Spock 0.7 and Groovy versions 1.8 and 2.0], because it is no longer necessary.
 
 NOTE: Grails 2.3 and higher have built-in Spock support and do not require a plugin.


### PR DESCRIPTION
For each Spock extension module, now the documentation explicitly mentions their group IDs and artifact names, also linking to the corresponding artifact at Maven Central. Before, users were struggling sometimes, and it was not easily possible to point them to the Spock manual.

See e.g. https://stackoverflow.com/a/70917526/1082681. Quote:

> We are missing one dependency here 
> ```groovy
> testImplementation group: 'org.spockframework', name: 'spock-spring', version: '2.1-M2-groovy-3.0'
> ```
> Which basically makes it possible to write tests in Spock and use spring test context. 
> 
> (...) it took me 4 hours to discover (very sad face) :// 