### PR TITLE
Add basic support for JUnit platform tags

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/FeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/FeatureNode.java
@@ -10,6 +10,7 @@ public abstract class FeatureNode extends SpockNode<FeatureInfo> {
   public FeatureNode(UniqueId uniqueId, String displayName, TestSource source, RunnerConfiguration configuration,
                      FeatureInfo featureInfo) {
     super(uniqueId, displayName, source, configuration, featureInfo);
+    tags = getTags(featureInfo.getFeatureMethod().getReflection());
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/IterationNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IterationNode.java
@@ -15,6 +15,7 @@ public class IterationNode extends SpockNode<FeatureInfo> {
     super(uniqueId, iterationInfo.getDisplayName(), featureToMethodSource(iterationInfo.getFeature()), configuration,
       iterationInfo.getFeature());
     this.iterationInfo = iterationInfo;
+    tags = getTags(iterationInfo.getFeature().getFeatureMethod().getReflection());
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/JUnitTag.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/JUnitTag.java
@@ -1,0 +1,57 @@
+package org.spockframework.runtime;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @JUnitTag} is a {@linkplain Repeatable repeatable} annotation that is
+ * used to declare a <em>tag</em> for the annotated test class or test method.
+ *
+ * <p>Tags are used to filter which tests are executed for a given test
+ * plan. For example, a development team may tag tests with values such as
+ * {@code "fast"}, {@code "slow"}, {@code "ci-server"}, etc. and then supply a
+ * list of tags to be included in or excluded from the current test plan,
+ * potentially dependent on the current environment.
+ *
+ * <h3>Syntax Rules for Tags</h3>
+ * <ul>
+ * <li>A tag must not be blank.</li>
+ * <li>A <em>trimmed</em> tag must not contain whitespace.</li>
+ * <li>A <em>trimmed</em> tag must not contain ISO control characters.</li>
+ * <li>A <em>trimmed</em> tag must not contain any of the following
+ * <em>reserved characters</em>.
+ * <ul>
+ * <li>{@code ,}: <em>comma</em></li>
+ * <li>{@code (}: <em>left parenthesis</em></li>
+ * <li>{@code )}: <em>right parenthesis</em></li>
+ * <li>{@code &}: <em>ampersand</em></li>
+ * <li>{@code |}: <em>vertical bar</em></li>
+ * <li>{@code !}: <em>exclamation point</em></li>
+ * </ul>
+ * </li>
+ * </ul>
+ *
+ * @since 2.2
+ * @see JUnitTags
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Repeatable(JUnitTags.class)
+public @interface JUnitTag {
+  /**
+   * The <em>tag</em>.
+   *
+   * <p>Note: the tag will first be {@linkplain String#trim() trimmed}. If the
+   * supplied tag is syntactically invalid after trimming, the error will be
+   * logged as a warning, and the invalid tag will be effectively ignored. See
+   * {@linkplain JUnitTag Syntax Rules for Tags}.
+   */
+  String value();
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/JUnitTags.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/JUnitTags.java
@@ -1,0 +1,30 @@
+package org.spockframework.runtime;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @JUnitTags} is a container for one or more {@link JUnitTag} declarations.
+ *
+ * <p>Note, however, that use of the {@code @JUnitTags} container is completely
+ * optional since {@code @JUnitTag} is a {@linkplain java.lang.annotation.Repeatable
+ * repeatable} annotation.
+ *
+ * @since 2.2
+ * @see JUnitTag
+ * @see java.lang.annotation.Repeatable
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface JUnitTags {
+  /**
+   * An array of one or more {@link JUnitTag}s.
+   */
+  JUnitTag[] value();
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecNode.java
@@ -12,6 +12,7 @@ public class SpecNode extends SpockNode<SpecInfo> {
 
   protected SpecNode(UniqueId uniqueId, RunnerConfiguration configuration, SpecInfo specInfo) {
     super(uniqueId, specInfo.getDisplayName(), ClassSource.from(specInfo.getReflection()), configuration, specInfo);
+    tags = getTags(specInfo.getReflection());
   }
 
   @Override

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RepeatableLocalExtensionsSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RepeatableLocalExtensionsSpec.groovy
@@ -223,5 +223,5 @@ def foo() {
 
 @Retention(RetentionPolicy.RUNTIME)
 @interface FooContainer {
-  Foo[] value();
+  Foo[] value() default [];
 }


### PR DESCRIPTION
Two new annotations `JUnitTag` and `JUnitTags`, basically copied from Jupiter's `Tag` and `Tags`, as well as a copy of static helper method `JupiterTestDescriptor.getTags` are the building blocks of tag support.

In order to actually pass on the tags to JUnit platform, classes `SpockNode`, `SpecNode`, `FeatureNode`, `IterationNode` were adjusted.

This PR has not been tested extensively, but I did try with Maven Surefire's `groups` and `excludedGroups` parameters, which worked nicely, also for the boolean [tag expression syntax](https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions) supported by the JUnit platform. I also gave it a quick try to e.g. tag a spec with an included tag and a feature with an excluded one, which correctly excluded the one feature.

Fixes #1288.

To do:
  - [ ] Discuss annotation naming. IMO, we could also use `Tag|Tags`, similar to Jupiter but in Spock's package namespace so as not to require a dependency on Jupiter.
  - [ ] Optionally also support Jupiter's tag annotations, e.g. by using reflection for matching in order to also avoid a dependency on Jupiter. That way we could both automatically support Jupiter annotations and at the same time not depend on them for users happy with the ones from the Spock namespace.
  - [ ] Check if it makes more sense to use Spock's hierarchy of super/sub specs in `SpecInfo` instead of using the cloned helper method `JupiterTestDescriptor.getTags` which in turn relies on the public, but internal platform method `AnnotationUtils.findRepeatableAnnotations`.
  - [ ] Clarify possible design issue with regard to field `SpockNode.tags` which is defined as protected and non-final, so it can be re-used and initialised in subclasses. The analog classes in Jupiter use private or protected final fields not in the common base class analog `JupiterTestDescriptor`, but in its class-or method-based subclasses in order to enforce initialisation in constructors. As a consequence, Jupiter also has to use multiple similar or identical copies of `getTags()` methods in those subclasses, each accessing the individual `this.tags` field in each subclass. My decision to make the field non-final might be a little bit less clean, but avoids duplicate fields and methods, keeping the code more maintainable.
  - [ ] Test with a Gradle project in addition to just Maven.
  - [ ] Add automated tests to Spock.

Personal notes:
- This was not as difficult to add as I thought. I never used JUnit tags before, but the discussions in #1288 and #1425 made me curious, so I gave it a try. Actually, this tags concept is quite charming, usable to either complement or replace Spock's traditional include/exclude extension, which needs to be configured in a Spock config file. Supporting JUnit platform tags opens up the world of direct build tool support without adding any Spock-specific build options or plugin extensions.
- This being my first Spock coding PR, I might have missed one or multiple important points and/or corner cases. But I think this is at least a good proof of concept, maybe even eventually mergeable with a few added tests.