### PR TITLE
Annotation-driven extension to support JUnit platform tags

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/SpockNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockNode.java
@@ -157,7 +157,8 @@ public abstract class SpockNode<T extends SpecElementInfo<?,?>>
   private void addTestTagsFrom(List<Tag> specElementTags) {
     specElementTags.stream()
       .filter(tag -> tag.getKey().equals(TagExtension.TAG_EXTENSION_KEY))
-      .map(tag -> TestTag.create(tag.getName()))
+      .map(Tag::getName)
+      .map(TestTag::create)
       .forEach(tags::add);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockNode.java
@@ -156,7 +156,7 @@ public abstract class SpockNode<T extends SpecElementInfo<?,?>>
 
   private void addTestTagsFrom(List<Tag> specElementTags) {
     specElementTags.stream()
-      .filter(tag -> tag.getKey().equals(TagExtension.TAG_EXTENSION_KEY))
+      .filter(tag -> tag.getKey().equals(TagExtension.TEST_TAG_KEY))
       .map(Tag::getName)
       .map(TestTag::create)
       .forEach(tags::add);

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagExtension.java
@@ -13,6 +13,8 @@
  */
 package org.spockframework.runtime.extension.builtin;
 
+import org.junit.platform.engine.TestTag;
+import org.spockframework.runtime.extension.ExtensionException;
 import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.SpecElementInfo;
@@ -26,9 +28,9 @@ import spock.lang.Tag;
  * {@link org.junit.platform.engine.TestTag platform tags} in order to enable filtering, e.g. from build tools like
  * Maven or Gradle.
  *
- * @see <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">
- *   JUnit platform tag expression syntax</a>
  * @author Alexander Kriegisch
+ * @see <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">
+ * JUnit platform tag expression syntax</a>
  * @since 2.2
  */
 public class TagExtension implements IAnnotationDrivenExtension<Tag> {
@@ -46,9 +48,15 @@ public class TagExtension implements IAnnotationDrivenExtension<Tag> {
 
   private void addTags(Tag tag, SpecElementInfo<?, ?> specElement) {
     for (String value : tag.value()) {
-      specElement.addTag(
-        new org.spockframework.runtime.model.Tag(value, TEST_TAG_KEY, value)
-      );
+      if (!TestTag.isValid(value))
+        throw new InvalidTagNameException("Tag '" + value + "' must conform to JUnit platform tag syntax");
+      specElement.addTag(new org.spockframework.runtime.model.Tag(value, TEST_TAG_KEY, value));
+    }
+  }
+
+  public static class InvalidTagNameException extends ExtensionException {
+    public InvalidTagNameException(String message) {
+      super(message);
     }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagExtension.java
@@ -32,7 +32,7 @@ import spock.lang.Tag;
  * @since 2.2
  */
 public class TagExtension implements IAnnotationDrivenExtension<Tag> {
-  public static final String TAG_EXTENSION_KEY = "TagExtension";
+  public static final String TEST_TAG_KEY = "testTag";
 
   @Override
   public void visitSpecAnnotation(Tag tag, SpecInfo spec) {
@@ -47,7 +47,7 @@ public class TagExtension implements IAnnotationDrivenExtension<Tag> {
   private void addTags(Tag tag, SpecElementInfo<?, ?> specElement) {
     for (String value : tag.value()) {
       specElement.addTag(
-        new org.spockframework.runtime.model.Tag(value, TAG_EXTENSION_KEY, value)
+        new org.spockframework.runtime.model.Tag(value, TEST_TAG_KEY, value)
       );
     }
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagExtension.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spockframework.runtime.extension.builtin;
+
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.model.FeatureInfo;
+import org.spockframework.runtime.model.SpecElementInfo;
+import org.spockframework.runtime.model.SpecInfo;
+import spock.lang.Tag;
+
+/**
+ * Processes {@link Tag @Tag} annotations on specifications and features, converting them to
+ * {@link org.spockframework.runtime.model.Tag Spock tags} which can potentially be used by reporting extensions.
+ * More importantly, it also makes the tag information available to JUnit 5 as
+ * {@link org.junit.platform.engine.TestTag platform tags} in order to enable filtering, e.g. from build tools like
+ * Maven or Gradle.
+ *
+ * @see <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">
+ *   JUnit platform tag expression syntax</a>
+ * @author Alexander Kriegisch
+ * @since 2.2
+ */
+public class TagExtension implements IAnnotationDrivenExtension<Tag> {
+  public static final String TAG_EXTENSION_KEY = "TagExtension";
+
+  @Override
+  public void visitSpecAnnotation(Tag tag, SpecInfo spec) {
+    addTags(tag, spec);
+  }
+
+  @Override
+  public void visitFeatureAnnotation(Tag tag, FeatureInfo feature) {
+    addTags(tag, feature);
+  }
+
+  private void addTags(Tag tag, SpecElementInfo<?, ?> specElement) {
+    for (String value : tag.value()) {
+      specElement.addTag(
+        new org.spockframework.runtime.model.Tag(value, TAG_EXTENSION_KEY, value)
+      );
+    }
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -182,10 +182,9 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
    */
   @Override
   public List<Tag> getTags(boolean includeParents) {
-    if (!includeParents)
-      return getTags();
-    List<Tag> tagsRecursive = getTags();
-    tagsRecursive.addAll(getSpec().getTags(true));
+    List<Tag> tagsRecursive = super.getTags(includeParents);
+    if (includeParents)
+      tagsRecursive.addAll(getSpec().getTags(true));
     return tagsRecursive;
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -172,4 +172,20 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> {
       if (provider.getDataProviderMethod().hasBytecodeName(name)) return true;
     return false;
   }
+
+  /**
+   * Returns the feature's tags, optionally including spec and super spec tags.
+   *
+   * @param includeParents whether to recursively add spec and super spec tags to the result
+   * @return the feature's tags, optionally including spec and super spec tags
+   * @since 2.2
+   */
+  @Override
+  public List<Tag> getTags(boolean includeParents) {
+    if (!includeParents)
+      return getTags();
+    List<Tag> tagsRecursive = getTags();
+    tagsRecursive.addAll(getSpec().getTags(true));
+    return tagsRecursive;
+  }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ITaggable.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ITaggable.java
@@ -30,6 +30,22 @@ public interface ITaggable {
   List<Tag> getTags();
 
   /**
+   * Returns the element's tags, optionally including parent tags.
+   * <p>
+   * The default implementation simply returns the result of {@link #getTags()} for backward compatibility. Overriding
+   * classes are not required to remove any duplicates from the list, considering the fact that {@link Tag} currently
+   * does not override {@link Object#equals(Object)}. Furthermore, the notion of what constitutes a duplicate - e.g.
+   * duplicate key, duplicate key/value pair, duplicate name - might vary depending on the tag usage context.
+   *
+   * @param includeParents whether to recursively add parent tags to the result
+   * @return the element's tags, optionally including parent tags
+   * @since 2.2
+   */
+  default List<Tag> getTags(boolean includeParents) {
+    return getTags();
+  }
+
+  /**
    * Adds a tag to the element.
    *
    * @param tag the tag to be added

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ITaggable.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ITaggable.java
@@ -16,6 +16,7 @@
 
 package org.spockframework.runtime.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,17 +33,17 @@ public interface ITaggable {
   /**
    * Returns the element's tags, optionally including parent tags.
    * <p>
-   * The default implementation simply returns the result of {@link #getTags()} for backward compatibility. Overriding
-   * classes are not required to remove any duplicates from the list, considering the fact that {@link Tag} currently
-   * does not override {@link Object#equals(Object)}. Furthermore, the notion of what constitutes a duplicate - e.g.
-   * duplicate key, duplicate key/value pair, duplicate name - might vary depending on the tag usage context.
+   * The default implementation simply returns a copy of the result of {@link #getTags()} for backward compatibility.
+   * Overriding classes are not required to remove any duplicates from the list, considering the fact that {@link Tag}
+   * currently does not override {@link Object#equals(Object)}. Furthermore, the notion of what constitutes a duplicate
+   * - e.g. duplicate key, duplicate key/value pair, duplicate name - might vary depending on the tag usage context.
    *
    * @param includeParents whether to recursively add parent tags to the result
    * @return the element's tags, optionally including parent tags
    * @since 2.2
    */
   default List<Tag> getTags(boolean includeParents) {
-    return getTags();
+    return new ArrayList<>(getTags());
   }
 
   /**

--- a/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
@@ -377,10 +377,8 @@ public class SpecInfo extends SpecElementInfo<NodeInfo, Class<?>> implements IMe
    */
   @Override
   public List<Tag> getTags(boolean includeParents) {
-    if (!includeParents)
-      return getTags();
-    List<Tag> tagsRecursive = getTags();
-    if (getSuperSpec() != null)
+    List<Tag> tagsRecursive = super.getTags(includeParents);
+    if (includeParents && getSuperSpec() != null)
       tagsRecursive.addAll(getSuperSpec().getTags(true));
     return tagsRecursive;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/SpecInfo.java
@@ -367,4 +367,21 @@ public class SpecInfo extends SpecElementInfo<NodeInfo, Class<?>> implements IMe
         return feature.getName();
     return methodName;
   }
+
+  /**
+   * Returns the spec's tags, optionally including super spec tags.
+   *
+   * @param includeParents whether to recursively add super spec tags to the result
+   * @return the element's tags, optionally including super spec tags
+   * @since 2.2
+   */
+  @Override
+  public List<Tag> getTags(boolean includeParents) {
+    if (!includeParents)
+      return getTags();
+    List<Tag> tagsRecursive = getTags();
+    if (getSuperSpec() != null)
+      tagsRecursive.addAll(getSuperSpec().getTags(true));
+    return tagsRecursive;
+  }
 }

--- a/spock-core/src/main/java/spock/lang/Tag.java
+++ b/spock-core/src/main/java/spock/lang/Tag.java
@@ -27,7 +27,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that a feature method or specification belongs to a certain user-defined category.
+ * Indicates that a feature method or specification belongs to one or more user-defined categories.
  *
  * @since 2.2
  * @author Alexander Kriegisch
@@ -38,6 +38,14 @@ import java.lang.annotation.Target;
 @Repeatable(Tag.Container.class)
 public @interface Tag {
   /**
+   * <b>Syntax rules:</b> Even though tags are general-purpose, user-defined semantic categories, one of those purposes
+   * is that tags can also be mapped to JUnit platform tags, enabling users to filter their test classes and methods and
+   * run only the ones they want in any given build. In order to ensure interoperability with the JUnit 5 platform,
+   * please also obey the same syntax rules when naming tags, e.g. no whitespace inside tags ("my tag"), no commas,
+   * parentheses, ampersands, vertical bars, exclamation points.
+   * See <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-syntax-rules">
+   *   JUnit syntax rules for tags</a> for more details.
+   *
    * @return the user-defined categories which the annotated element belongs to
    */
   String[] value();

--- a/spock-core/src/main/java/spock/lang/Tag.java
+++ b/spock-core/src/main/java/spock/lang/Tag.java
@@ -18,7 +18,6 @@ package spock.lang;
 
 import org.spockframework.runtime.extension.ExtensionAnnotation;
 import org.spockframework.runtime.extension.builtin.TagExtension;
-import org.spockframework.util.Beta;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
@@ -38,13 +37,14 @@ import java.lang.annotation.Target;
 @Repeatable(Tag.Container.class)
 public @interface Tag {
   /**
-   * <b>Syntax rules:</b> Even though tags are general-purpose, user-defined semantic categories, one of those purposes
-   * is that tags can also be mapped to JUnit platform tags, enabling users to filter their test classes and methods and
-   * run only the ones they want in any given build. In order to ensure interoperability with the JUnit 5 platform,
-   * please also obey the same syntax rules when naming tags, e.g. no whitespace inside tags ("my tag"), no commas,
-   * parentheses, ampersands, vertical bars, exclamation points.
-   * See <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-syntax-rules">
-   *   JUnit syntax rules for tags</a> for more details.
+   * <b>Syntax rules:</b> Even though tags are general-purpose, user-defined categories, one of those purposes is to map
+   * them to JUnit platform tags, enabling users to filter their test classes and methods and run only the ones they
+   * want in any given build. In order to ensure interoperability with the JUnit 5 platform, Spock tags must conform to
+   * <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-syntax-rules">
+   * JUnit syntax rules for tags</a>, e.g. no whitespace inside tags ("my tag"), no commas, parentheses, ampersands,
+   * vertical bars, exclamation points. If a Spock tag violates those syntax rules, an
+   * {@link org.spockframework.runtime.extension.builtin.TagExtension.InvalidTagNameException InvalidTagNameException}
+   * will be thrown during tag processing.
    *
    * @return the user-defined categories which the annotated element belongs to
    */
@@ -54,7 +54,6 @@ public @interface Tag {
    * @since 2.2
    * @author Alexander Kriegisch
    */
-  @Beta
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD})
   @interface Container {

--- a/spock-core/src/main/java/spock/lang/Tag.java
+++ b/spock-core/src/main/java/spock/lang/Tag.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spock.lang;
+
+import org.spockframework.runtime.extension.ExtensionAnnotation;
+import org.spockframework.runtime.extension.builtin.TagExtension;
+import org.spockframework.util.Beta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a feature method or specification belongs to a certain user-defined category.
+ *
+ * @since 2.2
+ * @author Alexander Kriegisch
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtensionAnnotation(TagExtension.class)
+@Repeatable(Tag.Container.class)
+public @interface Tag {
+  /**
+   * @return the user-defined categories which the annotated element belongs to
+   */
+  String[] value();
+
+  /**
+   * @since 2.2
+   * @author Alexander Kriegisch
+   */
+  @Beta
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE, ElementType.METHOD})
+  @interface Container {
+    Tag[] value();
+  }
+}


### PR DESCRIPTION
The new repeatable `@spock.lang.Tag` annotation can be applied to both specs and features and permits adding (lists of) user-defined tags, which then get processed by `TagExtension`, passing them on to the JUnit 5 platform as `TestTag` instances. This enables filtering using JUnit's boolean [tag expression syntax](https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions). This feature can be used from build tools like Maven or Gradle and potentially also be integrated into IDE test
runners.

Fixes #1288. Relates to #1425.

Supersedes #1436, after I got private feedback from @leonard84 that my first approach, adding tag support directly into Spock's core classes instead of adding an annotation-driven extension, does not fit so well with Spock's design. In this second approach here, I also utilised the existing (reporting) tag infrastructure, simply adding a new filtering key, decorating spec and feature infos by Spock tags and accessing them later when passing them on to the JUnit platform, instead of manually scanning classes and methods for annotations.

To do:
  - [ ] Test with a Gradle project in addition to just Maven
  - [ ] Add automated tests to Spock
  - [ ] Document extension in the Spock manual