### PR TITLE
Add Gradle Test Retry plugin for timing sensitive tests...

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@ pluginManagement {
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
     id "com.github.ben-manes.versions" version "0.39.0"
     id "biz.aQute.bnd.builder" version "6.2.0"
+    id "org.gradle.test-retry" version "1.3.1"
   }
 
   includeBuild "build-logic"

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -2,6 +2,7 @@ import aQute.bnd.gradle.Resolve
 
 plugins {
   id "biz.aQute.bnd.builder"
+  id "org.gradle.test-retry"
 }
 
 apply from: script("publishMaven")
@@ -107,4 +108,19 @@ def verifyOSGi = tasks.register('verifyOSGi', Resolve) {
 
 tasks.named('check') {
   dependsOn(verifyOSGi)
+}
+
+boolean isCiServer = System.env["CI"] || System.env["GITHUB_ACTIONS"]
+if (isCiServer) {
+  test {
+    retry {
+      maxRetries = 2
+      maxFailures = 20
+
+      filter {
+        includeAnnotationClasses.add("spock.lang.Timeout")
+        includeAnnotationClasses.add("spock.lang.Isolated")
+      }
+    }
+  }
 }


### PR DESCRIPTION
prior to this commit we had sporadic failing tests due to timeouts.
We could either increase the timeouts at the cost of slowing the tests down,
or retry if they occasionally fail on CI.