### PR TITLE
Prevent removal of ErrorSpecNode by Maven

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ErrorSpecNode.java
@@ -32,6 +32,13 @@ public class ErrorSpecNode extends SpecNode {
   }
 
   @Override
+  public boolean mayRegisterTests() {
+    // Maven Surefire removes nodes if org.junit.platform.launcher.TestPlan.containsTests is false.
+    // The easiest way to avoid this, is to return true here. This seems to work and not to bother Gradle either.
+    return true;
+  }
+
+  @Override
   public SpockExecutionContext prepare(SpockExecutionContext context) throws Exception {
     return ExceptionUtil.sneakyThrow(error);
   }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/ErrorSpecNodeSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/ErrorSpecNodeSpec.groovy
@@ -33,4 +33,16 @@ class ErrorSpecNodeSpec extends Specification {
     then:
     0 * tdParent.removeChild(*_)
   }
+
+  def 'make TestDescriptor think that an ErrorSpecNode contains tests'() {
+    given:
+    def errorSpecNodeSpy = Spy(errorSpecNode)
+
+    when:
+    def containsTests = TestDescriptor.containsTests(errorSpecNodeSpy)
+
+    then:
+    containsTests
+    1 * errorSpecNodeSpy.mayRegisterTests()
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/ErrorSpecNodeSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/ErrorSpecNodeSpec.groovy
@@ -1,6 +1,6 @@
 package org.spockframework.runtime
 
-import spock.lang.Specification
+import spock.lang.*
 
 import org.junit.platform.engine.*
 import spock.lang.Subject
@@ -34,6 +34,7 @@ class ErrorSpecNodeSpec extends Specification {
     0 * tdParent.removeChild(*_)
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/1444")
   def 'make TestDescriptor think that an ErrorSpecNode contains tests'() {
     given:
     def errorSpecNodeSpy = Spy(errorSpecNode)


### PR DESCRIPTION
Fixes #1444.

At the moment, `SpockEngineDiscoveryPostProcessor#processSpecNode` creates an `ErrorSpecNode` (which implements `org.junit.platform.engine.TestDescriptor`) after catching errors thrown by extensions, which is then silently discarded by Maven Surefire because it filters for `testPlan.containsTests()`. Therefore, we have to make sure that `containsTests` returns `true`. An easy way to do that is to override `mayRegisterTests()`. Another way would be to override `isTest()` instead, but actually neither an error node nor a spec actually _is_ as test, they rather can contain tests.