### PR TITLE
Draft: Sanity check build with JDK 18 on CI

### DIFF
--- a/.github/actions/setup-jdks/action.yml
+++ b/.github/actions/setup-jdks/action.yml
@@ -9,9 +9,15 @@ runs:
   steps:
     - name: 'Set up JDK ${{ inputs.additional-java-version }}'
       uses: actions/setup-java@v2
-      if: inputs.additional-java-version != 8
+      if: inputs.additional-java-version != 8 && inputs.additional-java-version < 18
       with:
         distribution: 'adopt'
+        java-version: ${{ inputs.additional-java-version }}
+    - name: 'Set up JDK ${{ inputs.additional-java-version }}'
+      uses: actions/setup-java@v2
+      if: inputs.additional-java-version > 17
+      with:
+        distribution: 'temurin'
         java-version: ${{ inputs.additional-java-version }}
     - name: 'Prepare JDK${{ inputs.additional-java-version }} env var'
       shell: bash

--- a/.github/workflows/branches-and-prs.yml
+++ b/.github/workflows/branches-and-prs.yml
@@ -41,6 +41,12 @@ jobs:
           - os: 'macos-latest'
             variant: '4.0'
             java: '8'
+          - os: 'ubuntu-latest'
+            variant: '3.0'
+            java: '18'
+          - os: 'ubuntu-latest'
+            variant: '4.0'
+            java: '18'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/branches-and-prs.yml
+++ b/.github/workflows/branches-and-prs.yml
@@ -46,6 +46,7 @@ jobs:
             java: '18'
           - os: 'ubuntu-latest'
             variant: '4.0'
+            # Switching to newer JDK version remember to adjust "org.gradle.java.installations.fromEnv" in gradle.properties
             java: '18'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,12 @@ jobs:
           - os: 'macos-latest'
             variant: '4.0'
             java: '8'
+          - os: 'ubuntu-latest'
+            variant: '3.0'
+            java: '18'
+          - os: 'ubuntu-latest'
+            variant: '4.0'
+            java: '18'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -21,24 +21,24 @@ ext {
   variant = System.getProperty("variant") as BigDecimal ?: variants.first()
   buildScan.tag "groovy-$variant"
   if (variant == 2.5) {
-      groovyGroup = "org.codehaus.groovy"
-      groovyVersion = "2.5.16"
-      minGroovyVersion = "2.5.0"
-      maxGroovyVersion = "2.9.99"
-      if(javaVersion >= 17) {
-        throw new InvalidUserDataException("Groovy $variant is not compatible with Java $javaVersion")
-      }
-    } else if (variant == 3.0) {
-      groovyGroup = "org.codehaus.groovy"
-      groovyVersion = "3.0.10"
-      minGroovyVersion = "3.0.0"
-      maxGroovyVersion = "3.9.99"
-    }  else if (variant == 4.0) {
-      groovyGroup = "org.apache.groovy"
-      groovyVersion = "4.0.1"
-      minGroovyVersion = "4.0.0"
-      maxGroovyVersion = "4.9.99"
-    } else {
+    groovyGroup = "org.codehaus.groovy"
+    groovyVersion = "2.5.16"
+    minGroovyVersion = "2.5.0"
+    maxGroovyVersion = "2.9.99"
+    if (javaVersion >= 17) {
+      throw new InvalidUserDataException("Groovy $variant is not compatible with Java $javaVersion")
+    }
+  } else if (variant == 3.0) {
+    groovyGroup = "org.codehaus.groovy"
+    groovyVersion = "3.0.10"
+    minGroovyVersion = "3.0.0"
+    maxGroovyVersion = "3.9.99"
+  } else if (variant == 4.0) {
+    groovyGroup = "org.apache.groovy"
+    groovyVersion = "4.0.1"
+    minGroovyVersion = "4.0.0"
+    maxGroovyVersion = "4.9.99"
+  } else {
     throw new InvalidUserDataException("Unknown variant: $variant. Choose one of: $variants")
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ ext {
     junitPlatformConsole: [group: 'org.junit.platform', name: 'junit-platform-console'],
     log4j               : [group: 'log4j', name: 'log4j', version: '1.2.17'],
     objenesis           : [group: 'org.objenesis', name: 'objenesis', version: '3.2'],
-    jacocoAgent         : [group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.7', classifier: 'runtime']
+    jacocoAgent         : [group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.8', classifier: 'runtime']
   ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ ext {
 
   libs = [
     jetbrainsAnnotations: [group: "org.jetbrains", name: "annotations", version: "20.1.0"],
-    asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.2'],
-    bytebuddy           : [group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.1'],
+    asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.3'],
+    bytebuddy           : [group: 'net.bytebuddy', name: 'byte-buddy', version: '1.12.9'],
     cglib               : [group: 'cglib', name: 'cglib-nodep', version: '3.3.0'],
     groovy              : groovyDependencies,
     groovySql           : [group: groovyGroup, name: 'groovy-sql', version: groovyVersion], //for some Spring and Unitils tests

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 org.gradle.java.installations.auto-download=false
-org.gradle.java.installations.fromEnv=JDK8,JDK11,JDK17
+org.gradle.java.installations.fromEnv=JDK8,JDK11,JDK17,JDK18
 
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+#distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+#distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220429115913+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
-#distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
-distributionUrl=https://services.gradle.org/distributions-snapshots/gradle-7.5-20220427150934+0000-bin.zip
+distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-# https://gradle.org/release-checksums/
-distributionSha256Sum=e5444a57cda4a95f90b0c9446a9e1b47d3d7f69057765bfb54bd4f482542d548
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+#distributionSha256Sum=29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+#distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions-snapshots/gradle-7.5-20220427150934+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Add basic JDK 18 tests on CI with Temurin.

Unfortunately, Gradle 7.4.1/2 [refuses](https://github.com/spockframework/spock/runs/5960598888?check_suite_focus=true#step:4:43) to play with JDK 18:
```
 * What went wrong:
A problem occurred evaluating project ':spock-specs'.
> Could not resolve all dependencies for configuration ':spock-specs:jacocoAgentRuntime'.
   > Failed to query the value of task ':spock-specs:compileGroovy' property 'javaLauncher'.
      > No compatible toolchains found for request filter: {languageVersion=18, vendor=any, implementation=vendor-specific} (auto-detect true, auto-download false)
```

However, it builds fine locally with JDK 18. Is it "just" a toolchain detection issue which could be easily overridden or Gradle 7.5 is a must?
