### PR TITLE
Discard unnecessary state in ConfineMetaClassChangesInterceptor

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConfineMetaClassChangesInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConfineMetaClassChangesInterceptor.java
@@ -28,7 +28,6 @@ import groovy.lang.*;
  */
 public class ConfineMetaClassChangesInterceptor implements IMethodInterceptor {
   private final Collection<Class<?>> classes;
-  private final List<MetaClass> originalMetaClasses = new ArrayList<>();
 
   public ConfineMetaClassChangesInterceptor(Collection<Class<?>> classes) {
     this.classes = classes;
@@ -37,6 +36,7 @@ public class ConfineMetaClassChangesInterceptor implements IMethodInterceptor {
   @Override
   public void intercept(IMethodInvocation invocation) throws Throwable {
     MetaClassRegistry registry = GroovySystem.getMetaClassRegistry();
+    List<MetaClass> originalMetaClasses = new ArrayList<>();
 
     for (Class<?> clazz : classes) {
       originalMetaClasses.add(registry.getMetaClass(clazz));
@@ -48,10 +48,8 @@ public class ConfineMetaClassChangesInterceptor implements IMethodInterceptor {
     try {
       invocation.proceed();
     } finally {
-      for (MetaClass original : originalMetaClasses) {
+      for (MetaClass original : originalMetaClasses)
         registry.setMetaClass(original.getTheClass(), original);
-      }
-      originalMetaClasses.clear();
     }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConfineMetaClassChangesInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConfineMetaClassChangesInterceptor.java
@@ -48,8 +48,10 @@ public class ConfineMetaClassChangesInterceptor implements IMethodInterceptor {
     try {
       invocation.proceed();
     } finally {
-      for (MetaClass original : originalMetaClasses)
+      for (MetaClass original : originalMetaClasses) {
         registry.setMetaClass(original.getTheClass(), original);
+      }
+      originalMetaClasses.clear();
     }
   }
 }


### PR DESCRIPTION
If `@ConfineMetaClassChanges` is used on a data-driver feature method, the
`ConfineMetaClassChangesInterceptor` is shared between iterations of the
method. Clear the `originalMetaClasses` field of the interceptor after
each invocation to avoid populating the list with duplicate references
to original meta-classes.

The previous implementation was not defective _per se_, but this fixes a
potential efficiency issue (determined by how many meta-classes are
stored and how many iterations of the feature method are run).