### PR TITLE
Update Gradle plugins

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,14 +2,14 @@ import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionW
 
 pluginManagement {
   plugins {
-    id "com.gradle.enterprise" version "3.9"
-    id "com.gradle.common-custom-user-data-gradle-plugin" version "1.6.4"
+    id "com.gradle.enterprise" version "3.10"
+    id "com.gradle.common-custom-user-data-gradle-plugin" version "1.6.5"
     id "org.asciidoctor.jvm.convert" version "3.3.2"
-    id "net.nemerosa.versioning" version "2.14.0"
+    id "net.nemerosa.versioning" version "2.15.1"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
-    id "com.github.ben-manes.versions" version "0.39.0"
+    id "com.github.ben-manes.versions" version "0.42.0"
     id "biz.aQute.bnd.builder" version "6.2.0"
-    id "org.gradle.test-retry" version "1.3.1"
+    id "org.gradle.test-retry" version "1.3.2"
   }
 
   includeBuild "build-logic"


### PR DESCRIPTION
com.gradle.enterprise                              3.10
com.gradle.common-custom-user-data-gradle-plugin   1.6.5
org.asciidoctor.jvm.convert                        3.3.2
net.nemerosa.versioning                            2.15.1
io.github.gradle-nexus.publish-plugin to           1.1.0
com.github.ben-manes.versions                      0.42.0
biz.aQute.bnd.builder                              6.2.0
org.gradle.test-retry                              1.3.2