### PR TITLE
Removed runtime dependency on Jetbrains Annotations

### DIFF
--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -24,8 +24,9 @@ dependencies {
     api project(':spock-groovy2-compat')
   }
 
+  compileOnly libs.jetbrainsAnnotations
+
   implementation libs.junitPlatformTestkit, optional
-  implementation libs.jetbrainsAnnotations, optional
   implementation libs.asm, optional
   implementation libs.bytebuddy, optional
   implementation libs.cglib, optional

--- a/spock-junit4/junit4.gradle
+++ b/spock-junit4/junit4.gradle
@@ -12,8 +12,8 @@ dependencies {
   api project(":spock-core")
   api libs.junit4
 
+  testCompileOnly libs.jetbrainsAnnotations
   testImplementation libs.junitPlatformTestkit
-  testImplementation libs.jetbrainsAnnotations
   testImplementation libs.groovyTest  //for @NotYetImplemented
 }
 

--- a/spock-specs/specs.gradle
+++ b/spock-specs/specs.gradle
@@ -14,7 +14,7 @@ configurations {
 
 dependencies {
   implementation libs.groovyJmx
-  testImplementation libs.jetbrainsAnnotations
+  testCompileOnly libs.jetbrainsAnnotations
   testImplementation libs.junitPlatformTestkit
 
   testImplementation project(":spock-core")


### PR DESCRIPTION
All Jetbrains annotations have retention policy `CLASS`.
Accroding to [Jetbrains repo](https://github.com/JetBrains/java-annotations#using-the-annotations) recommended way to include them in gradle project is:
```groovy
dependencies {
    compileOnly 'org.jetbrains:annotations:23.0.0'
}
```
testCompileOnly for `spock-junit4` and `spock-specs`