### PR TITLE
Make EnableSharedInjection public

### DIFF
--- a/spock-spring/src/main/java/org/spockframework/spring/EnableSharedInjection.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/EnableSharedInjection.java
@@ -28,5 +28,5 @@ import java.lang.annotation.*;
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@interface EnableSharedInjection {
+public @interface EnableSharedInjection {
 }


### PR DESCRIPTION
Quick fix for https://github.com/spockframework/spock/issues/1471

Based on the release notes from [2.0.0-M5](https://spockframework.org/spock/docs/2.0/release_notes.html#_misc_2), it looks like the `EnableSharedInjection` annotation should be public.

While the annotation appears to work as expected despite being package-private, it does produce some noisy IDE warnings that are worth getting rid of.

This doesn't seem to affect the tests in `org.spockframework.spring.SharedFieldsInjection`. I don't think it merits a test of its own, but I could be wrong.