### PR TITLE
Make ClassSelectorResolver public

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/ClassSelectorResolver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ClassSelectorResolver.java
@@ -13,12 +13,12 @@ import org.junit.platform.engine.support.discovery.SelectorResolver;
 
 import static java.util.Collections.emptySet;
 
-class ClassSelectorResolver implements SelectorResolver {
+public class ClassSelectorResolver implements SelectorResolver {
 
   private final Predicate<String> classNameFilter;
   private final RunContext runContext;
 
-  ClassSelectorResolver(Predicate<String> classNameFilter, RunContext runContext) {
+  public ClassSelectorResolver(Predicate<String> classNameFilter, RunContext runContext) {
     this.classNameFilter = classNameFilter;
     this.runContext = runContext;
   }


### PR DESCRIPTION
The `MethodSelectorResolver` class is public, so it made sense to make the `ClassSelectorResolver` and its constructor public. This is helpful for me, in my case, as I'm trying to extend the `SpockEngine`.

You can get a bit more background on my use case at https://groovy-community.slack.com/archives/C2LPWPATZ/p1652715262687109, though I think making the `SelectorResolver` implementations public makes sense on its own.