### PR TITLE
Introduce DataIterator and IDataDriver

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/DataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIterator.java
@@ -1,7 +1,9 @@
 package org.spockframework.runtime;
 
 import java.util.Iterator;
+import java.util.List;
 
 public interface DataIterator extends Iterator<Object[]>, AutoCloseable {
   int getEstimatedNumIterations();
+  List<String> getDataVariableNames();
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIterator.java
@@ -1,0 +1,7 @@
+package org.spockframework.runtime;
+
+import java.util.Iterator;
+
+public interface DataIterator extends Iterator<Object[]>, AutoCloseable {
+  int getEstimatedNumIterations();
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIterator.java
@@ -3,7 +3,20 @@ package org.spockframework.runtime;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * A special iterator, that gives to the data produced by Spock's data providers.
+ *
+ * @since 2.2
+ * @author Leonard Brünings
+ */
 public interface DataIterator extends Iterator<Object[]>, AutoCloseable {
+  /**
+   * @return the number of data sets that are provided by this iterator. This will be {@code -1} if it cannot be determined.
+   */
   int getEstimatedNumIterations();
+
+  /**
+   * @return the names of the data variables in the order they are present in the array
+   */
   List<String> getDataVariableNames();
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
@@ -16,11 +16,11 @@ public class DataIteratorFactory {
     this.supervisor = supervisor;
   }
 
-  public DataIterator createFeatureDataIterator(SpockExecutionContext context) {
+  public IDataIterator createFeatureDataIterator(SpockExecutionContext context) {
     return new DataProcessorIterator(supervisor, context, new FeatureDataProviderIterator(supervisor, context));
   }
 
-  private abstract static class BaseDataIterator implements DataIterator {
+  private abstract static class BaseDataIterator implements IDataIterator {
     protected final IRunSupervisor supervisor;
     protected final SpockExecutionContext context;
 
@@ -40,10 +40,10 @@ public class DataIteratorFactory {
   }
 
   private static class DataProcessorIterator extends BaseDataIterator {
-    private final DataIterator delegate;
+    private final IDataIterator delegate;
     private final List<String> dataVariableNames;
 
-    private DataProcessorIterator(IRunSupervisor supervisor, SpockExecutionContext context, DataIterator delegate) {
+    private DataProcessorIterator(IRunSupervisor supervisor, SpockExecutionContext context, IDataIterator delegate) {
       super(supervisor, context);
       this.delegate = delegate;
       this.dataVariableNames = readDataVariableNames();

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
@@ -1,9 +1,10 @@
 package org.spockframework.runtime;
 
-import org.jetbrains.annotations.NotNull;
 import org.spockframework.runtime.model.*;
 
 import java.util.*;
+
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.stream.Collectors.toList;
 
@@ -19,7 +20,7 @@ public class DataIteratorFactory {
     return new DataProcessorIterator(supervisor, context, new FeatureDataProviderIterator(supervisor, context));
   }
 
-  private static abstract class BaseDataIterator implements DataIterator {
+  private abstract static class BaseDataIterator implements DataIterator {
     protected final IRunSupervisor supervisor;
     protected final SpockExecutionContext context;
 

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
@@ -14,19 +14,19 @@ public class DataIteratorFactory {
     this.supervisor = supervisor;
   }
 
-  public DataIterator createDataProviderStream(SpockExecutionContext context) {
-    return new DataProviderIterator(supervisor, context);
+  public DataIterator createFeatureDataIterator(SpockExecutionContext context) {
+    return new FeatureDataProviderIterator(supervisor, context);
   }
 
-  private static class DataProviderIterator implements DataIterator {
+  private static class FeatureDataProviderIterator implements DataIterator {
     private final IRunSupervisor supervisor;
     private final SpockExecutionContext context;
     private final Object[] dataProviders;
-    private final Iterator[] iterators;
+    private final Iterator<?>[] iterators;
     private final int estimatedNumIterations;
     private int iteration = 0;
 
-    public DataProviderIterator(IRunSupervisor supervisor, SpockExecutionContext context) {
+    public FeatureDataProviderIterator(IRunSupervisor supervisor, SpockExecutionContext context) {
       this.supervisor = supervisor;
       this.context = context;
       // order is important as they rely on each other
@@ -211,12 +211,12 @@ public class DataIteratorFactory {
       return result.toArray();
     }
 
-    private Iterator[] createIterators() {
+    private Iterator<?>[] createIterators() {
       if (context.getErrorInfoCollector().hasErrors()) {
         return null;
       }
 
-      Iterator[] iterators = new Iterator<?>[dataProviders.length];
+      Iterator<?>[] iterators = new Iterator<?>[dataProviders.length];
       for (int i = 0; i < dataProviders.length; i++)
         try {
           Iterator<?> iter = GroovyRuntimeUtil.asIterator(dataProviders[i]);

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
@@ -24,6 +24,7 @@ public class DataIteratorFactory {
     private final Object[] dataProviders;
     private final Iterator<?>[] iterators;
     private final int estimatedNumIterations;
+    private final List<String> dataVariableNames;
     private int iteration = 0;
 
     public FeatureDataProviderIterator(IRunSupervisor supervisor, SpockExecutionContext context) {
@@ -31,8 +32,9 @@ public class DataIteratorFactory {
       this.context = context;
       // order is important as they rely on each other
       this.dataProviders = createDataProviders();
-      this.iterators = createIterators();
       this.estimatedNumIterations = estimateNumIterations();
+      this.iterators = createIterators();
+      dataVariableNames = Collections.unmodifiableList(Arrays.asList(context.getCurrentFeature().getDataProcessorMethod().getAnnotation(DataProcessorMetadata.class).dataVariables()));
     }
 
     @Override
@@ -106,6 +108,11 @@ public class DataIteratorFactory {
     @Override
     public int getEstimatedNumIterations() {
       return estimatedNumIterations;
+    }
+
+    @Override
+    public List<String> getDataVariableNames() {
+      return dataVariableNames;
     }
 
     private int estimateNumIterations() {

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
@@ -1,0 +1,251 @@
+package org.spockframework.runtime;
+
+import static java.util.stream.Collectors.toList;
+
+import org.spockframework.runtime.model.*;
+
+import java.util.*;
+
+public class DataIteratorFactory {
+
+  protected final IRunSupervisor supervisor;
+
+  public DataIteratorFactory(IRunSupervisor supervisor) {
+    this.supervisor = supervisor;
+  }
+
+  public DataIterator createDataProviderStream(SpockExecutionContext context) {
+    return new DataProviderIterator(supervisor, context);
+  }
+
+  private static class DataProviderIterator implements DataIterator {
+    private final IRunSupervisor supervisor;
+    private final SpockExecutionContext context;
+    private final Object[] dataProviders;
+    private final Iterator[] iterators;
+    private final int estimatedNumIterations;
+    private int iteration = 0;
+
+    public DataProviderIterator(IRunSupervisor supervisor, SpockExecutionContext context) {
+      this.supervisor = supervisor;
+      this.context = context;
+      // order is important as they rely on each other
+      this.dataProviders = createDataProviders();
+      this.iterators = createIterators();
+      this.estimatedNumIterations = estimateNumIterations();
+    }
+
+    @Override
+    public void close() {
+      if (dataProviders == null) {
+        return; // there was an error creating the providers
+      }
+
+      for (Object provider : dataProviders) {
+        GroovyRuntimeUtil.invokeMethodQuietly(provider, "close");
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (context.getErrorInfoCollector().hasErrors()) {
+        return false;
+      }
+      if (iterators.length == 0 && iteration > 0) {
+        // no iterators => no data providers => only derived parameterizations => limit to one iteration
+        return false;
+      }
+
+      boolean haveNext = true;
+
+      for (int i = 0; i < iterators.length; i++)
+        try {
+          boolean hasNext = iterators[i].hasNext();
+          if (i == 0) {
+            haveNext = hasNext;
+          } else if (haveNext != hasNext) {
+            DataProviderInfo provider = context.getCurrentFeature().getDataProviders().get(i);
+            supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(provider.getDataProviderMethod(),
+              createDifferentNumberOfDataValuesException(provider, hasNext)));
+            return false;
+          }
+
+        } catch (Throwable t) {
+          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(), t));
+          return false;
+        }
+
+      return haveNext;
+    }
+
+    @Override
+    public Object[] next() {
+      if (context.getErrorInfoCollector().hasErrors()) {
+        return null;
+      }
+      iteration++;
+
+      // advances iterators and computes args
+      Object[] next = new Object[iterators.length];
+      for (int i = 0; i < iterators.length; i++)
+        try {
+          next[i] = iterators[i].next();
+        } catch (Throwable t) {
+          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(), t));
+          return null;
+        }
+
+      try {
+        return (Object[])invokeRaw(context, context.getSharedInstance(), context.getCurrentFeature().getDataProcessorMethod(), next);
+      } catch (Throwable t) {
+        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProcessorMethod(), t));
+        return null;
+      }
+    }
+
+    @Override
+    public int getEstimatedNumIterations() {
+      return estimatedNumIterations;
+    }
+
+    private int estimateNumIterations() {
+      if (context.getErrorInfoCollector().hasErrors()) {
+        return -1;
+      }
+      if (dataProviders.length == 0) {
+        return 1;
+      }
+
+      int result = Integer.MAX_VALUE;
+      for (Object prov : dataProviders) {
+        if (prov instanceof Iterator)
+        // unbelievably, DGM provides a size() method for Iterators,
+        // although it is of course destructive (i.e. it exhausts the Iterator)
+        {
+          continue;
+        }
+
+        Object rawSize = GroovyRuntimeUtil.invokeMethodQuietly(prov, "size");
+        if (!(rawSize instanceof Number)) {
+          continue;
+        }
+
+        int size = ((Number)rawSize).intValue();
+        if (size < 0 || size >= result) {
+          continue;
+        }
+
+        result = size;
+      }
+
+      return result == Integer.MAX_VALUE ? -1 : result;
+    }
+
+    private Object invokeRaw(SpockExecutionContext context, Object target, MethodInfo method, Object... arguments) {
+      try {
+        return method.invoke(target, arguments);
+      } catch (Throwable throwable) {
+        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(method, throwable));
+        return null;
+      }
+    }
+
+    private Object[] createDataProviders() {
+      if (context.getErrorInfoCollector().hasErrors()) {
+        return null;
+      }
+
+      List<DataProviderInfo> dataProviderInfos = context.getCurrentFeature().getDataProviders();
+      if (dataProviderInfos.isEmpty()) {
+        return new Object[0];
+      }
+
+      List<String> dataProviderVariables = dataProviderInfos
+        .stream()
+        .map(DataProviderInfo::getDataVariables)
+        .flatMap(List::stream)
+        .collect(toList());
+
+      Object[] dataProviders = new Object[dataProviderInfos.size()];
+
+      for (int i = 0, size = dataProviderInfos.size(); i < size; i++) {
+        DataProviderInfo dataProviderInfo = dataProviderInfos.get(i);
+        MethodInfo method = dataProviderInfo.getDataProviderMethod();
+
+        Object provider = invokeRaw(
+          context, context.getCurrentInstance(), method,
+          getPreviousDataTableProviders(dataProviderVariables, dataProviders, dataProviderInfo));
+
+        if (context.getErrorInfoCollector().hasErrors()) {
+          if (provider != null) {
+            dataProviders[i] = provider;
+          }
+          break;
+        } else if (provider == null) {
+          SpockExecutionException error = new SpockExecutionException("Data provider is null!");
+          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(method, error));
+          break;
+        }
+
+        dataProviders[i] = provider;
+      }
+
+      return dataProviders;
+    }
+
+    private Object[] getPreviousDataTableProviders(List<String> dataProviderVariables, Object[] dataProviders,
+                                                   DataProviderInfo dataProviderInfo) {
+      List<Object> result = new ArrayList<>();
+      previousDataTableVariablesLoop:
+      for (String previousDataTableVariable : dataProviderInfo.getPreviousDataTableVariables()) {
+        for (int i = 0, size = dataProviderVariables.size(); i < size; i++) {
+          String dataProviderVariable = dataProviderVariables.get(i);
+          if (previousDataTableVariable.equals(dataProviderVariable)) {
+            result.add(dataProviders[i]);
+            continue previousDataTableVariablesLoop;
+          }
+        }
+        throw new IllegalStateException(String.format("Variable name not defined (%s not in %s)!",
+          previousDataTableVariable, dataProviderVariables));
+      }
+      return result.toArray();
+    }
+
+    private Iterator[] createIterators() {
+      if (context.getErrorInfoCollector().hasErrors()) {
+        return null;
+      }
+
+      Iterator[] iterators = new Iterator<?>[dataProviders.length];
+      for (int i = 0; i < dataProviders.length; i++)
+        try {
+          Iterator<?> iter = GroovyRuntimeUtil.asIterator(dataProviders[i]);
+          if (iter == null) {
+            supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(),
+              new SpockExecutionException("Data provider's iterator() method returned null")));
+            return null;
+          }
+          iterators[i] = iter;
+        } catch (Throwable t) {
+          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(), t));
+          return null;
+        }
+
+      return iterators;
+    }
+
+    private SpockExecutionException createDifferentNumberOfDataValuesException(DataProviderInfo provider,
+                                                                               boolean hasNext) {
+      String msg = String.format("Data provider for variable '%s' has %s values than previous data provider(s)",
+        provider.getDataVariables().get(0), hasNext ? "more" : "fewer");
+      SpockExecutionException exception = new SpockExecutionException(msg);
+      FeatureInfo feature = provider.getParent();
+      SpecInfo spec = feature.getParent();
+      StackTraceElement elem = new StackTraceElement(spec.getReflection().getName(),
+        feature.getName(), spec.getFilename(), provider.getLine());
+      exception.setStackTrace(new StackTraceElement[]{elem});
+      return exception;
+    }
+
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/IDataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IDataIterator.java
@@ -1,15 +1,17 @@
 package org.spockframework.runtime;
 
-import java.util.Iterator;
-import java.util.List;
+import org.spockframework.util.Beta;
+
+import java.util.*;
 
 /**
  * A special iterator, that gives to the data produced by Spock's data providers.
  *
- * @since 2.2
  * @author Leonard Brünings
+ * @since 2.2
  */
-public interface DataIterator extends Iterator<Object[]>, AutoCloseable {
+@Beta
+public interface IDataIterator extends Iterator<Object[]>, AutoCloseable {
   /**
    * @return the number of data sets that are provided by this iterator. This will be {@code -1} if it cannot be determined.
    */

--- a/spock-core/src/main/java/org/spockframework/runtime/IDataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IDataIterator.java
@@ -6,6 +6,8 @@ import java.util.*;
 
 /**
  * A special iterator, that gives to the data produced by Spock's data providers.
+ * <p>
+ * The creator of the data iterator is responsible to close it.
  *
  * @author Leonard Brünings
  * @since 2.2

--- a/spock-core/src/main/java/org/spockframework/runtime/IDataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IDataIterator.java
@@ -8,6 +8,9 @@ import java.util.*;
  * A special iterator, that gives to the data produced by Spock's data providers.
  * <p>
  * The creator of the data iterator is responsible to close it.
+ * <p>
+ * {@link #next()} will return {@code null} when an error occurs during calculation of the values.
+ * Consumers of the data iterator should check for {@code null} values, and skip the iteration if it is {@code null}.
  *
  * @author Leonard Brünings
  * @since 2.2

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureChildExecutor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureChildExecutor.java
@@ -5,35 +5,72 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.platform.engine.*;
+import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.hierarchical.Node.DynamicTestExecutor;
 import org.opentest4j.TestAbortedException;
+import org.spockframework.runtime.model.ExecutionResult;
 
 import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
+import static org.junit.platform.engine.TestExecutionResult.Status.SUCCESSFUL;
 
 class ParameterizedFeatureChildExecutor {
 
   private final ParameterizedFeatureNode parameterizedFeatureNode;
-  private AtomicInteger executionCounter = new AtomicInteger();
+  private final AtomicInteger executionCounter = new AtomicInteger();
 
-  private Map<TestExecutionResult.Status, Queue<Throwable>> results = new ConcurrentHashMap<>();
+  private final Map<TestExecutionResult.Status, Queue<Throwable>> results = new ConcurrentHashMap<>();
+  private final Map<TestDescriptor, CompletableFuture<ExecutionResult>> pending = new ConcurrentHashMap<>();
 
   private final DynamicTestExecutor delegate;
-  private EngineExecutionListener executionListener;
+  private final EngineExecutionListener executionListener;
 
-  ParameterizedFeatureChildExecutor(ParameterizedFeatureNode parameterizedFeatureNode, DynamicTestExecutor delegate) {
+  ParameterizedFeatureChildExecutor(ParameterizedFeatureNode parameterizedFeatureNode,
+                                    DynamicTestExecutor delegate,
+                                    EngineExecutionListener delegateEngineExecutionListener) {
     this.parameterizedFeatureNode = parameterizedFeatureNode;
     this.delegate = delegate;
 
-    // if we are not going to report single iterations,
-    // we will need a listener for the child executions
-    // so create it here once and use it repeatedly later on
-    if (!parameterizedFeatureNode.getNodeInfo().isReportIterations()) {
+    if (parameterizedFeatureNode.getNodeInfo().isReportIterations()) {
+      executionListener = new EngineExecutionListener() {
+        @Override
+        public void dynamicTestRegistered(TestDescriptor testDescriptor) {
+          delegateEngineExecutionListener.dynamicTestRegistered(testDescriptor);
+        }
+
+        @Override
+        public void executionSkipped(TestDescriptor testDescriptor, String reason) {
+          delegateEngineExecutionListener.executionSkipped(testDescriptor, reason);
+          pending.remove(testDescriptor).complete(ExecutionResult.ABORTED);
+        }
+
+        @Override
+        public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
+          delegateEngineExecutionListener.executionFinished(testDescriptor, testExecutionResult);
+          ExecutionResult result = testExecutionResult.getStatus() == SUCCESSFUL ?
+            ExecutionResult.SUCCESSFUL : ExecutionResult.FAILED;
+          pending.remove(testDescriptor).complete(result);
+        }
+
+        @Override
+        public void executionStarted(TestDescriptor testDescriptor) {
+          delegateEngineExecutionListener.executionStarted(testDescriptor);
+        }
+
+        @Override
+        public void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
+          delegateEngineExecutionListener.reportingEntryPublished(testDescriptor, entry);
+        }
+      };
+    } else {
+      // if we are not going to report single iterations,
+      // we will need a listener for the child executions
       executionListener = new EngineExecutionListener() {
         @Override
         public void executionSkipped(TestDescriptor testDescriptor, String reason) {
           results
             .computeIfAbsent(ABORTED, status -> new ConcurrentLinkedQueue<>())
             .add(new TestAbortedException(reason));
+          pending.remove(testDescriptor).complete(ExecutionResult.ABORTED);
         }
 
         @Override
@@ -41,19 +78,21 @@ class ParameterizedFeatureChildExecutor {
           Queue<Throwable> failures = results
             .computeIfAbsent(testExecutionResult.getStatus(), status -> new ConcurrentLinkedQueue<>());
           testExecutionResult.getThrowable().ifPresent(failures::add);
+          ExecutionResult result = testExecutionResult.getStatus() == SUCCESSFUL ?
+            ExecutionResult.SUCCESSFUL : ExecutionResult.FAILED;
+          pending.remove(testDescriptor).complete(result);
         }
       };
     }
   }
 
-  public void execute(TestDescriptor testDescriptor) {
+  public CompletableFuture<ExecutionResult> execute(TestDescriptor testDescriptor) {
     executionCounter.incrementAndGet();
     parameterizedFeatureNode.addChild(testDescriptor);
-    if (parameterizedFeatureNode.getNodeInfo().isReportIterations()) {
-      delegate.execute(testDescriptor);
-    } else {
-      delegate.execute(testDescriptor, executionListener);
-    }
+    CompletableFuture<ExecutionResult> future = new CompletableFuture<>();
+    pending.put(testDescriptor, future);
+    delegate.execute(testDescriptor, executionListener);
+    return future;
   }
 
   public void awaitFinished() throws InterruptedException {

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
@@ -36,7 +36,7 @@ public class ParameterizedFeatureNode extends FeatureNode {
     verifyNotSkipped(getNodeInfo());
     ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
     context = context.withErrorInfoCollector(errorInfoCollector);
-    ParameterizedFeatureChildExecutor childExecutor = new ParameterizedFeatureChildExecutor(this, dynamicTestExecutor);
+    ParameterizedFeatureChildExecutor childExecutor = new ParameterizedFeatureChildExecutor(this, dynamicTestExecutor, context.getEngineExecutionListener());
     context.getRunner().runParameterizedFeature(context, childExecutor);
     errorInfoCollector.assertEmpty();
     if (childExecutor.getExecutionCount() < 1) {

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -72,7 +72,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
         if (iterationInfo.getFeature().getIterationFilter().isAllowed(iterationInfo.getIterationIndex())) {
           return childExecutor.execute(iterationNode);
         }
-        return null;
+        return CompletableFuture.completedFuture(ExecutionResult.SKIPPED);
       }
     };
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -19,6 +19,7 @@ package org.spockframework.runtime;
 import org.spockframework.runtime.extension.IDataDriver;
 import org.spockframework.runtime.extension.IIterationRunner;
 import org.spockframework.runtime.model.ExecutionResult;
+import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.IterationInfo;
 import spock.config.RunnerConfiguration;
 
@@ -41,10 +42,11 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
       return;
     }
 
+    FeatureInfo feature = context.getCurrentFeature();
     try (DataIterator dataIterator = new DataIteratorFactory(supervisor).createFeatureDataIterator(context)) {
       IIterationRunner iterationRunner = createIterationRunner(context, childExecutor);
-      IDataDriver dataDriver = context.getCurrentFeature().getDataDriver();
-      dataDriver.runIterations(dataIterator, iterationRunner);
+      IDataDriver dataDriver = feature.getDataDriver();
+      dataDriver.runIterations(dataIterator, iterationRunner, feature.getFeatureMethod().getParameters());
       childExecutor.awaitFinished();
     } catch (InterruptedException ie) {
       throw ie;
@@ -59,7 +61,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
 
       @Override
       public CompletableFuture<ExecutionResult> runIteration(Object[] args) {
-        IterationInfo iterationInfo = createIterationInfo(context, iterationIndex.get(), args, Integer.MAX_VALUE);
+        IterationInfo iterationInfo = createIterationInfo(context, iterationIndex.get(), args, -1);
         IterationNode iterationNode = new IterationNode(
           context.getParentId().append("iteration", String.valueOf(iterationIndex.getAndIncrement())),
           context.getRunContext().getConfiguration(RunnerConfiguration.class), iterationInfo);

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -18,6 +18,7 @@ package org.spockframework.runtime;
 
 import org.spockframework.runtime.extension.*;
 import org.spockframework.runtime.model.*;
+import org.spockframework.util.ExceptionUtil;
 import spock.config.RunnerConfiguration;
 
 import java.util.concurrent.CompletableFuture;
@@ -48,7 +49,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
     } catch (InterruptedException ie) {
       throw ie;
     } catch (Exception e) {
-      // DataIterator.close doesn't throw
+      ExceptionUtil.sneakyThrow(e);
     }
   }
 
@@ -58,9 +59,10 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
 
       @Override
       public CompletableFuture<ExecutionResult> runIteration(Object[] args) {
-        IterationInfo iterationInfo = createIterationInfo(context, iterationIndex.get(), args, -1);
+        int currIterationIndex = iterationIndex.getAndIncrement();
+        IterationInfo iterationInfo = createIterationInfo(context, currIterationIndex, args, -1);
         IterationNode iterationNode = new IterationNode(
-          context.getParentId().append("iteration", String.valueOf(iterationIndex.getAndIncrement())),
+          context.getParentId().append("iteration", String.valueOf(currIterationIndex)),
           context.getRunContext().getConfiguration(RunnerConfiguration.class), iterationInfo);
 
         if (context.getErrorInfoCollector().hasErrors()) {

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -16,11 +16,8 @@
 
 package org.spockframework.runtime;
 
-import org.spockframework.runtime.extension.IDataDriver;
-import org.spockframework.runtime.extension.IIterationRunner;
-import org.spockframework.runtime.model.ExecutionResult;
-import org.spockframework.runtime.model.FeatureInfo;
-import org.spockframework.runtime.model.IterationInfo;
+import org.spockframework.runtime.extension.*;
+import org.spockframework.runtime.model.*;
 import spock.config.RunnerConfiguration;
 
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +40,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
     }
 
     FeatureInfo feature = context.getCurrentFeature();
-    try (DataIterator dataIterator = new DataIteratorFactory(supervisor).createFeatureDataIterator(context)) {
+    try (IDataIterator dataIterator = new DataIteratorFactory(supervisor).createFeatureDataIterator(context)) {
       IIterationRunner iterationRunner = createIterationRunner(context, childExecutor);
       IDataDriver dataDriver = feature.getDataDriver();
       dataDriver.runIterations(dataIterator, iterationRunner, feature.getFeatureMethod().getParameters());

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -16,12 +16,8 @@
 
 package org.spockframework.runtime;
 
-import org.spockframework.runtime.model.*;
+import org.spockframework.runtime.model.IterationInfo;
 import spock.config.RunnerConfiguration;
-
-import java.util.*;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * Adds the ability to run parameterized features.
@@ -39,143 +35,24 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
       return;
     }
 
-    Object[] dataProviders = createDataProviders(context);
-    int numIterations = estimateNumIterations(context, dataProviders);
-    Iterator[] iterators = createIterators(context, dataProviders);
-    runIterations(context, childExecutor, iterators, numIterations);
-    try {
+    try (DataIterator dataProviderStream = new DataIteratorFactory(supervisor).createDataProviderStream(context)) {
+      runIterations(context, childExecutor, dataProviderStream);
       childExecutor.awaitFinished();
-    } finally {
-      closeDataProviders(dataProviders);
+    } catch (InterruptedException ie) {
+      throw ie;
+    } catch (Exception e) {
+      // DataIterator.close doesn't throw
     }
   }
 
-  private Object[] createDataProviders(SpockExecutionContext context) {
-    if (context.getErrorInfoCollector().hasErrors()) {
-      return null;
-    }
-
-    List<DataProviderInfo> dataProviderInfos = context.getCurrentFeature().getDataProviders();
-    if (dataProviderInfos.isEmpty()) {
-      return new Object[0];
-    }
-
-    List<String> dataProviderVariables = dataProviderInfos
-        .stream()
-        .map(DataProviderInfo::getDataVariables)
-        .flatMap(List::stream)
-        .collect(toList());
-
-    Object[] dataProviders = new Object[dataProviderInfos.size()];
-
-    for (int i = 0, size = dataProviderInfos.size(); i < size; i++) {
-      DataProviderInfo dataProviderInfo = dataProviderInfos.get(i);
-      MethodInfo method = dataProviderInfo.getDataProviderMethod();
-
-      Object provider = invokeRaw(
-          context, context.getCurrentInstance(), method,
-          getPreviousDataTableProviders(dataProviderVariables, dataProviders, dataProviderInfo));
-
-      if (context.getErrorInfoCollector().hasErrors()) {
-        if (provider != null) {
-          dataProviders[i] = provider;
-        }
-        break;
-      } else if (provider == null) {
-        SpockExecutionException error = new SpockExecutionException("Data provider is null!");
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(method, error));
-        break;
-      }
-
-      dataProviders[i] = provider;
-    }
-
-    return dataProviders;
-  }
-
-  private Object[] getPreviousDataTableProviders(List<String> dataProviderVariables, Object[] dataProviders,
-                                                 DataProviderInfo dataProviderInfo) {
-    List<Object> result = new ArrayList<>();
-    previousDataTableVariablesLoop:
-    for (String previousDataTableVariable : dataProviderInfo.getPreviousDataTableVariables()) {
-      for (int i = 0, size = dataProviderVariables.size(); i < size; i++) {
-        String dataProviderVariable = dataProviderVariables.get(i);
-        if (previousDataTableVariable.equals(dataProviderVariable)) {
-          result.add(dataProviders[i]);
-          continue previousDataTableVariablesLoop;
-        }
-      }
-      throw new IllegalStateException(String.format("Variable name not defined (%s not in %s)!",
-          previousDataTableVariable, dataProviderVariables));
-    }
-    return result.toArray();
-  }
-
-  private Iterator[] createIterators(SpockExecutionContext context, Object[] dataProviders) {
-    if (context.getErrorInfoCollector().hasErrors()) {
-      return null;
-    }
-
-    Iterator[] iterators = new Iterator<?>[dataProviders.length];
-    for (int i = 0; i < dataProviders.length; i++)
-      try {
-        Iterator<?> iter = GroovyRuntimeUtil.asIterator(dataProviders[i]);
-        if (iter == null) {
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(),
-              new SpockExecutionException("Data provider's iterator() method returned null")));
-          return null;
-        }
-        iterators[i] = iter;
-      } catch (Throwable t) {
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(), t));
-        return null;
-      }
-
-    return iterators;
-  }
-
-  // -1 => unknown
-  private int estimateNumIterations(SpockExecutionContext context, Object[] dataProviders) {
-    if (context.getErrorInfoCollector().hasErrors()) {
-      return -1;
-    }
-    if (dataProviders.length == 0) {
-      return 1;
-    }
-
-    int result = Integer.MAX_VALUE;
-    for (Object prov : dataProviders) {
-      if (prov instanceof Iterator)
-      // unbelievably, DGM provides a size() method for Iterators,
-      // although it is of course destructive (i.e. it exhausts the Iterator)
-      {
-        continue;
-      }
-
-      Object rawSize = GroovyRuntimeUtil.invokeMethodQuietly(prov, "size");
-      if (!(rawSize instanceof Number)) {
-        continue;
-      }
-
-      int size = ((Number)rawSize).intValue();
-      if (size < 0 || size >= result) {
-        continue;
-      }
-
-      result = size;
-    }
-
-    return result == Integer.MAX_VALUE ? -1 : result;
-  }
-
-  private void runIterations(SpockExecutionContext context, ParameterizedFeatureChildExecutor childExecutor, Iterator[] iterators, int estimatedNumIterations) {
+  private void runIterations(SpockExecutionContext context, ParameterizedFeatureChildExecutor childExecutor, DataIterator dataIterator) {
     if (context.getErrorInfoCollector().hasErrors()) {
       return;
     }
 
     int iterationIndex = 0;
-    while (haveNext(context, iterators)) {
-      IterationInfo iterationInfo = createIterationInfo(context, iterationIndex, nextArgs(context, iterators), estimatedNumIterations);
+    while (dataIterator.hasNext()) {
+      IterationInfo iterationInfo = createIterationInfo(context, iterationIndex, dataIterator.next(), dataIterator.getEstimatedNumIterations());
       IterationNode iterationNode = new IterationNode(
           context.getParentId().append("iteration", String.valueOf(iterationIndex++)),
           context.getRunContext().getConfiguration(RunnerConfiguration.class), iterationInfo);
@@ -186,84 +63,6 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
       if (iterationInfo.getFeature().getIterationFilter().isAllowed(iterationInfo.getIterationIndex())) {
         childExecutor.execute(iterationNode);
       }
-
-      // no iterators => no data providers => only derived parameterizations => limit to one iteration
-      if (iterators.length == 0) {
-        break;
-      }
-    }
-  }
-
-  private void closeDataProviders(Object[] dataProviders) {
-    if (dataProviders == null) {
-      return; // there was an error creating the providers
-    }
-
-    for (Object provider : dataProviders) {
-      GroovyRuntimeUtil.invokeMethodQuietly(provider, "close");
-    }
-  }
-
-  private boolean haveNext(SpockExecutionContext context, Iterator[] iterators) {
-    if (context.getErrorInfoCollector().hasErrors()) {
-      return false;
-    }
-
-    boolean haveNext = true;
-
-    for (int i = 0; i < iterators.length; i++)
-      try {
-        boolean hasNext = iterators[i].hasNext();
-        if (i == 0) {
-          haveNext = hasNext;
-        } else if (haveNext != hasNext) {
-          DataProviderInfo provider = context.getCurrentFeature().getDataProviders().get(i);
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(provider.getDataProviderMethod(),
-              createDifferentNumberOfDataValuesException(provider, hasNext)));
-          return false;
-        }
-
-      } catch (Throwable t) {
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(), t));
-        return false;
-      }
-
-    return haveNext;
-  }
-
-  private SpockExecutionException createDifferentNumberOfDataValuesException(DataProviderInfo provider,
-                                                                             boolean hasNext) {
-    String msg = String.format("Data provider for variable '%s' has %s values than previous data provider(s)",
-        provider.getDataVariables().get(0), hasNext ? "more" : "fewer");
-    SpockExecutionException exception = new SpockExecutionException(msg);
-    FeatureInfo feature = provider.getParent();
-    SpecInfo spec = feature.getParent();
-    StackTraceElement elem = new StackTraceElement(spec.getReflection().getName(),
-        feature.getName(), spec.getFilename(), provider.getLine());
-    exception.setStackTrace(new StackTraceElement[]{elem});
-    return exception;
-  }
-
-  // advances iterators and computes args
-  private Object[] nextArgs(SpockExecutionContext context, Iterator[] iterators) {
-    if (context.getErrorInfoCollector().hasErrors()) {
-      return null;
-    }
-
-    Object[] next = new Object[iterators.length];
-    for (int i = 0; i < iterators.length; i++)
-      try {
-        next[i] = iterators[i].next();
-      } catch (Throwable t) {
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(), t));
-        return null;
-      }
-
-    try {
-      return (Object[])invokeRaw(context, context.getSharedInstance(), context.getCurrentFeature().getDataProcessorMethod(), next);
-    } catch (Throwable t) {
-      supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProcessorMethod(), t));
-      return null;
     }
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionContext.java
@@ -157,4 +157,8 @@ public class SpockExecutionContext implements EngineExecutionContext, Cloneable 
   public ErrorInfoCollector getErrorInfoCollector() {
     return errorInfoCollector;
   }
+
+  public EngineExecutionListener getEngineExecutionListener() {
+    return engineExecutionListener;
+  }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
@@ -1,13 +1,16 @@
 package org.spockframework.runtime.extension;
 
 import org.spockframework.runtime.DataIterator;
+import org.spockframework.runtime.model.ParameterInfo;
+
+import java.util.List;
 
 public interface IDataDriver {
-  IDataDriver DEFAULT = (dataIterator, iterationRunner) -> {
+  IDataDriver DEFAULT = (dataIterator, iterationRunner, parameters) -> {
     while (dataIterator.hasNext()) {
       iterationRunner.runIteration(dataIterator.next());
     }
   };
 
-  void runIterations(DataIterator dataIterator, IIterationRunner iterationRunner);
+  void runIterations(DataIterator dataIterator, IIterationRunner iterationRunner, List<ParameterInfo> parameters);
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
@@ -30,7 +30,7 @@ public interface IDataDriver {
    */
   IDataDriver DEFAULT = (dataIterator, iterationRunner, parameters) -> {
     while (dataIterator.hasNext()) {
-      iterationRunner.runIteration(dataIterator.next());
+      iterationRunner.runIteration(prepareArgumentArray(dataIterator.next(), parameters));
     }
   };
 
@@ -44,4 +44,33 @@ public interface IDataDriver {
    * @param parameters the parameters of the test method
    */
   void runIterations(DataIterator dataIterator, IIterationRunner iterationRunner, List<ParameterInfo> parameters);
+
+  /**
+   * Prepares the arguments for invocation of the test method.
+   * <p>
+   * It is possible to have fewer arguments produced by the data driver than the number of parameters.
+   * In this case, the missing arguments are filled with {@link MethodInfo#MISSING_ARGUMENT}.
+   * <p>
+   * Custom implementations of IDataDriver should use this method to prepare the argument array.
+   * <p>
+   * Important: The method relies on the fact that the data iterator produces the data in the same order as the parameters,
+   * with missing arguments being on the end. If a custom implementation of IDataDriver does not follow this convention,
+   * then it should not rely on this method. However, it must still follow the contract of setting the missing arguments as
+   * {@link MethodInfo#MISSING_ARGUMENT}.
+   *
+   * @param arguments the arguments created by the data driver
+   * @param parameters the parameters of the test method
+   * @return an array of arguments that can be passed to the test method
+   */
+  static Object[] prepareArgumentArray(Object[] arguments, List<ParameterInfo> parameters) {
+    int parameterCount = parameters.size();
+    if (arguments.length == parameterCount) {
+      return arguments;
+    }
+
+    Object[] methodArguments = new Object[parameterCount];
+    arraycopy(arguments, 0, methodArguments, 0, arguments.length);
+    Arrays.fill(methodArguments, arguments.length, parameterCount, MISSING_ARGUMENT);
+    return methodArguments;
+  }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
@@ -1,11 +1,10 @@
 package org.spockframework.runtime.extension;
 
-import org.spockframework.runtime.DataIterator;
-import org.spockframework.runtime.model.MethodInfo;
-import org.spockframework.runtime.model.ParameterInfo;
+import org.spockframework.runtime.IDataIterator;
+import org.spockframework.runtime.model.*;
+import org.spockframework.util.Beta;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import static java.lang.System.arraycopy;
 import static org.spockframework.runtime.model.MethodInfo.MISSING_ARGUMENT;
@@ -22,6 +21,7 @@ import static org.spockframework.runtime.model.MethodInfo.MISSING_ARGUMENT;
  * @since 2.2
  * @author Leonard Brünings
  */
+@Beta
 public interface IDataDriver {
   /**
    * The default implementation of IDataDriver.
@@ -38,12 +38,15 @@ public interface IDataDriver {
    * Run all iterations of the test method.
    * <p>
    * A custom implementation of the DataDriver can choose to run fewer or more iterations than the data iterator provides.
+   * <p>
+   * An implementation doesn't have to wait on the futures returned by the {@code iterationRunner},
+   * the future can be used to make subsequent iterations depend on the outcome of previous iterations.
    *
    * @param dataIterator the data iterator giving access to the data from the data providers.
    * @param iterationRunner the iteration runner that will be used to run the test method for each iteration.
    * @param parameters the parameters of the test method
    */
-  void runIterations(DataIterator dataIterator, IIterationRunner iterationRunner, List<ParameterInfo> parameters);
+  void runIterations(IDataIterator dataIterator, IIterationRunner iterationRunner, List<ParameterInfo> parameters);
 
   /**
    * Prepares the arguments for invocation of the test method.

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
@@ -1,0 +1,13 @@
+package org.spockframework.runtime.extension;
+
+import org.spockframework.runtime.DataIterator;
+
+public interface IDataDriver {
+  IDataDriver DEFAULT = (dataIterator, iterationRunner) -> {
+    while (dataIterator.hasNext()) {
+      iterationRunner.runIteration(dataIterator.next());
+    }
+  };
+
+  void runIterations(DataIterator dataIterator, IIterationRunner iterationRunner);
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
@@ -30,7 +30,12 @@ public interface IDataDriver {
    */
   IDataDriver DEFAULT = (dataIterator, iterationRunner, parameters) -> {
     while (dataIterator.hasNext()) {
-      iterationRunner.runIteration(prepareArgumentArray(dataIterator.next(), parameters));
+      Object[] arguments = dataIterator.next();
+
+      // dataIterator.next() will return null if an error occurs, so skip the iteration if it is null.
+      if (arguments != null) {
+        iterationRunner.runIteration(prepareArgumentArray(arguments, parameters));
+      }
     }
   };
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
@@ -42,7 +42,7 @@ public interface IDataDriver {
    * An implementation doesn't have to wait on the futures returned by the {@code iterationRunner},
    * the future can be used to make subsequent iterations depend on the outcome of previous iterations.
    *
-   * @param dataIterator the data iterator giving access to the data from the data providers.
+   * @param dataIterator the data iterator giving access to the data from the data providers. The data iterator is not to be closed by this method.
    * @param iterationRunner the iteration runner that will be used to run the test method for each iteration.
    * @param parameters the parameters of the test method
    */

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
@@ -1,16 +1,47 @@
 package org.spockframework.runtime.extension;
 
 import org.spockframework.runtime.DataIterator;
+import org.spockframework.runtime.model.MethodInfo;
 import org.spockframework.runtime.model.ParameterInfo;
 
+import java.util.Arrays;
 import java.util.List;
 
+import static java.lang.System.arraycopy;
+import static org.spockframework.runtime.model.MethodInfo.MISSING_ARGUMENT;
+
+/**
+ * The data driver is responsible to map the data from the data providers to the individual iterations.
+ * <p>
+ * It can be used to change the behavior of the data provider, e.g. to provide data in a different order,
+ * filter data iterations, produce more iterations.
+ * <p>
+ * A thing to keep in mind is that if the order is not consistent between runs,
+ * then it will interfere with {@link org.junit.platform.engine.discovery.DiscoverySelectors.IterationSelector}.
+ *
+ * @since 2.2
+ * @author Leonard Brünings
+ */
 public interface IDataDriver {
+  /**
+   * The default implementation of IDataDriver.
+   * <p>
+   * It simply runs all iterations.
+   */
   IDataDriver DEFAULT = (dataIterator, iterationRunner, parameters) -> {
     while (dataIterator.hasNext()) {
       iterationRunner.runIteration(dataIterator.next());
     }
   };
 
+  /**
+   * Run all iterations of the test method.
+   * <p>
+   * A custom implementation of the DataDriver can choose to run fewer or more iterations than the data iterator provides.
+   *
+   * @param dataIterator the data iterator giving access to the data from the data providers.
+   * @param iterationRunner the iteration runner that will be used to run the test method for each iteration.
+   * @param parameters the parameters of the test method
+   */
   void runIterations(DataIterator dataIterator, IIterationRunner iterationRunner, List<ParameterInfo> parameters);
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IIterationRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IIterationRunner.java
@@ -1,0 +1,9 @@
+package org.spockframework.runtime.extension;
+
+import org.spockframework.runtime.model.ExecutionResult;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface IIterationRunner {
+  CompletableFuture<ExecutionResult> runIteration(Object[] args);
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IIterationRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IIterationRunner.java
@@ -1,6 +1,7 @@
 package org.spockframework.runtime.extension;
 
 import org.spockframework.runtime.model.ExecutionResult;
+import org.spockframework.util.Beta;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -10,12 +11,14 @@ import java.util.concurrent.CompletableFuture;
  * @since 2.2
  * @author Leonard Brünings
  */
+@Beta
 public interface IIterationRunner {
   /**
    * Runs the iteration.
    * <p>
    * The returned future can be used to wait for the iteration to complete and to get the result,
    * allowing the data driver to base the next iteration on the result of the previous one.
+   * However, it is not required to wait on the futures in any way.
    *
    * @param args arguments to use for the iteration
    * @return a future that will be completed with the result of the iteration

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IIterationRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IIterationRunner.java
@@ -4,6 +4,21 @@ import org.spockframework.runtime.model.ExecutionResult;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Interface for running an iteration of a test.
+ *
+ * @since 2.2
+ * @author Leonard Brünings
+ */
 public interface IIterationRunner {
+  /**
+   * Runs the iteration.
+   * <p>
+   * The returned future can be used to wait for the iteration to complete and to get the result,
+   * allowing the data driver to base the next iteration on the result of the previous one.
+   *
+   * @param args arguments to use for the iteration
+   * @return a future that will be completed with the result of the iteration
+   */
   CompletableFuture<ExecutionResult> runIteration(Object[] args);
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ExecutionResult.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ExecutionResult.java
@@ -1,0 +1,27 @@
+package org.spockframework.runtime.model;
+
+public enum ExecutionResult {
+
+  /**
+   * Indicates that the execution of a test or container was
+   * <em>successful</em>.
+   */
+  SUCCESSFUL,
+
+  /**
+   * Indicates that the execution of a test or container was
+   * <em>aborted</em> (started but not finished).
+   */
+  ABORTED,
+
+  /**
+   * Indicates that the execution of a test or container <em>failed</em>.
+   */
+  FAILED,
+
+  /**
+   * Indicates that the execution of a test or container was rejected due to a previous failure.
+   * No further executions should be triggered when this status is returned.
+   */
+  REJECTED
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ExecutionResult.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ExecutionResult.java
@@ -10,6 +10,12 @@ public enum ExecutionResult {
 
   /**
    * Indicates that the execution of a test or container was
+   * <em>skipped</em>.
+   */
+  SKIPPED,
+
+  /**
+   * Indicates that the execution of a test or container was
    * <em>aborted</em> (started but not finished).
    */
   ABORTED,

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -1,5 +1,6 @@
 package org.spockframework.runtime.model;
 
+import org.spockframework.runtime.extension.IDataDriver;
 import org.spockframework.runtime.extension.IMethodInterceptor;
 import org.spockframework.runtime.model.parallel.*;
 import org.spockframework.util.Nullable;
@@ -28,6 +29,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
   private MethodInfo featureMethod;
   private MethodInfo dataProcessorMethod;
   private NameProvider<IterationInfo> iterationNameProvider;
+  private IDataDriver dataDriver = IDataDriver.DEFAULT;
   private final List<DataProviderInfo> dataProviders = new ArrayList<>();
   private final IterationFilter iterationFilter = new IterationFilter();
 
@@ -157,6 +159,14 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
 
   public IterationFilter getIterationFilter() {
     return iterationFilter;
+  }
+
+  public IDataDriver getDataDriver() {
+    return dataDriver;
+  }
+
+  public void setDataDriver(IDataDriver dataDriver) {
+    this.dataDriver = dataDriver;
   }
 
   /**

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ParameterInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ParameterInfo.java
@@ -1,0 +1,11 @@
+package org.spockframework.runtime.model;
+
+import java.lang.reflect.Parameter;
+
+public class ParameterInfo extends NodeInfo<MethodInfo, Parameter> {
+  public ParameterInfo(MethodInfo parent, String parameterName, Parameter parameter) {
+    setParent(parent);
+    setName(parameterName);
+    setReflection(parameter);
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/ClosingOfDataProviders.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/ClosingOfDataProviders.groovy
@@ -16,8 +16,10 @@
 
 package org.spockframework.runtime
 
+import spock.lang.Ignore
 import spock.lang.Specification
 
+@Ignore("Method removed from PlatformParameterizedSpecRunner")
 class ClosingOfDataProviders extends Specification {
   def runner = new PlatformParameterizedSpecRunner(null)
 

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/EstimatedNumberOfIterations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/EstimatedNumberOfIterations.groovy
@@ -16,8 +16,10 @@
 
 package org.spockframework.runtime
 
+import spock.lang.Ignore
 import spock.lang.Specification
 
+@Ignore("Method removed from PlatformParameterizedSpecRunner")
 class EstimatedNumberOfIterations extends Specification {
   def runner = new PlatformParameterizedSpecRunner(null)
   def context = new SpockExecutionContext().withErrorInfoCollector(new ErrorInfoCollector())

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/EstimatedNumberOfIterations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/EstimatedNumberOfIterations.groovy
@@ -16,36 +16,151 @@
 
 package org.spockframework.runtime
 
-import spock.lang.Ignore
+import org.spockframework.runtime.model.*
 import spock.lang.Specification
 
-@Ignore("Method removed from PlatformParameterizedSpecRunner")
+import org.junit.platform.engine.EngineExecutionListener
+
 class EstimatedNumberOfIterations extends Specification {
-  def runner = new PlatformParameterizedSpecRunner(null)
-  def context = new SpockExecutionContext().withErrorInfoCollector(new ErrorInfoCollector())
+
+  def context = new SpockExecutionContext(Stub(EngineExecutionListener))
+    .withErrorInfoCollector(new ErrorInfoCollector())
+    .withCurrentInstance(this)
+  def factory = new DataIteratorFactory(Stub(IRunSupervisor))
 
   def "w/o data provider"() {
+    given:
+    FeatureInfo featureInfo = Stub {
+      getDataProcessorMethod() >> methodInfoFor('dataProcessor1')
+      getDataProviders() >> []
+    }
+
     expect: "estimation is 1"
-      runner.estimateNumIterations(context, new Object[0]) == 1
+    factory.createFeatureDataIterator(context.withCurrentFeature(featureInfo)).estimatedNumIterations == 1
+  }
+
+
+  @DataProcessorMetadata(dataVariables = [])
+  Object[] dataProcessor1(Object[] args) {
+    return new Object[0]
   }
 
   def "w/ data provider that doesn't respond to size"() {
+    given:
+    FeatureInfo featureInfo = Stub {
+      getDataProcessorMethod() >> methodInfoFor('dataProcessor2')
+      getDataProviders() >> [new DataProviderInfo(dataVariables: ['a'], previousDataTableVariables: [], dataProviderMethod: methodInfoFor('dataProvider2'))]
+    }
+
     expect: "estimation is 'unknown', represented as -1"
-      runner.estimateNumIterations(context, [1] as Object[]) == -1
+    factory.createFeatureDataIterator(context.withCurrentFeature(featureInfo)).estimatedNumIterations == -1
+  }
+
+
+  @DataProviderMetadata(dataVariables = ['a'])
+  Iterator<String> dataProvider2() {
+    ['a'].iterator()
+  }
+
+  @DataProcessorMetadata(dataVariables = ['a'])
+  Object[] dataProcessor2(Object[] args) {
+    return args
   }
 
   def "w/ data provider that responds to size"() {
+    given:
+    FeatureInfo featureInfo = Stub {
+      getDataProcessorMethod() >> methodInfoFor('dataProcessor3')
+      getDataProviders() >> [new DataProviderInfo(dataVariables: ['a'], previousDataTableVariables: [], dataProviderMethod: methodInfoFor('dataProvider3'))]
+    }
     expect: "estimation is size"
-      runner.estimateNumIterations(context, [[1, 2, 3]] as Object[]) == 3
+    factory.createFeatureDataIterator(context.withCurrentFeature(featureInfo)).estimatedNumIterations == 3
   }
+
+  @DataProviderMetadata(dataVariables = ['a'])
+  List<String> dataProvider3() {
+    ['a', 'b', 'c']
+  }
+
+  @DataProcessorMetadata(dataVariables = ['a'])
+  Object[] dataProcessor3(Object[] args) {
+    return args
+  }
+
 
   def "w/ multiple data providers, all of which respond to size"() {
+    given:
+    FeatureInfo featureInfo = Stub {
+      getDataProcessorMethod() >> methodInfoFor('dataProcessor4')
+      getDataProviders() >> [
+        new DataProviderInfo(dataVariables: ['a'], previousDataTableVariables: [], dataProviderMethod: methodInfoFor('dataProvider4_1')),
+        new DataProviderInfo(dataVariables: ['b'], previousDataTableVariables: [], dataProviderMethod: methodInfoFor('dataProvider4_2')),
+        new DataProviderInfo(dataVariables: ['c'], previousDataTableVariables: [], dataProviderMethod: methodInfoFor('dataProvider4_3'))
+      ]
+    }
     expect: "estimation is minimum"
-      runner.estimateNumIterations(context, [[1], [1, 2], [1, 2, 3]] as Object[]) == 1
+    factory.createFeatureDataIterator(context.withCurrentFeature(featureInfo)).estimatedNumIterations == 1
   }
 
+
+  @DataProviderMetadata(dataVariables = ['a'])
+  List<String> dataProvider4_1() {
+    ['a']
+  }
+
+  @DataProviderMetadata(dataVariables = ['b'])
+  Range<Integer> dataProvider4_2() {
+    (1..3)
+  }
+
+  @DataProviderMetadata(dataVariables = ['c'])
+  Iterable<Integer> dataProvider4_3() {
+    [1, 2]
+  }
+
+  @DataProcessorMetadata(dataVariables = ['a', 'b', 'c'])
+  Object[] dataProcessor4(Object[] args) {
+    return args
+  }
+
+
   def "w/ multiple data providers, one of which doesn't respond to size"() {
-  expect: "estimation is minimum of others"
-    runner.estimateNumIterations(context, [1, [1, 2], [1, 2, 3]] as Object[]) == 2
+
+    given:
+    FeatureInfo featureInfo = Stub {
+      getDataProcessorMethod() >> methodInfoFor('dataProcessor5')
+      getDataProviders() >> [
+        new DataProviderInfo(dataVariables: ['a'], previousDataTableVariables: [], dataProviderMethod: methodInfoFor('dataProvider5_1')),
+        new DataProviderInfo(dataVariables: ['b'], previousDataTableVariables: [], dataProviderMethod: methodInfoFor('dataProvider5_2')),
+        new DataProviderInfo(dataVariables: ['c'], previousDataTableVariables: [], dataProviderMethod: methodInfoFor('dataProvider5_3'))
+      ]
+    }
+    expect: "estimation is minimum of others"
+    factory.createFeatureDataIterator(context.withCurrentFeature(featureInfo)).estimatedNumIterations == 2
+  }
+
+
+  @DataProviderMetadata(dataVariables = ['a'])
+  Iterator<String> dataProvider5_1() {
+    ['a'].iterator()
+  }
+
+  @DataProviderMetadata(dataVariables = ['b'])
+  Range<Integer> dataProvider5_2() {
+    (1..3)
+  }
+
+  @DataProviderMetadata(dataVariables = ['c'])
+  Iterable<Integer> dataProvider5_3() {
+    [1, 2]
+  }
+
+  @DataProcessorMetadata(dataVariables = ['a', 'b', 'c'])
+  Object[] dataProcessor5(Object[] args) {
+    return args
+  }
+
+  private MethodInfo methodInfoFor(String methodName) {
+    EstimatedNumberOfIterations.declaredMethods.find { it.name == methodName }.with { new MethodInfo(reflection: it) }
   }
 }


### PR DESCRIPTION
The main motivation is to extract the `DataIterator` logic from the 
`PlatformParameterizedSpecRunner` into a reusable form, so that it can
serve as foundation for data driven specs in the future.

This also opened up the possibility of adding a new extension point `IDataDriver`,
which can be used to control the actual iterations of a feature.
A possible use-case is to enable property based testing like jqwik
via a third-party extension.