### PR TITLE
Update build logic to require JDK 11...

### DIFF
--- a/.github/actions/setup-jdks/action.yml
+++ b/.github/actions/setup-jdks/action.yml
@@ -9,18 +9,28 @@ runs:
   steps:
     - name: 'Set up JDK ${{ inputs.additional-java-version }}'
       uses: actions/setup-java@v2
-      if: inputs.additional-java-version != 8
+      if: inputs.additional-java-version != 8 && inputs.additional-java-version != 11
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ inputs.additional-java-version }}
     - name: 'Prepare JDK${{ inputs.additional-java-version }} env var'
       shell: bash
       run: echo "JDK${{ inputs.additional-java-version }}=$JAVA_HOME" >> $GITHUB_ENV
+    # We need JDK to compile Spock Core
     - name: 'Set up JDK 8'
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 8
     - name: Prepare JDK8 env var
       shell: bash
       run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
+    # We need JDK 11 for the Gradle build logic
+    - name: 'Set up JDK 11'
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: 11
+    - name: Prepare JDK11 env var
+      shell: bash
+      run: echo "JDK11=$JAVA_HOME" >> $GITHUB_ENV

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
     id "com.gradle.enterprise" version "3.10.2"
     id "com.gradle.common-custom-user-data-gradle-plugin" version "1.7.2"
     id "org.asciidoctor.jvm.convert" version "3.3.2"
-    id "net.nemerosa.versioning" version "2.15.1"
+    id "net.nemerosa.versioning" version "3.0.0"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
     id "com.github.ben-manes.versions" version "0.42.0"
     id "biz.aQute.bnd.builder" version "6.3.1"
@@ -25,6 +25,11 @@ dependencyResolutionManagement {
     mavenCentral()
   }
 }
+
+if (((System.getProperty("java.specification.version") ?: 8) as BigDecimal) < 11) {
+  throw new InvalidUserDataException("The spock build needs to be run with JDK 11 or higher, but was: ${System.getProperty("java.specification.version")}")
+}
+
 
 def gradleEnterpriseServer = "https://ge.spockframework.org"
 def isCiServer = System.env["CI"] || System.env["GITHUB_ACTIONS"]


### PR DESCRIPTION
Prior to this commit, the gradle build could be run with JDK 8,
but since a plugin now requires JDK 11, the build needs to be run with JDK 11+.

JDK 8 must still be installed as spock-core is compiled against it via toolchains.
JDK locations should be made known to toolchains via `JDK<version>=<PATH>` environment
variable, e.g., `JDK8=/path/to/jdk8`.