### PR TITLE
Make the asciidoc extension available to IJ plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ stacktrace.log
 
 Foo.*
 /.shelf/
+/.asciidoctor/
 
 !.idea/icon.png

--- a/build-logic/asciidoc-extensions/asciidoc-extensions.gradle
+++ b/build-logic/asciidoc-extensions/asciidoc-extensions.gradle
@@ -8,3 +8,12 @@ dependencies {
   compileOnly 'org.asciidoctor:asciidoctorj:2.5.4'
 }
 
+tasks.register('installAsciidocExtension', Copy) {
+  from(tasks.named('jar'))
+  into('../../.asciidoctor/lib')
+}
+
+tasks.named('ideaModule').configure {
+  it.dependsOn('installAsciidocExtension')
+}
+

--- a/build-logic/asciidoc-extensions/asciidoc-extensions.gradle
+++ b/build-logic/asciidoc-extensions/asciidoc-extensions.gradle
@@ -13,7 +13,7 @@ tasks.register('installAsciidocExtension', Copy) {
   into('../../.asciidoctor/lib')
 }
 
-tasks.named('ideaModule').configure {
+tasks.named('ideaModule') {
   it.dependsOn('installAsciidocExtension')
 }
 


### PR DESCRIPTION
Copy the local to `.asciidoctor/lib`, so that the IntelliJ Asciidoctor
plugin can pick it up. This can be done manually by calling the
`installAsciidocExtension` task on the `asciidoc-extensions` project,
or simply by triggering the `idea` task.