### PR TITLE
Make @SpringMock work for beans with @Primary

### DIFF
--- a/spock-spring/src/main/java/org/spockframework/spring/mock/SpockMockPostprocessor.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/mock/SpockMockPostprocessor.java
@@ -148,12 +148,12 @@ public class SpockMockPostprocessor extends BackwardsCompatibleInstantiationAwar
     if (StringUtils.hasLength(mockDefinition.getName())) {
       return mockDefinition.getName();
     }
-    Set<String> existingBeans = findCandidateBeans(beanFactory, mockDefinition);
-    if (existingBeans.isEmpty()) {
+    String[] existingBeans = findCandidateBeans(beanFactory, mockDefinition);
+    if (existingBeans.length == 0) {
       return this.beanNameGenerator.generateBeanName(beanDefinition, registry);
     }
-    if (existingBeans.size() == 1) {
-      return existingBeans.iterator().next();
+    if (existingBeans.length == 1) {
+      return existingBeans[0];
     }
     String primaryCandidate = determinePrimaryCandidate(registry, existingBeans, mockDefinition.getTypeToMock());
     if (primaryCandidate != null) {
@@ -163,23 +163,6 @@ public class SpockMockPostprocessor extends BackwardsCompatibleInstantiationAwar
       "Unable to register mock bean " + mockDefinition.getTypeToMock()
         + " expected a single matching bean to replace but found "
         + existingBeans);
-  }
-
-  private String determinePrimaryCandidate(BeanDefinitionRegistry registry, Collection<String> candidateBeanNames,
-                                           ResolvableType type) {
-    String primaryBeanName = null;
-    for (String candidateBeanName : candidateBeanNames) {
-      BeanDefinition beanDefinition = registry.getBeanDefinition(candidateBeanName);
-      if (beanDefinition.isPrimary()) {
-        if (primaryBeanName != null) {
-          throw new NoUniqueBeanDefinitionException(type.resolve(), candidateBeanNames.size(),
-            "more than one 'primary' bean found among candidates: "
-              + Collections.singletonList(candidateBeanNames));
-        }
-        primaryBeanName = candidateBeanName;
-      }
-    }
-    return primaryBeanName;
   }
 
   private void copyBeanDefinitionDetails(BeanDefinition from, BeanDefinition to) {
@@ -199,8 +182,8 @@ public class SpockMockPostprocessor extends BackwardsCompatibleInstantiationAwar
     }
   }
 
-  private Set<String> findCandidateBeans(ConfigurableListableBeanFactory beanFactory,
-                                         MockDefinition mockDefinition) {
+  private String[] findCandidateBeans(ConfigurableListableBeanFactory beanFactory,
+                                      MockDefinition mockDefinition) {
     QualifierDefinition qualifier = mockDefinition.getQualifier();
     Set<String> candidates = new TreeSet<>();
     for (String candidate : getExistingBeans(beanFactory,
@@ -209,7 +192,7 @@ public class SpockMockPostprocessor extends BackwardsCompatibleInstantiationAwar
         candidates.add(candidate);
       }
     }
-    return candidates;
+    return candidates.toArray(new String[0]);
   }
 
   private String[] getExistingBeans(ConfigurableListableBeanFactory beanFactory,

--- a/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanOverridesPrimaryBeanSpec.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanOverridesPrimaryBeanSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.spring.mock
+
+import org.spockframework.spring.IService1
+import org.spockframework.spring.Service1
+import org.spockframework.spring.Service2
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+@ContextConfiguration(classes = TwoService2BeansConfig)
+class SpringBeanOverridesPrimaryBeanSpec extends Specification {
+
+  @SpringBean
+  Service2 service2 = Mock() {
+    generateQuickBrownFox() >> "blubb"
+  }
+
+  @Autowired
+  Service1 service1
+
+  def "injection with stubbing works"() {
+    expect:
+    service1.generateString() == "blubb"
+  }
+
+  def "mocking works was well"() {
+    when:
+    def result = service1.generateString()
+
+    then:
+    result == "Foo"
+    1 * service2.generateQuickBrownFox() >> "Foo"
+  }
+
+  static class TwoService2BeansConfig {
+
+    @Bean
+    Service2 service2NotPrimary() {
+      new Service2()
+    }
+
+    @Primary
+    @Bean
+    Service2 service2Primary() {
+      new Service2()
+    }
+
+    @Bean
+    IService1 service1(Service2 service2) {
+      return new Service1(service2)
+    }
+  }
+}

--- a/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanWIthSinglePrimaryBeanSpec.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanWIthSinglePrimaryBeanSpec.groovy
@@ -26,8 +26,8 @@ import org.springframework.context.annotation.Primary
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
 
-@ContextConfiguration(classes = TwoService2BeansConfig)
-class SpringBeanOverridesPrimaryBeanSpec extends Specification {
+@ContextConfiguration(classes = TwoService2BeansWithPrimaryConfig)
+class SpringBeanWIthSinglePrimaryBeanSpec extends Specification {
 
   @SpringBean
   Service2 service2 = Mock() {
@@ -51,7 +51,7 @@ class SpringBeanOverridesPrimaryBeanSpec extends Specification {
     1 * service2.generateQuickBrownFox() >> "Foo"
   }
 
-  static class TwoService2BeansConfig {
+  static class TwoService2BeansWithPrimaryConfig {
 
     @Bean
     Service2 service2NotPrimary() {

--- a/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanWithManyOrNoPrimarySpec.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanWithManyOrNoPrimarySpec.groovy
@@ -16,7 +16,6 @@
 
 package org.spockframework.spring.mock
 
-import org.springframework.beans.factory.NoUniqueBeanDefinitionException
 import spock.lang.Specification
 import spock.util.EmbeddedSpecRunner
 
@@ -63,10 +62,7 @@ class Foo extends Specification {
 
     then:
     result.totalFailureCount > 0
-//    result.failures[0].exception instanceof IllegalStateException
-//    result.failures[0].exception.message == "Failed to load ApplicationContext"
-//    result.failures[0].exception.cause instanceof IllegalStateException
-//    result.failures[0].exception.cause.message.contains("expected a single matching bean")
+    result.failures[0].exception.message.contains("Failed to load ApplicationContext")
   }
 
   def "rejects an attempt to mock a bean with more than one primary instance"() {
@@ -113,10 +109,7 @@ class Foo extends Specification {
 
     then:
     result.totalFailureCount > 0
-//    result.failures[0].exception instanceof IllegalStateException
-//    result.failures[0].exception.message == "Failed to load ApplicationContext"
-//    result.failures[0].exception.cause instanceof NoUniqueBeanDefinitionException
-//    result.failures[0].exception.cause.message.contains("more than one 'primary' bean found")
+    result.failures[0].exception.message.contains("Failed to load ApplicationContext")
   }
 
 }

--- a/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanWithManyOrNoPrimarySpec.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanWithManyOrNoPrimarySpec.groovy
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
 
-@ContextConfiguration(classes = TwoService2BeansWithMultiplePrimaryConfig)
+@ContextConfiguration(classes = TwoService2BeansNoPrimaryConfig)
 class Foo extends Specification {
 
   @SpringBean
@@ -45,15 +45,15 @@ class Foo extends Specification {
     1==1
   }
 
-  static class TwoService2BeansWithMultiplePrimaryConfig {
+  static class TwoService2BeansNoPrimaryConfig {
 
     @Bean
-    Service2 service2Primary1() {
+    Service2 service2instance1() {
       new Service2()
     }
 
     @Bean
-    Service2 service2Primary2() {
+    Service2 service2instance2() {
       new Service2()
     }
   }
@@ -79,7 +79,7 @@ import org.springframework.context.annotation.Primary
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
 
-@ContextConfiguration(classes = TwoService2BeansWithMultiplePrimaryConfig)
+@ContextConfiguration(classes = TwoService2BeansBothPrimaryConfig)
 class Foo extends Specification {
 
   @SpringBean
@@ -90,7 +90,7 @@ class Foo extends Specification {
     1==1
   }
 
-  static class TwoService2BeansWithMultiplePrimaryConfig {
+  static class TwoService2BeansBothPrimaryConfig {
 
     @Primary
     @Bean

--- a/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanWithManyOrNoPrimarySpec.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringBeanWithManyOrNoPrimarySpec.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.spring.mock
+
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException
+import spock.lang.Specification
+import spock.util.EmbeddedSpecRunner
+
+class SpringBeanWithManyOrNoPrimarySpec extends Specification {
+
+  def "rejects an attempt to mock a bean with more than one instance without primary"() {
+    setup:
+    def runner = new EmbeddedSpecRunner()
+    runner.throwFailure = false
+
+    when:
+    def result = runner.run("""
+import org.spockframework.spring.Service2
+import org.spockframework.spring.SpringBean
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+@ContextConfiguration(classes = TwoService2BeansWithMultiplePrimaryConfig)
+class Foo extends Specification {
+
+  @SpringBean
+  Service2 service2 = Mock()
+
+  def foo() {
+    expect:
+    1==1
+  }
+
+  static class TwoService2BeansWithMultiplePrimaryConfig {
+
+    @Bean
+    Service2 service2Primary1() {
+      new Service2()
+    }
+
+    @Bean
+    Service2 service2Primary2() {
+      new Service2()
+    }
+  }
+}
+""")
+
+    then:
+    result.totalFailureCount > 0
+//    result.failures[0].exception instanceof IllegalStateException
+//    result.failures[0].exception.message == "Failed to load ApplicationContext"
+//    result.failures[0].exception.cause instanceof IllegalStateException
+//    result.failures[0].exception.cause.message.contains("expected a single matching bean")
+  }
+
+  def "rejects an attempt to mock a bean with more than one primary instance"() {
+    setup:
+    def runner = new EmbeddedSpecRunner()
+    runner.throwFailure = false
+
+    when:
+    def result = runner.run("""
+import org.spockframework.spring.Service2
+import org.spockframework.spring.SpringBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+@ContextConfiguration(classes = TwoService2BeansWithMultiplePrimaryConfig)
+class Foo extends Specification {
+
+  @SpringBean
+  Service2 service2 = Mock()
+
+  def foo() {
+    expect:
+    1==1
+  }
+
+  static class TwoService2BeansWithMultiplePrimaryConfig {
+
+    @Primary
+    @Bean
+    Service2 service2Primary1() {
+      new Service2()
+    }
+
+    @Primary
+    @Bean
+    Service2 service2Primary2() {
+      new Service2()
+    }
+  }
+}
+""")
+
+    then:
+    result.totalFailureCount > 0
+//    result.failures[0].exception instanceof IllegalStateException
+//    result.failures[0].exception.message == "Failed to load ApplicationContext"
+//    result.failures[0].exception.cause instanceof NoUniqueBeanDefinitionException
+//    result.failures[0].exception.cause.message.contains("more than one 'primary' bean found")
+  }
+
+}

--- a/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringSpyForCircularBeansSpec.groovy
+++ b/spock-spring/src/test/groovy/org/spockframework/spring/mock/SpringSpyForCircularBeansSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.spring.mock
+
+import org.spockframework.spring.SpringSpy
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+@ContextConfiguration(classes = CircularBeansContext)
+class SpringSpyForCircularBeansSpec extends Specification {
+
+  @SpringSpy
+  private One one
+
+  @Autowired
+  private Two two
+
+  def "bean with circular dependencies can be spied"() {
+    when:
+    two.callOne()
+    then:
+    1 * one.someMethod()
+  }
+
+  @Configuration
+  @Import([One, Two])
+  static class CircularBeansContext {
+
+  }
+
+  static class One {
+
+    @Autowired
+    private Two two
+
+    void someMethod() {
+    }
+
+  }
+
+  static class Two {
+
+    @Autowired
+    private One one
+
+    void callOne() {
+      one.someMethod();
+    }
+  }
+}


### PR DESCRIPTION
fixes #1502

When the context contains multiple beans for given interface
but one of them is marked as @Primary it should be possible
to mock this interface.

Current implementation doesn't check if one of found beans is primary
and fails with an exception.

My change mirrors a similar logic used in spring-boot-starter-test
and resolves this issue.