### PR TITLE
Fix contributing link in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -130,7 +130,7 @@ automatically (unless already present).
 === Contributing
 
 Contributions are welcome! Please see the
-https://github.com/spockframework/spock/blob/master/CONTRIBUTING.md[contributing
+https://github.com/spockframework/spock/blob/master/CONTRIBUTING.adoc[contributing
 page] for detailed instructions.
 
 === Support


### PR DESCRIPTION
Hello!
I have noticed that in the `README.adoc` file, there is a link to contributing page that does not work. I've noticed that the extension of the file has changed from `CONTRIBUTING.md` to `CONTRIBUTING.adoc`, but the readme was not changed accordingly.

This PR fixes it.