### PR TITLE
fix: change sourceUrl

### DIFF
--- a/gradle/publishMaven.gradle
+++ b/gradle/publishMaven.gradle
@@ -30,7 +30,7 @@ publishing {
         scm {
           connection = "scm:git:git://github.com/spockframework/spock.git"
           developerConnection = "scm:git:ssh://git@github.com/spockframework/spock.git"
-          url = "https://github.spockframework.org/spock"
+          url = "https://github.com/spockframework/spock"
         }
         developers {
           developer {


### PR DESCRIPTION
The sourceUrl for the deps are `github.spockframework.org/spock` which cannot be resolved so I have changed it to poin to this repo `github.com/spockframework/spock`.