### PR TITLE
Extends @Execution with optional "reason" field

### DIFF
--- a/spock-core/src/main/java/spock/lang/Execution.java
+++ b/spock-core/src/main/java/spock/lang/Execution.java
@@ -17,5 +17,19 @@ import java.lang.annotation.*;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @ExtensionAnnotation(ExecutionExtension.class)
 public @interface Execution {
+
+  /**
+   * The required/preferred execution mode.
+   *
+   * @see ExecutionMode
+   */
   ExecutionMode value();
+
+  /**
+   * The reason of using a non-default execution mode.
+   *
+   * @since 2.4
+   */
+  String reason() default "";
+
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryFeatureExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryFeatureExtensionSpec.groovy
@@ -14,7 +14,7 @@ import static org.junit.platform.testkit.engine.EventConditions.finishedWithFail
 import static org.junit.platform.testkit.engine.EventConditions.test
 import static org.spockframework.runtime.model.parallel.ExecutionMode.SAME_THREAD
 
-@Execution(SAME_THREAD)
+@Execution(value = SAME_THREAD, reason = "tests use static field")
 class RetryFeatureExtensionSpec extends EmbeddedSpecification {
 
   static AtomicInteger setupCounter = new AtomicInteger()


### PR DESCRIPTION
To explain - without using a comment - why a non-default execution mode is used.

Occasionally, I had to use the construction similar to the following when a reason could be not obvious.

```groovy
@Execution(ExecutionMode.SAME_THREAD) // because test is using static fields
class MyTestWithStaticFields extends Specification {
   ...
}
```

WDYT?