### PR TITLE
Add implied features...

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/DependencyFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DependencyFeatureNode.java
@@ -1,0 +1,97 @@
+package org.spockframework.runtime;
+
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.spockframework.runtime.model.FeatureInfo;
+
+import java.util.Optional;
+
+/**
+ * A feature that is a dependency of one or multiple other features, depends on one or multiple other features, or both.
+ * The actual test work is delegated to another feature node.
+ * This node makes sure the node is not removed from hierarchy e.g. due to filtering as long as one dependee is still present.
+ */
+public class DependencyFeatureNode extends FeatureNode {
+
+  private final FeatureNode delegate;
+
+  private boolean removedFromHierarchy;
+
+  public DependencyFeatureNode(FeatureNode delegate) {
+    super(delegate);
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Type getType() {
+    return delegate.getType();
+  }
+
+  @Override
+  public SpockExecutionContext prepare(SpockExecutionContext context) throws Exception {
+    return delegate.prepare(context);
+  }
+
+  @Override
+  public SpockExecutionContext before(SpockExecutionContext context) throws Exception {
+    return delegate.before(context);
+  }
+
+  @Override
+  public void around(SpockExecutionContext context, Invocation<SpockExecutionContext> invocation) {
+    delegate.around(context, invocation);
+  }
+
+  @Override
+  public SpockExecutionContext execute(SpockExecutionContext context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
+    return delegate.execute(context, dynamicTestExecutor);
+  }
+
+  @Override
+  public void after(SpockExecutionContext context) throws Exception {
+    delegate.after(context);
+  }
+
+  @Override
+  public void nodeFinished(SpockExecutionContext context, TestDescriptor testDescriptor, TestExecutionResult result) {
+    delegate.nodeFinished(context, testDescriptor, result);
+  }
+
+  @Override
+  public void nodeSkipped(SpockExecutionContext context, TestDescriptor testDescriptor, SkipResult result) {
+    delegate.nodeSkipped(context, testDescriptor, result);
+  }
+
+  @Override
+  public SkipResult shouldBeSkipped(SpockExecutionContext context) throws Exception {
+    return delegate.shouldBeSkipped(context);
+  }
+
+  private boolean allDependeesAreRemoved() {
+    return getNodeInfo()
+      .getDependees()
+      .stream()
+      .map(FeatureInfo::getNode)
+      .map(DependencyFeatureNode.class::cast)
+      .map(TestDescriptor::getParent)
+      .noneMatch(Optional::isPresent);
+  }
+
+  @Override
+  public void removeFromHierarchy() {
+    if (getNodeInfo().getDependees().isEmpty() || allDependeesAreRemoved()) {
+      super.removeFromHierarchy();
+      // retry to remove dependencies that were just preserved for this dependee
+      getNodeInfo()
+        .getDependencies()
+        .stream()
+        .map(FeatureInfo::getNode)
+        .map(DependencyFeatureNode.class::cast)
+        .filter(dependency -> dependency.removedFromHierarchy)
+        .forEach(TestDescriptor::removeFromHierarchy);
+    } else {
+      // do not remove from hierarchy but remember it was removed
+      removedFromHierarchy = true;
+    }
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/DependencyFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DependencyFeatureNode.java
@@ -75,18 +75,18 @@ public class DependencyFeatureNode extends FeatureNode {
   }
 
   private boolean allDependeesAreRemoved() {
-    return !findDependencyFeatureNodes(getRootDescriptor(this), getNodeInfo().getDependees())
+    return !findDependencyFeatureNodes(getRootDescriptor(this), getNodeInfo().getImplyingFeatures())
       .findAny()
       .isPresent();
   }
 
   @Override
   public void removeFromHierarchy() {
-    if (getNodeInfo().getDependees().isEmpty() || allDependeesAreRemoved()) {
+    if (getNodeInfo().getImplyingFeatures().isEmpty() || allDependeesAreRemoved()) {
       TestDescriptor rootDescriptor = getRootDescriptor(this);
       super.removeFromHierarchy();
       // retry to remove dependencies that were just preserved for this dependee
-      findDependencyFeatureNodes(rootDescriptor, getNodeInfo().getDependencies())
+      findDependencyFeatureNodes(rootDescriptor, getNodeInfo().getImpliedFeatures())
         .filter(dependency -> dependency.removedFromHierarchy)
         .forEach(TestDescriptor::removeFromHierarchy);
     } else {

--- a/spock-core/src/main/java/org/spockframework/runtime/FeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/FeatureNode.java
@@ -16,6 +16,10 @@ public abstract class FeatureNode extends SpockNode<FeatureInfo> {
     super(uniqueId, displayName, source, configuration, featureInfo);
   }
 
+  protected FeatureNode(FeatureNode other) {
+    super(other);
+  }
+
   @Override
   public Type getType() {
     return Type.CONTAINER;

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockEngineDiscoveryPostProcessor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockEngineDiscoveryPostProcessor.java
@@ -26,7 +26,7 @@ class SpockEngineDiscoveryPostProcessor {
       result = describeSimpleFeature(specNode.getUniqueId(), feature, configuration);
     }
     if (!feature.getImplyingFeatures().isEmpty() || !feature.getImpliedFeatures().isEmpty()) {
-      result = new DependencyFeatureNode(result);
+      result = new ImplicationFeatureNode(result);
     }
     return result;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockEngineDiscoveryPostProcessor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockEngineDiscoveryPostProcessor.java
@@ -28,7 +28,6 @@ class SpockEngineDiscoveryPostProcessor {
     if (!feature.getDependees().isEmpty() || !feature.getDependencies().isEmpty()) {
       result = new DependencyFeatureNode(result);
     }
-    feature.setNode(result);
     return result;
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockEngineDiscoveryPostProcessor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockEngineDiscoveryPostProcessor.java
@@ -25,7 +25,7 @@ class SpockEngineDiscoveryPostProcessor {
     } else {
       result = describeSimpleFeature(specNode.getUniqueId(), feature, configuration);
     }
-    if (!feature.getDependees().isEmpty() || !feature.getDependencies().isEmpty()) {
+    if (!feature.getImplyingFeatures().isEmpty() || !feature.getImpliedFeatures().isEmpty()) {
       result = new DependencyFeatureNode(result);
     }
     return result;

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockEngineDiscoveryPostProcessor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockEngineDiscoveryPostProcessor.java
@@ -18,12 +18,18 @@ class SpockEngineDiscoveryPostProcessor {
     return processedEngineDescriptor;
   }
 
-  private SpockNode createNode(SpecNode specNode, FeatureInfo feature, RunnerConfiguration configuration) {
+  private FeatureNode createNode(SpecNode specNode, FeatureInfo feature, RunnerConfiguration configuration) {
+    FeatureNode result;
     if (feature.isParameterized()) {
-      return describeParameterizedFeature(specNode.getUniqueId(), feature, configuration);
+      result = describeParameterizedFeature(specNode.getUniqueId(), feature, configuration);
     } else {
-      return describeSimpleFeature(specNode.getUniqueId(), feature, configuration);
+      result = describeSimpleFeature(specNode.getUniqueId(), feature, configuration);
     }
+    if (!feature.getDependees().isEmpty() || !feature.getDependencies().isEmpty()) {
+      result = new DependencyFeatureNode(result);
+    }
+    feature.setNode(result);
+    return result;
   }
 
   private FeatureNode describeParameterizedFeature(UniqueId parentId, FeatureInfo feature,
@@ -31,7 +37,7 @@ class SpockEngineDiscoveryPostProcessor {
     return new ParameterizedFeatureNode(toUniqueId(parentId, feature), configuration, feature);
   }
 
-  private SpockNode describeSimpleFeature(UniqueId parentId, FeatureInfo feature, RunnerConfiguration configuration) {
+  private FeatureNode describeSimpleFeature(UniqueId parentId, FeatureInfo feature, RunnerConfiguration configuration) {
     IterationInfo iterationInfo = new IterationInfo(feature, 0, EMPTY_ARGS, 1);
     iterationInfo.setName(feature.getName());
     UniqueId uniqueId = toUniqueId(parentId, feature);

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockNode.java
@@ -27,6 +27,12 @@ public abstract class SpockNode<T extends SpecElementInfo<?,?>>
     this.nodeInfo = nodeInfo;
   }
 
+  protected SpockNode(SpockNode<T> other) {
+    super(other.getUniqueId(), other.getDisplayName(), other.getSource().orElse(null));
+    this.configuration = other.configuration;
+    this.nodeInfo = other.nodeInfo;
+  }
+
   public T getNodeInfo() {
     return nodeInfo;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/StepwiseExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/StepwiseExtension.java
@@ -73,7 +73,7 @@ public class StepwiseExtension implements IAnnotationDrivenExtension<Stepwise> {
       else if (!feature.isExcluded()) includeRemaining = true;
 
       if (i > 0) {
-        feature.addDependency(features.get(i - 1));
+        feature.addImpliedFeature(features.get(i - 1));
       }
     }
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/StepwiseExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/StepwiseExtension.java
@@ -71,6 +71,10 @@ public class StepwiseExtension implements IAnnotationDrivenExtension<Stepwise> {
       FeatureInfo feature = features.get(i);
       if (includeRemaining) feature.setExcluded(false);
       else if (!feature.isExcluded()) includeRemaining = true;
+
+      if (i > 0) {
+        feature.addDependency(features.get(i - 1));
+      }
     }
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -34,9 +34,9 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
   private final List<DataProviderInfo> dataProviders = new ArrayList<>();
   private final IterationFilter iterationFilter = new IterationFilter();
 
-  private final List<FeatureInfo> dependees = new ArrayList<>();
+  private final List<FeatureInfo> implyingFeatures = new ArrayList<>();
 
-  private final List<FeatureInfo> dependencies = new ArrayList<>();
+  private final List<FeatureInfo> impliedFeatures = new ArrayList<>();
 
   private boolean reportIterations = true;
 
@@ -123,17 +123,56 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
     dataProviders.add(dataProvider);
   }
 
-  public List<FeatureInfo> getDependees() {
-    return dependees;
+  /**
+   * Returns the features that imply this feature.
+   * If one of the returned features is going to be executed, this feature is also going to be executed,
+   * even if for example a post discovery filter would have filtered out this feature, like IDEs and build
+   * tools do if a specific test or a pattern of tests is executed.
+   *
+   * <p><b>NOTE:</b> This relationship does not imply any ordering constraint. According to configured
+   *                 run order and parallel execution settings the features can run in any order or even
+   *                 concurrently.
+   *
+   * @return the features that imply this feature
+   */
+  @Beta
+  public List<FeatureInfo> getImplyingFeatures() {
+    return implyingFeatures;
   }
 
-  public List<FeatureInfo> getDependencies() {
-    return dependencies;
+  /**
+   * Returns the features this feature implies.
+   * If this feature is going to be executed, the returned features are also going to be executed,
+   * even if for example a post discovery filter would have filtered them out, like IDEs and build
+   * tools do if a specific test or a pattern of tests is executed.
+   *
+   * <p><b>NOTE:</b> This relationship does not imply any ordering constraint. According to configured
+   *                 run order and parallel execution settings the features can run in any order or even
+   *                 concurrently.
+   *
+   * @return the features this feature implies
+   */
+  @Beta
+  public List<FeatureInfo> getImpliedFeatures() {
+    return impliedFeatures;
   }
 
-  public void addDependency(FeatureInfo featureInfo) {
-    dependencies.add(featureInfo);
-    featureInfo.dependees.add(this);
+  /**
+   * Adds the given feature as implied by this features.
+   * If this feature is going to be executed, the given feature is also going to be executed,
+   * even if for example a post discovery filter would have filtered out the given feature,
+   * like IDEs and build tools do if a specific test or a pattern of tests is executed.
+   *
+   * <p><b>NOTE:</b> This relationship does not imply any ordering constraint. According to configured
+   *                 run order and parallel execution settings the features can run in any order or even
+   *                 concurrently.
+   *
+   * @param feature a feature that should be implied by this feature
+   */
+  @Beta
+  public void addImpliedFeature(FeatureInfo feature) {
+    impliedFeatures.add(feature);
+    feature.implyingFeatures.add(this);
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -125,7 +125,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
 
   /**
    * Returns the features that imply this feature.
-   * All features are within the same specification as this feature.
+   * All features are within the same specification hierarchy as this feature.
    * If one of the returned features is going to be executed, this feature is also going to be executed,
    * even if for example a post discovery filter would have filtered out this feature, like IDEs and build
    * tools do if a specific test or a pattern of tests is executed.
@@ -143,7 +143,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
 
   /**
    * Returns the features this feature implies.
-   * All features are within the same specification as this feature.
+   * All features are within the same specification hierarchy as this feature.
    * If this feature is going to be executed, the returned features are also going to be executed,
    * even if for example a post discovery filter would have filtered them out, like IDEs and build
    * tools do if a specific test or a pattern of tests is executed.
@@ -161,7 +161,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
 
   /**
    * Adds the given feature as implied by this feature.
-   * The given feature must be within the same specification as this feature.
+   * The given feature must be within the same specification hierarchy as this feature.
    * If this feature is going to be executed, the given feature is also going to be executed,
    * even if for example a post discovery filter would have filtered out the given feature,
    * like IDEs and build tools do if a specific test or a pattern of tests is executed.
@@ -178,8 +178,10 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
       throw new IllegalArgumentException("Features cannot imply themselves");
     }
 
-    if (!getParent().equals(feature.getParent())) {
-      throw new IllegalArgumentException("Features can only imply features within the same specification");
+    Class<?> otherClass = feature.getParent().getReflection();
+    Class<?> clazz = getParent().getReflection();
+    if (!otherClass.isAssignableFrom(clazz) && !clazz.isAssignableFrom(otherClass)) {
+      throw new IllegalArgumentException("Features can only imply features within the same specification hierarchy");
     }
 
     impliedFeatures.add(feature);

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -1,6 +1,5 @@
 package org.spockframework.runtime.model;
 
-import org.spockframework.runtime.FeatureNode;
 import org.spockframework.runtime.extension.IDataDriver;
 import org.spockframework.runtime.extension.IMethodInterceptor;
 import org.spockframework.runtime.model.parallel.*;
@@ -38,8 +37,6 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
   private final List<FeatureInfo> dependees = new ArrayList<>();
 
   private final List<FeatureInfo> dependencies = new ArrayList<>();
-
-  private FeatureNode node;
 
   private boolean reportIterations = true;
 
@@ -137,14 +134,6 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
   public void addDependency(FeatureInfo featureInfo) {
     dependencies.add(featureInfo);
     featureInfo.dependees.add(this);
-  }
-
-  public FeatureNode getNode() {
-    return node;
-  }
-
-  public void setNode(FeatureNode node) {
-    this.node = node;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -125,6 +125,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
 
   /**
    * Returns the features that imply this feature.
+   * All features are within the same specification as this feature.
    * If one of the returned features is going to be executed, this feature is also going to be executed,
    * even if for example a post discovery filter would have filtered out this feature, like IDEs and build
    * tools do if a specific test or a pattern of tests is executed.
@@ -142,6 +143,7 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
 
   /**
    * Returns the features this feature implies.
+   * All features are within the same specification as this feature.
    * If this feature is going to be executed, the returned features are also going to be executed,
    * even if for example a post discovery filter would have filtered them out, like IDEs and build
    * tools do if a specific test or a pattern of tests is executed.
@@ -158,7 +160,8 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
   }
 
   /**
-   * Adds the given feature as implied by this features.
+   * Adds the given feature as implied by this feature.
+   * The given feature must be within the same specification as this feature.
    * If this feature is going to be executed, the given feature is also going to be executed,
    * even if for example a post discovery filter would have filtered out the given feature,
    * like IDEs and build tools do if a specific test or a pattern of tests is executed.
@@ -171,6 +174,14 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
    */
   @Beta
   public void addImpliedFeature(FeatureInfo feature) {
+    if (equals(feature)) {
+      throw new IllegalArgumentException("Features cannot imply themselves");
+    }
+
+    if (!getParent().equals(feature.getParent())) {
+      throw new IllegalArgumentException("Features can only imply features within the same specification");
+    }
+
     impliedFeatures.add(feature);
     feature.implyingFeatures.add(this);
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/FeatureInfo.java
@@ -1,5 +1,6 @@
 package org.spockframework.runtime.model;
 
+import org.spockframework.runtime.FeatureNode;
 import org.spockframework.runtime.extension.IDataDriver;
 import org.spockframework.runtime.extension.IMethodInterceptor;
 import org.spockframework.runtime.model.parallel.*;
@@ -33,6 +34,12 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
   private IDataDriver dataDriver = IDataDriver.DEFAULT;
   private final List<DataProviderInfo> dataProviders = new ArrayList<>();
   private final IterationFilter iterationFilter = new IterationFilter();
+
+  private final List<FeatureInfo> dependees = new ArrayList<>();
+
+  private final List<FeatureInfo> dependencies = new ArrayList<>();
+
+  private FeatureNode node;
 
   private boolean reportIterations = true;
 
@@ -117,6 +124,27 @@ public class FeatureInfo extends SpecElementInfo<SpecInfo, AnnotatedElement> imp
 
   public void addDataProvider(DataProviderInfo dataProvider) {
     dataProviders.add(dataProvider);
+  }
+
+  public List<FeatureInfo> getDependees() {
+    return dependees;
+  }
+
+  public List<FeatureInfo> getDependencies() {
+    return dependencies;
+  }
+
+  public void addDependency(FeatureInfo featureInfo) {
+    dependencies.add(featureInfo);
+    featureInfo.dependees.add(this);
+  }
+
+  public FeatureNode getNode() {
+    return node;
+  }
+
+  public void setNode(FeatureNode node) {
+    this.node = node;
   }
 
   @Override

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ImpliedFeatureSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/ImpliedFeatureSpec.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.extension
+
+import org.junit.platform.engine.FilterResult
+import org.junit.platform.launcher.PostDiscoveryFilter
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.extension.ExtensionAnnotation
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
+import org.spockframework.runtime.model.FeatureInfo
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+
+import static org.junit.platform.testkit.engine.EventConditions.displayName
+
+class ImpliedFeatureSpec extends EmbeddedSpecification {
+  def setup() {
+    compiler.addClassImport(Implies)
+    compiler.addClassImport(ImpliedBy)
+  }
+
+  def "implying a feature in the same specification"() {
+    def clazz = compiler.compileSpecBody """
+def foo() { expect: true }
+@Implies('foo')
+def bar() { expect: true }
+def baz() { expect: true }
+"""
+
+    when:
+    def result = runner.runClass(clazz, {
+      FilterResult.includedIf(it.displayName == "bar")
+    } as PostDiscoveryFilter)
+
+    then:
+    result.testEvents().succeeded().assertEventsMatchExactly(
+      displayName("foo"),
+      displayName("bar")
+    )
+  }
+
+  def "implying a feature in a super specification"() {
+    def clazz = compiler.compileWithImports("""
+class Super extends Specification {
+  def foo() { expect: true }
+  def bam() { expect: true }
+}
+class Sub extends Super {
+  @Implies('foo')
+  def bar() { expect: true }
+  def baz() { expect: true }
+}
+""")[1]
+
+    when:
+    def result = runner.runClass(clazz, {
+      FilterResult.includedIf(it.displayName == "bar")
+    } as PostDiscoveryFilter)
+
+    then:
+    result.testEvents().succeeded().assertEventsMatchExactly(
+      displayName("foo"),
+      displayName("bar")
+    )
+  }
+
+  def "implying a feature in a sub specification"() {
+    def clazz = compiler.compileWithImports("""
+class Super extends Specification {
+  def foo() { expect: true }
+  def bam() { expect: true }
+}
+class Sub extends Super {
+  @ImpliedBy('foo')
+  def bar() { expect: true }
+  def baz() { expect: true }
+}
+""")[1]
+
+    when:
+    def result = runner.runClass(clazz, {
+      FilterResult.includedIf(it.displayName == "foo")
+    } as PostDiscoveryFilter)
+
+    then:
+    result.testEvents().succeeded().assertEventsMatchExactly(
+      displayName("foo"),
+      displayName("bar")
+    )
+  }
+
+  static class ImpliesExtension implements IAnnotationDrivenExtension<Implies> {
+    @Override
+    void visitFeatureAnnotation(Implies annotation, FeatureInfo feature) {
+      feature.addImpliedFeature(feature.getParent().allFeatures.find {
+        it.displayName == annotation.value()
+      })
+    }
+  }
+
+  static class ImpliedByExtension implements IAnnotationDrivenExtension<ImpliedBy> {
+    @Override
+    void visitFeatureAnnotation(ImpliedBy annotation, FeatureInfo feature) {
+      feature.getParent().allFeatures.find {
+        it.displayName == annotation.value()
+      }.addImpliedFeature(feature)
+    }
+  }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@ExtensionAnnotation(ImpliedFeatureSpec.ImpliesExtension)
+@interface Implies {
+  String value()
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@ExtensionAnnotation(ImpliedFeatureSpec.ImpliedByExtension)
+@interface ImpliedBy {
+  String value()
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/StepwiseSpecs.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/StepwiseSpecs.groovy
@@ -19,7 +19,8 @@ import org.junit.platform.engine.discovery.DiscoverySelectors
 import org.junit.platform.launcher.PostDiscoveryFilter
 import org.spockframework.EmbeddedSpecification
 import spock.lang.Issue
-import spock.lang.PendingFeature
+
+import static org.junit.platform.testkit.engine.EventConditions.displayName
 
 class StepwiseSpecs extends EmbeddedSpecification {
   def "basic usage"() {
@@ -57,19 +58,34 @@ class Foo extends Specification {
   def step1() { expect: true }
   def step2() { expect: true }
   def step3() { expect: true }
+  def step4() { expect: true }
 }
     """)[0]
 
     when:
-    def result = runner.runWithSelectors(DiscoverySelectors.selectMethod(clazz, "step3"))
+    def result = runner.runWithSelectors(DiscoverySelectors.selectMethod(clazz, step))
 
     then:
-    result.testsSucceededCount == 3
-    result.testsFailedCount == 0
-    result.testsSkippedCount == 0
+    verifyAll {
+      result.testsSucceededCount == succeeded
+      result.testsFailedCount == 0
+      result.testsSkippedCount == 0
+      result.testEvents().succeeded().assertEventsMatchExactly(
+        *([
+          displayName("step1"),
+          displayName("step2"),
+          displayName("step3")
+        ].subList(0, succeeded))
+      )
+    }
+
+    where:
+    step    | succeeded
+    'step1' | 1
+    'step2' | 2
+    'step3' | 3
   }
 
-  @PendingFeature
   @Issue("https://github.com/spockframework/spock/issues/1593")
   def "automatically runs excluded methods that lead up to an included method with post discovery filter"() {
     def clazz = compiler.compileWithImports("""
@@ -78,18 +94,34 @@ class Foo extends Specification {
   def step1() { expect: true }
   def step2() { expect: true }
   def step3() { expect: true }
+  def step4() { expect: true }
 }
     """)[0]
 
     when:
     def result = runner.runClass(clazz, {
-      FilterResult.includedIf(it.displayName == 'step3')
+      FilterResult.includedIf(it.displayName == step)
     } as PostDiscoveryFilter)
 
     then:
-    result.testsSucceededCount == 3
-    result.testsFailedCount == 0
-    result.testsSkippedCount == 0
+    verifyAll {
+      result.testsSucceededCount == succeeded
+      result.testsFailedCount == 0
+      result.testsSkippedCount == 0
+      result.testEvents().succeeded().assertEventsMatchExactly(
+        *([
+          displayName("step1"),
+          displayName("step2"),
+          displayName("step3")
+        ].subList(0, succeeded))
+      )
+    }
+
+    where:
+    step    | succeeded
+    'step1' | 1
+    'step2' | 2
+    'step3' | 3
   }
 
   def "honors method-level @Ignore"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/StepwiseSpecs.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/StepwiseSpecs.groovy
@@ -56,6 +56,7 @@ class Foo extends Specification {
 @Stepwise
 class Foo extends Specification {
   def step1() { expect: true }
+  @ResourceLock('a')
   def step2() { expect: true }
   def step3() { expect: true }
   def step4() { expect: true }
@@ -92,6 +93,7 @@ class Foo extends Specification {
 @Stepwise
 class Foo extends Specification {
   def step1() { expect: true }
+  @ResourceLock('a')
   def step2() { expect: true }
   def step3() { expect: true }
   def step4() { expect: true }


### PR DESCRIPTION
Fixes #1593

With these changes, the dependency features are executed
and any extension could also define such dependencies.

It works perfectly fine for Maven and IntelliJ.
For Gradle it also works, as far as running is concerned,
the dependency tests are just not reported if they were successful
and reported awkwardly when they have a failure like being part of
`UnknownClass`. But that is most probably more a Gradle problem.
