### PR TITLE
Add annotation extensions for parameters

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -768,6 +768,9 @@ or your annotations might be handled twice. Be aware that the repeatable annotat
 directly, inside the container annotation or even both if the user added the container annotation manually
 and also attached one annotation directly.
 
+Repeatable annotations are not supported for parameter annotations,
+as they are primarily intended to provide a value and only a singular value is allowed.
+
 `IAnnotationDrivenExtension` has the following nine methods, where in each you can prepare a specification with your
 extension magic, like attaching interceptors to various interception points as described in the chapter
 <<Interceptors>>:
@@ -807,6 +810,10 @@ extension magic, like attaching interceptors to various interception points as d
 `visitFeatureAnnotation(T annotation, FeatureInfo feature)`::
   This is used as singular delegate for `visitFeatureAnnotations` and is otherwise not called by Spock directly.
   The default implementation throws an exception.
+
+`visitParameterAnnotation(T annotation, ParameterInfo parameter)`::
+  This is called once for each parameter of a feature or fixture method where the annotation is applied to.
+  It gets the annotation instance as first parameter and the `ParameterInfo` object as second parameter.
 
 `visitSpec(SpecInfo spec)`::
   This is called once for each specification within which the annotation is applied to at least one of the supported
@@ -917,6 +924,31 @@ featureInfo.featureMethod.addInterceptor new I('feature method')
 ----
 
 ==== Injecting Method Parameters
+
+Starting with Spock 2.4, it is possible to create `IAnnotationDrivenExtension` that target method parameters directly.
+The extension annotation must use the `@Target({ElementType.PARAMETER})` and the extension must implement `IAnnotationDrivenExtension.visitParameterAnnotation(T annotation, ParameterInfo parameter)`.
+In the `visitParameterAnnotation` you can then register a custom interceptor, or use the convenience `ParameterResolver.Interceptor` to handle the parameter injection.
+Parameter injection is supported for fixture methods, such as `setup` and `cleanup`, as well as for feature methods.
+
+
+.Example `ParameterIndex` extension
+[source,groovy]
+----
+include::{sourcedir}/extension/ParameterInjectionSpec.groovy[tag=extension]
+----
+<1> Add the interceptor to the method, which is the `parent` of the `ParameterInfo`.
+<2> The built-in `ParameterResolver.Interceptor` will handle the boilerplate part of parameter injection.
+<3> Pass the `ParameterInfo` to the interceptor, so the interceptor knows which parameter it is handling.
+<4> This is a `Function<IMethodInvocation, Object>`, which is called by the `ParameterResolver.Interceptor` to resolve the parameter value. Here we just return the value of the `ParameterInfo`'s `index` property, but you could also do some more complex logic here.
+
+.Example usage of `ParameterIndex` extension
+[source,groovy]
+----
+include::{sourcedir}/extension/ParameterInjectionSpec.groovy[tag=example]
+----
+
+
+===== For Spock versions prior to 2.4 or for advanced use cases
 
 If your interceptor should support custom method parameters for wrapped methods, this can be done by modifying
 `invocation.arguments`. Two use cases for this would be a mocking framework that can inject method parameters that are

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IAnnotationDrivenExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IAnnotationDrivenExtension.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.spockframework.runtime.InvalidSpecException;
 import org.spockframework.runtime.model.*;
+import org.spockframework.util.Beta;
 
 /**
  * @author Peter Niederwieser
@@ -143,6 +144,20 @@ public interface IAnnotationDrivenExtension<T extends Annotation> {
    */
   default void visitFeatureAnnotation(T annotation, FeatureInfo feature) {
     throw new InvalidSpecException("@%s may not be applied to feature methods")
+      .withArgs(annotation.annotationType().getSimpleName());
+  }
+
+  /**
+   * Handles the annotation when applied to a feature/fixture method parameter of a specification.
+   * The default implementation of this method throws an {@link InvalidSpecException}.
+   *
+   * @param annotation the annotation found on the parameter
+   * @param parameter the annotated parameter
+   * @since 2.4
+   */
+  @Beta
+  default void visitParameterAnnotation(T annotation, ParameterInfo parameter) {
+    throw new InvalidSpecException("@%s may not be applied to parameters")
       .withArgs(annotation.annotationType().getSimpleName());
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IMethodInvocation.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IMethodInvocation.java
@@ -17,6 +17,7 @@
 package org.spockframework.runtime.extension;
 
 import org.spockframework.runtime.model.*;
+import org.spockframework.util.Beta;
 import org.spockframework.util.Nullable;
 
 /**
@@ -101,10 +102,22 @@ public interface IMethodInvocation {
   /**
    * Sets the arguments for this method invocation.
    *
-   * @deprecated set the fields in the return value of {@link #getArguments()} instead
+   * @deprecated set the fields in the return value of {@link #getArguments()} instead,
+   * or use {@link #resolveArgument(int, Object)}.
    */
   @Deprecated
   void setArguments(Object[] arguments);
+
+  /**
+   * Sets a missing argument value.
+   * <p>
+   * It will throw an exception if the argument is already set.
+   * @param index the index of the argument
+   * @param value the value of the argument
+   * @since 2.4
+   */
+  @Beta
+  void resolveArgument(int index, Object value);
 
   /**
    * Proceeds with the method call. Always call this method

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/MethodInvocation.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/MethodInvocation.java
@@ -17,8 +17,11 @@
 package org.spockframework.runtime.extension;
 
 import org.spockframework.runtime.model.*;
+import org.spockframework.util.Assert;
 
 import java.util.Iterator;
+
+import static org.spockframework.runtime.model.MethodInfo.MISSING_ARGUMENT;
 
 /**
  *
@@ -93,6 +96,12 @@ public class MethodInvocation implements IMethodInvocation {
         "length of arguments array must not change from " + this.arguments.length + " to " + arguments.length);
     }
     this.arguments = arguments;
+  }
+
+  @Override
+  public void resolveArgument(int index, Object value) {
+    Assert.that(arguments[index] == MISSING_ARGUMENT, () -> "Parameter " + method.getParameters().get(index).getName() + " is already set");
+    arguments[index] = value;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/ParameterResolver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/ParameterResolver.java
@@ -1,0 +1,40 @@
+package org.spockframework.runtime.extension;
+
+import org.spockframework.runtime.model.ParameterInfo;
+import org.spockframework.util.Assert;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.spockframework.runtime.model.MethodInfo.MISSING_ARGUMENT;
+
+/**
+ * Helper class for resolving parameters.
+ *
+ * @author Leonard Brünings
+ * @since 2.4
+ */
+public class ParameterResolver {
+  public static void resolveParameter(IMethodInvocation invocation, ParameterInfo parameterInfo, Supplier<?> valueSupplier) {
+    invocation.resolveArgument(parameterInfo.getIndex(), valueSupplier.get());
+  }
+
+  /**
+   * Convenience interceptor that resolves a parameter.
+   */
+  public static class Interceptor<T> implements IMethodInterceptor {
+    private final ParameterInfo parameterInfo;
+    private final Function<IMethodInvocation, T> valueSupplier;
+
+    public Interceptor(ParameterInfo parameterInfo, Function<IMethodInvocation, T> valueSupplier) {
+      this.parameterInfo = parameterInfo;
+      this.valueSupplier = valueSupplier;
+    }
+
+    @Override
+    public void intercept(IMethodInvocation invocation) throws Throwable {
+      resolveParameter(invocation, parameterInfo, () -> valueSupplier.apply(invocation));
+      invocation.proceed();
+    }
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/model/MethodInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/MethodInfo.java
@@ -41,7 +41,7 @@ public class MethodInfo extends NodeInfo<SpecInfo, Method> implements IExcludabl
   private IterationInfo iteration;
   private boolean excluded = false;
   private final List<IMethodInterceptor> interceptors = new ArrayList<>();
-  private Invoker invoker;
+  private final Invoker invoker;
   private List<ParameterInfo> parameters;
 
   public MethodInfo() {
@@ -65,6 +65,7 @@ public class MethodInfo extends NodeInfo<SpecInfo, Method> implements IExcludabl
     this.setMetadata(other.getMetadata());
     this.interceptors.addAll(other.interceptors);
     this.invoker = other.invoker;
+    this.parameters = other.parameters;
   }
 
   public MethodKind getKind() {
@@ -123,7 +124,7 @@ public class MethodInfo extends NodeInfo<SpecInfo, Method> implements IExcludabl
       Parameter[] params = getReflection().getParameters();
       List<ParameterInfo> result = new ArrayList<>(params.length);
       for (int i = 0; i < params.length; i++) {
-        result.add(new ParameterInfo(this, nameProvider.apply(i), params[i]));
+        result.add(new ParameterInfo(this, nameProvider.apply(i), params[i], i));
       }
       parameters = Collections.unmodifiableList(result);
     }

--- a/spock-core/src/main/java/org/spockframework/runtime/model/ParameterInfo.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/ParameterInfo.java
@@ -1,11 +1,46 @@
 package org.spockframework.runtime.model;
 
 import java.lang.reflect.Parameter;
+import java.util.Objects;
 
 public class ParameterInfo extends NodeInfo<MethodInfo, Parameter> {
-  public ParameterInfo(MethodInfo parent, String parameterName, Parameter parameter) {
+
+  private int index;
+
+  public ParameterInfo(MethodInfo parent, String parameterName, Parameter parameter, int index) {
     setParent(parent);
     setName(parameterName);
     setReflection(parameter);
+    this.index = index;
+  }
+
+  /**
+   * @since 2.4
+   */
+  public int getIndex() {
+    return index;
+  }
+
+  /**
+   * @since 2.4
+   */
+  public void setIndex(int index) {
+    this.index = index;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null || getClass() != obj.getClass()) return false;
+    ParameterInfo other = (ParameterInfo) obj;
+    return index == other.index
+      || Objects.equals(getName(), other.getName())
+      || Objects.equals(getReflection(), other.getReflection())
+      || Objects.equals(getParent().getReflection(), other.getParent().getReflection());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getReflection(), getParent().getReflection(), index);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/util/Assert.java
+++ b/spock-core/src/main/java/org/spockframework/util/Assert.java
@@ -18,6 +18,8 @@ package org.spockframework.util;
 
 import org.jetbrains.annotations.Contract;
 
+import java.util.function.Supplier;
+
 /**
  * Assertions for use within Spock code. Failures indicate internal errors.
  *
@@ -43,6 +45,10 @@ public abstract class Assert {
   @Contract("false, _, _ -> fail")
   public static void that(boolean condition, String msg, Object... values) {
     if (!condition) throw new InternalSpockError(String.format(msg, values));
+  }
+
+  public static void that(boolean condition, Supplier<String> msgSupplier) {
+    if (!condition) throw new InternalSpockError(msgSupplier.get());
   }
 
   @Contract("_, _ -> fail")

--- a/spock-specs/src/test/groovy/org/spockframework/docs/extension/ParameterInjectionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/extension/ParameterInjectionSpec.groovy
@@ -1,0 +1,64 @@
+package org.spockframework.docs.extension
+
+import org.spockframework.runtime.SpockExecutionException
+import org.spockframework.runtime.extension.ExtensionAnnotation
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
+import org.spockframework.runtime.extension.ParameterResolver
+import org.spockframework.runtime.model.ParameterInfo
+import spock.lang.Specification
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+class ParameterInjectionSpec extends Specification {
+
+  def setupSpec(@ParameterIndex int param1) {
+    assert param1 == 0
+  }
+
+  // tag::example[]
+  def setup(@ParameterIndex int param1) {
+    assert param1 == 0
+  }
+
+  def "test"(@ParameterIndex int param1, @ParameterIndex Integer param2, @ParameterIndex int param3) {
+    expect:
+    param1 == 0
+    param2 == 1
+    param3 == 2
+  }
+  // end::example[]
+
+  def cleanup(@ParameterIndex int param1) {
+    assert param1 == 0
+  }
+
+  def cleanupSpec(@ParameterIndex int param1) {
+    assert param1 == 0
+  }
+}
+
+
+// tag::extension[]
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@ExtensionAnnotation(ParameterIndexExtension)
+@interface ParameterIndex {}
+
+class ParameterIndexExtension implements IAnnotationDrivenExtension<ParameterIndex> {
+  @Override
+  void visitParameterAnnotation(ParameterIndex annotation, ParameterInfo parameter) {
+    Class<?> type = parameter.reflection.type
+    if (!(type in [int, Integer])) {
+      throw new SpockExecutionException("Parameter must be a int/Integer but was ${type}")
+    }
+    parameter.parent.addInterceptor(       // <1>
+      new ParameterResolver.Interceptor(   // <2>
+        parameter,                         // <3>
+        { parameter.index }                // <4>
+      ))
+  }
+}
+// end::extension[]


### PR DESCRIPTION
Extension authors can now create annotation driven extensions, that target method parameters.