### PR TITLE
Enable type-safe project accessors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -361,7 +361,7 @@ task groovydoc(type: Groovydoc) {
   destinationDir file("build/groovydoc/$variantLessVersion")
   source subprojects.groovydoc.source
   classpath = files(subprojects.groovydoc.classpath)
-  groovyClasspath = project(":spock-core").groovydoc.groovyClasspath
+  groovyClasspath = projects.spockCore.dependencyProject.groovydoc.groovyClasspath
 }
 
 configureGroovydoc(groovydoc)

--- a/settings.gradle
+++ b/settings.gradle
@@ -82,6 +82,8 @@ buildCache {
   }
 }
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 includeBuild "build-logic"
 include "spock-bom"
 include "spock-core"

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -26,7 +26,7 @@ dependencies {
   api libs.junitPlatform
   api libs.hamcrest
   if (variant == 2.5) {
-    api project(':spock-groovy2-compat')
+    api projects.spockGroovy2Compat
   }
 
   compileOnly libs.jetbrainsAnnotations

--- a/spock-guice/guice.gradle
+++ b/spock-guice/guice.gradle
@@ -5,7 +5,7 @@ ext.displayName = "Spock Framework - Guice Module"
 description = "Spock's Guice Module provides support for testing Guice 2/3 based applications."
 
 dependencies {
-  api project(":spock-core")
+  api projects.spockCore
   compileOnly "com.google.inject:guice:3.0"
   testImplementation "com.google.inject:guice:3.0"
 }

--- a/spock-junit4/junit4.gradle
+++ b/spock-junit4/junit4.gradle
@@ -9,7 +9,7 @@ Spock is inspired from JUnit, jMock, RSpec, Groovy, Scala, Vulcans, and other fa
 
 
 dependencies {
-  api project(":spock-core")
+  api projects.spockCore
   api libs.junit4
 
   testCompileOnly libs.jetbrainsAnnotations

--- a/spock-specs/mock-integration/mock-integration.gradle
+++ b/spock-specs/mock-integration/mock-integration.gradle
@@ -9,7 +9,7 @@ configurations {
 }
 
 dependencies {
-  testImplementation(project(":spock-core")) {
+  testImplementation(projects.spockCore) {
     exclude group: "cglib"
     exclude group: "net.bytebuddy"
     exclude group: "org.objenesis"

--- a/spock-specs/specs.gradle
+++ b/spock-specs/specs.gradle
@@ -16,7 +16,7 @@ dependencies {
   testCompileOnly libs.jetbrainsAnnotations
   testImplementation libs.junitPlatformTestkit
 
-  testImplementation project(":spock-core")
+  testImplementation projects.spockCore
   testImplementation libs.groovyNio  //for groovy methods on Path
   testImplementation libs.groovySql  //for groovy.sql.Sql
   testImplementation(libs.groovyTest) {  //for groovy.test.NotYetImplemented

--- a/spock-spring/boot2-test/boot2-test.gradle
+++ b/spock-spring/boot2-test/boot2-test.gradle
@@ -24,8 +24,8 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-web"
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
-  testImplementation project(":spock-core")
-  testImplementation project(":spock-spring")
+  testImplementation projects.spockCore
+  testImplementation projects.spockSpring
 
   if (javaVersion >= 9) {
     testImplementation libs.jaxb

--- a/spock-spring/boot3-test/boot3-test.gradle
+++ b/spock-spring/boot3-test/boot3-test.gradle
@@ -37,8 +37,8 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-data-jpa"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
-  testImplementation project(":spock-core")
-  testImplementation project(":spock-spring")
+  testImplementation projects.spockCore
+  testImplementation projects.spockSpring
 
   runtimeOnly "com.h2database:h2"
 }

--- a/spock-spring/spring.gradle
+++ b/spock-spring/spring.gradle
@@ -17,7 +17,7 @@ def testSpringVersions = [
 ].findAll { javaVersion in it.value }.keySet()
 
 dependencies {
-  api project(":spock-core")
+  api projects.spockCore
   compileOnly "org.springframework:spring-test:$springVersion"
   compileOnly "org.springframework:spring-beans:$springVersion"
   compileOnly "org.springframework:spring-context:$springVersion"

--- a/spock-spring/spring3-test/spring3-test.gradle
+++ b/spock-spring/spring3-test/spring3-test.gradle
@@ -3,11 +3,11 @@ def springVersion = "3.2.16.RELEASE"
 dependencies {
   implementation "org.springframework:spring-core"
 
-  testImplementation project(":spock-core")
+  testImplementation projects.spockCore
   testImplementation "org.springframework:spring-context"
   testImplementation ("org.springframework:spring-test")
 
-  testRuntimeOnly project(":spock-spring")
+  testRuntimeOnly projects.spockSpring
 }
 
 

--- a/spock-spring/spring5-test/spring5-test.gradle
+++ b/spock-spring/spring5-test/spring5-test.gradle
@@ -3,8 +3,8 @@ def springVersion = "5.0.2.RELEASE"
 dependencies {
   implementation "org.springframework:spring-core"
 
-  testImplementation project(":spock-core")
-  testImplementation project(":spock-spring")
+  testImplementation projects.spockCore
+  testImplementation projects.spockSpring
   testImplementation libs.junit4
   testImplementation "org.springframework:spring-context"
   testImplementation ("org.springframework:spring-test")

--- a/spock-spring/spring6-test/spring6-test.gradle
+++ b/spock-spring/spring6-test/spring6-test.gradle
@@ -16,8 +16,8 @@ tasks.withType(JavaCompile) {
 dependencies {
   implementation "org.springframework:spring-core"
 
-  testImplementation project(":spock-core")
-  testImplementation project(":spock-spring")
+  testImplementation projects.spockCore
+  testImplementation projects.spockSpring
   testImplementation libs.junit4
   testImplementation "org.springframework:spring-context"
   testImplementation("org.springframework:spring-test")

--- a/spock-tapestry/tapestry.gradle
+++ b/spock-tapestry/tapestry.gradle
@@ -11,7 +11,7 @@ def useTapestry54 = javaVersion >= 8
 def tapestryVersionTest = useTapestry54 ? tapestryVersion54 : "5.2.6"
 
 dependencies {
-  api project(":spock-core")
+  api projects.spockCore
   compileOnly "org.apache.tapestry:tapestry-ioc:$tapestryVersion54"
 
   testImplementation "javax.inject:javax.inject:1"

--- a/spock-testkit/testkit.gradle
+++ b/spock-testkit/testkit.gradle
@@ -9,7 +9,7 @@ ext.displayName = "Spock Framework - Temp Specs for Core Module"
 //}
 
 dependencies {
-  api project(":spock-core")
+  api projects.spockCore
 
   testRuntimeOnly libs.asm
   testRuntimeOnly libs.bytebuddy

--- a/spock-unitils/unitils.gradle
+++ b/spock-unitils/unitils.gradle
@@ -7,7 +7,7 @@ description = "Spock's Unitils Module makes it possible to use Unitils together 
 ext.unitilsVersion = "3.4.6"
 
 dependencies {
-  api project(":spock-core")
+  api projects.spockCore
   compileOnly "org.unitils:unitils-core:${unitilsVersion}"
 
   testImplementation "org.unitils:unitils-dbunit:${unitilsVersion}", {


### PR DESCRIPTION
https://docs.gradle.org/8.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors