### PR TITLE
Fix wrong interceptor/action order for `SimpleFeatureNode`

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/FeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/FeatureNode.java
@@ -1,9 +1,11 @@
 package org.spockframework.runtime;
 
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
 import org.spockframework.runtime.model.FeatureInfo;
 import spock.config.RunnerConfiguration;
-
-import org.junit.platform.engine.*;
 
 import java.util.List;
 import java.util.Objects;
@@ -41,10 +43,7 @@ public abstract class FeatureNode extends SpockNode<FeatureInfo> {
 
   @Override
   public void around(SpockExecutionContext context, Invocation<SpockExecutionContext> invocation) {
-    ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
-    final SpockExecutionContext innerContext = context.withErrorInfoCollector(errorInfoCollector);
-    context.getRunner().runFeature(innerContext, () -> sneakyInvoke(invocation, innerContext));
-    errorInfoCollector.assertEmpty();
+    context.runAndAssertWithNewErrorCollector(ctx -> context.getRunner().runFeature(ctx, () -> sneakyInvoke(invocation, ctx)));
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ParameterizedFeatureNode.java
@@ -1,13 +1,16 @@
 package org.spockframework.runtime;
 
+import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.engine.UniqueId;
+import org.opentest4j.MultipleFailuresError;
+import org.opentest4j.TestAbortedException;
 import org.spockframework.runtime.model.FeatureInfo;
 import spock.config.RunnerConfiguration;
 
-import java.util.*;
-
-import org.junit.platform.engine.TestExecutionResult.Status;
-import org.junit.platform.engine.UniqueId;
-import org.opentest4j.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.platform.engine.TestExecutionResult.Status.*;
@@ -34,11 +37,8 @@ public class ParameterizedFeatureNode extends FeatureNode {
   @Override
   public SpockExecutionContext execute(SpockExecutionContext context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
     verifyNotSkipped(getNodeInfo());
-    ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
-    context = context.withErrorInfoCollector(errorInfoCollector);
     ParameterizedFeatureChildExecutor childExecutor = new ParameterizedFeatureChildExecutor(this, dynamicTestExecutor, context.getEngineExecutionListener());
-    context.getRunner().runParameterizedFeature(context, childExecutor);
-    errorInfoCollector.assertEmpty();
+    context.runAndAssertWithNewErrorCollector(ctx -> ctx.getRunner().runParameterizedFeature(ctx, childExecutor));
     if (childExecutor.getExecutionCount() < 1) {
      throw new SpockExecutionException("Data provider has no data");
     }

--- a/spock-core/src/main/java/org/spockframework/runtime/SimpleFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SimpleFeatureNode.java
@@ -29,10 +29,7 @@ public class SimpleFeatureNode extends FeatureNode {
 
   @Override
   public SpockExecutionContext prepare(SpockExecutionContext context) throws Exception {
-    return delegate.prepare(
-      context.withCurrentFeature(getNodeInfo())
-      //.withParentId(getUniqueId())
-    );
+    return context.withCurrentFeature(getNodeInfo());
   }
 
   @Override
@@ -49,7 +46,10 @@ public class SimpleFeatureNode extends FeatureNode {
   @Override
   public void around(SpockExecutionContext context, Invocation<SpockExecutionContext> invocation) {
     // Wrap the Feature invocation around the invocation of the Iteration delegate
-    super.around(context, ctx -> delegate.around(ctx, invocation));
+    super.around(context, ctx -> {
+      ctx = delegate.prepare(ctx);
+      delegate.around(ctx, invocation);
+    });
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/SimpleFeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SimpleFeatureNode.java
@@ -1,9 +1,10 @@
 package org.spockframework.runtime;
 
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.UniqueId;
 import org.spockframework.runtime.model.FeatureInfo;
 import spock.config.RunnerConfiguration;
-
-import org.junit.platform.engine.*;
 
 /**
  * A non-parametric feature (test) that only has a single "iteration".
@@ -35,11 +36,7 @@ public class SimpleFeatureNode extends FeatureNode {
   @Override
   public SpockExecutionContext before(SpockExecutionContext context) throws Exception {
     context = super.before(context);
-    ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
-    context = context.withErrorInfoCollector(errorInfoCollector);
-    context.getRunner().runSetup(context);
-    errorInfoCollector.assertEmpty();
-
+    context.runAndAssertWithNewErrorCollector(context.getRunner()::runSetup);
     return context;
   }
 
@@ -61,11 +58,8 @@ public class SimpleFeatureNode extends FeatureNode {
 
   @Override
   public void after(SpockExecutionContext context) throws Exception {
-    ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
-    context = context.withErrorInfoCollector(errorInfoCollector);
-    delegate.after(context);
+    context.runAndAssertWithNewErrorCollector(delegate::after);
     // First the iteration node, then the Feature node
-    errorInfoCollector.assertEmpty();
     super.after(context);
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecNode.java
@@ -1,12 +1,11 @@
 package org.spockframework.runtime;
 
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.spockframework.runtime.model.SpecInfo;
 import spock.config.RunnerConfiguration;
 
 import java.util.Optional;
-
-import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.descriptor.ClassSource;
 
 public class SpecNode extends SpockNode<SpecInfo> {
 
@@ -41,27 +40,18 @@ public class SpecNode extends SpockNode<SpecInfo> {
 
   @Override
   public SpockExecutionContext before(SpockExecutionContext context) throws Exception {
-    ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
-    context = context.withErrorInfoCollector(errorInfoCollector);
-    context.getRunner().runSetupSpec(context);
-    errorInfoCollector.assertEmpty();
+    context.runAndAssertWithNewErrorCollector(context.getRunner()::runSetupSpec);
     return context;
   }
 
   @Override
   public void after(SpockExecutionContext context) throws Exception {
-    ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
-    context = context.withErrorInfoCollector(errorInfoCollector);
-    context.getRunner().runCleanupSpec(context);
-    errorInfoCollector.assertEmpty();
+    context.runAndAssertWithNewErrorCollector(context.getRunner()::runCleanupSpec);
   }
 
   @Override
   public void around(SpockExecutionContext context, Invocation<SpockExecutionContext> invocation) throws Exception {
-    ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
-    SpockExecutionContext ctx = context.withErrorInfoCollector(errorInfoCollector);
-    ctx.getRunner().runSpec(ctx, () -> sneakyInvoke(invocation, ctx));
-    errorInfoCollector.assertEmpty();
+    context.runAndAssertWithNewErrorCollector(ctx -> ctx.getRunner().runSpec(ctx, () -> sneakyInvoke(invocation, ctx)));
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionContext.java
@@ -1,11 +1,14 @@
 package org.spockframework.runtime;
 
-import org.spockframework.runtime.model.*;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
+import org.spockframework.runtime.model.FeatureInfo;
+import org.spockframework.runtime.model.IterationInfo;
+import org.spockframework.runtime.model.SpecInfo;
+import org.spockframework.util.IThrowableConsumer;
 import org.spockframework.util.InternalSpockError;
 import spock.lang.Specification;
-
-import org.junit.platform.engine.*;
-import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 
 public class SpockExecutionContext implements EngineExecutionContext, Cloneable {
   private EngineExecutionListener engineExecutionListener;
@@ -124,6 +127,12 @@ public class SpockExecutionContext implements EngineExecutionContext, Cloneable 
 
   public SpockExecutionContext withErrorInfoCollector(ErrorInfoCollector errorInfoCollector) {
     return clone().setErrorInfoCollector(errorInfoCollector);
+  }
+
+  public <E extends Throwable> void runAndAssertWithNewErrorCollector(IThrowableConsumer<SpockExecutionContext, E> consumer) throws E {
+    ErrorInfoCollector errorInfoCollector = new ErrorInfoCollector();
+    consumer.accept(withErrorInfoCollector(errorInfoCollector));
+    errorInfoCollector.assertEmpty();
   }
 
   public SpockExecutionContext withParentId(UniqueId uniqueId) {

--- a/spock-core/src/main/java/org/spockframework/util/IThrowableConsumer.java
+++ b/spock-core/src/main/java/org/spockframework/util/IThrowableConsumer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.util;
+
+/**
+ * A consumer from for value V that may throw a checked exception.
+ *
+ * @author Leonard Brünings
+ * @since 2.4
+ */
+@FunctionalInterface
+public interface IThrowableConsumer<V, T extends Throwable> {
+  void accept(V value) throws T;
+}

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitFixtureMethods.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitFixtureMethods.groovy
@@ -14,10 +14,12 @@
 
 package org.spockframework.junit4.junit
 
+import org.intellij.lang.annotations.Language
+import org.spockframework.runtime.model.parallel.ExecutionMode
+import spock.lang.Execution
 import spock.lang.Unroll
 
-import org.intellij.lang.annotations.Language
-
+@Execution(value = ExecutionMode.SAME_THREAD, reason = 'Uses static state to communicate with embedded specifications')
 class JUnitFixtureMethods extends JUnitBaseSpec {
   static invocations = []
   static RECORD_INVOCATION_METHOD = "static record(methodName) { JUnitFixtureMethods.invocations << methodName }"

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/StackTraceFiltering.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/StackTraceFiltering.groovy
@@ -23,7 +23,6 @@ import org.spockframework.runtime.StackTraceFilter
 import org.spockframework.runtime.WrongExceptionThrownError
 import org.spockframework.runtime.model.ExpressionInfo
 import org.spockframework.util.Identifiers
-
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -161,7 +160,6 @@ def foo() { expect: true }
     ConditionNotSatisfiedError e = thrown()
     stackTraceLooksLike e, """
 apackage.ASpec|\$spock_initializeFields_closure1|1
-apackage.ASpec|\$spock_initializeFields_closure1|-
 apackage.ASpec|\$spock_initializeFields|1
     """
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/InterceptorOrder.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/InterceptorOrder.groovy
@@ -1,0 +1,170 @@
+package org.spockframework.smoke.extension
+
+import org.spockframework.EmbeddedSpecification
+
+class InterceptorOrder extends EmbeddedSpecification {
+  static List<String> events
+
+  def setup() {
+    events = []
+  }
+
+  def cleanupSpec() {
+    events = null
+  }
+
+  def "interceptors are called in the right order"() {
+    given:
+
+    when:
+    runner.runWithImports '''
+import org.spockframework.runtime.extension.*
+import org.spockframework.runtime.model.SpecInfo
+
+import java.lang.annotation.*
+
+import static org.spockframework.smoke.extension.InterceptorOrder.events
+
+    @InterceptEverything
+    class ExampleSpec extends Specification {
+      def setup() { events << "setup" }
+      def cleanup() { events << "cleanup" }
+      def setupSpec() { events << "setupSpec" }
+      def cleanupSpec() { events << "cleanupSpec" }
+
+      def "simple feature"() {
+        expect:
+        events << "simpleFeature"
+       }
+
+      def "parameterized feature"(int i) {
+      expect:
+      events << "parameterizedFeature"
+
+      where:
+      i << [1, 2]
+      }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @ExtensionAnnotation(InterceptEverythingExtension)
+    @interface InterceptEverything {}
+
+    class InterceptEverythingExtension implements IAnnotationDrivenExtension<InterceptEverything> {
+      @Override
+      void visitSpecAnnotation(InterceptEverything annotation ,SpecInfo spec) {
+        spec.addSharedInitializerInterceptor (interceptor('sharedInitializerInterceptor'))
+        spec.sharedInitializerMethod?.addInterceptor (interceptor('sharedInitializerMethodInterceptor'))
+        spec.addInterceptor (interceptor('specInterceptor'))
+        spec.addSetupSpecInterceptor (interceptor('setupSpecInterceptor'))
+        spec.setupSpecMethods*.addInterceptor (interceptor('setupSpecMethodInterceptor'))
+        spec.addInitializerInterceptor (interceptor('initializerInterceptor'))
+        spec.initializerMethod?.addInterceptor (interceptor('initializerMethodInterceptor'))
+        spec.addSetupInterceptor (interceptor('setupInterceptor'))
+        spec.setupMethods*.addInterceptor (interceptor('setupMethodInterceptor'))
+        spec.addCleanupInterceptor (interceptor('cleanupInterceptor'))
+        spec.cleanupMethods*.addInterceptor (interceptor('cleanupMethodInterceptor'))
+        spec.addCleanupSpecInterceptor (interceptor('cleanupSpecInterceptor'))
+        spec.cleanupSpecMethods*.addInterceptor (interceptor('cleanupSpecMethodInterceptor'))
+        spec.features.each {
+          it.addInterceptor(interceptor('featureInterceptor'))
+          it.addIterationInterceptor(interceptor('iterationInterceptor'))
+          it.featureMethod.addInterceptor(interceptor('featureMethodInterceptor'))
+        }
+      }
+
+      IMethodInterceptor interceptor(String tag) { new InterceptEverythingInterceptor(tag) }
+    }
+
+    class InterceptEverythingInterceptor implements IMethodInterceptor {
+      static indent = 0
+      String tag
+
+      InterceptEverythingInterceptor(String tag) {
+        this.tag = tag
+      }
+
+      @Override
+      void intercept(IMethodInvocation invocation) throws Throwable {
+        events << "${' ' * indent++}> ${invocation.method.kind} $tag ${invocation.feature?.name}"
+        invocation.proceed()
+        events << "${' ' * --indent}< ${invocation.method.kind} $tag ${invocation.feature?.name}"
+      }
+    }
+'''
+
+    then:
+    events == [
+      '> SHARED_INITIALIZER sharedInitializerInterceptor null',
+      '< SHARED_INITIALIZER sharedInitializerInterceptor null',
+      '> SPEC_EXECUTION specInterceptor null',
+      ' > SETUP_SPEC setupSpecInterceptor null',
+      '  > SETUP_SPEC setupSpecMethodInterceptor null',
+      'setupSpec',
+      '  < SETUP_SPEC setupSpecMethodInterceptor null',
+      ' < SETUP_SPEC setupSpecInterceptor null',
+      ' > FEATURE_EXECUTION featureInterceptor simple feature',
+      '  > INITIALIZER initializerInterceptor simple feature',
+      '  < INITIALIZER initializerInterceptor simple feature',
+      '  > ITERATION_EXECUTION iterationInterceptor simple feature',
+      '   > SETUP setupInterceptor simple feature',
+      '    > SETUP setupMethodInterceptor simple feature',
+      'setup',
+      '    < SETUP setupMethodInterceptor simple feature',
+      '   < SETUP setupInterceptor simple feature',
+      '   > FEATURE featureMethodInterceptor simple feature',
+      'simpleFeature',
+      '   < FEATURE featureMethodInterceptor simple feature',
+      '   > CLEANUP cleanupInterceptor simple feature',
+      '    > CLEANUP cleanupMethodInterceptor simple feature',
+      'cleanup',
+      '    < CLEANUP cleanupMethodInterceptor simple feature',
+      '   < CLEANUP cleanupInterceptor simple feature',
+      '  < ITERATION_EXECUTION iterationInterceptor simple feature',
+      ' < FEATURE_EXECUTION featureInterceptor simple feature',
+      ' > FEATURE_EXECUTION featureInterceptor parameterized feature',
+      '  > INITIALIZER initializerInterceptor parameterized feature',
+      '  < INITIALIZER initializerInterceptor parameterized feature',
+      '  > ITERATION_EXECUTION iterationInterceptor parameterized feature',
+      '   > SETUP setupInterceptor parameterized feature',
+      '    > SETUP setupMethodInterceptor parameterized feature',
+      'setup',
+      '    < SETUP setupMethodInterceptor parameterized feature',
+      '   < SETUP setupInterceptor parameterized feature',
+      '   > FEATURE featureMethodInterceptor parameterized feature',
+      'parameterizedFeature',
+      '   < FEATURE featureMethodInterceptor parameterized feature',
+      '   > CLEANUP cleanupInterceptor parameterized feature',
+      '    > CLEANUP cleanupMethodInterceptor parameterized feature',
+      'cleanup',
+      '    < CLEANUP cleanupMethodInterceptor parameterized feature',
+      '   < CLEANUP cleanupInterceptor parameterized feature',
+      '  < ITERATION_EXECUTION iterationInterceptor parameterized feature',
+      '  > INITIALIZER initializerInterceptor parameterized feature',
+      '  < INITIALIZER initializerInterceptor parameterized feature',
+      '  > ITERATION_EXECUTION iterationInterceptor parameterized feature',
+      '   > SETUP setupInterceptor parameterized feature',
+      '    > SETUP setupMethodInterceptor parameterized feature',
+      'setup',
+      '    < SETUP setupMethodInterceptor parameterized feature',
+      '   < SETUP setupInterceptor parameterized feature',
+      '   > FEATURE featureMethodInterceptor parameterized feature',
+      'parameterizedFeature',
+      '   < FEATURE featureMethodInterceptor parameterized feature',
+      '   > CLEANUP cleanupInterceptor parameterized feature',
+      '    > CLEANUP cleanupMethodInterceptor parameterized feature',
+      'cleanup',
+      '    < CLEANUP cleanupMethodInterceptor parameterized feature',
+      '   < CLEANUP cleanupInterceptor parameterized feature',
+      '  < ITERATION_EXECUTION iterationInterceptor parameterized feature',
+      ' < FEATURE_EXECUTION featureInterceptor parameterized feature',
+      ' > CLEANUP_SPEC cleanupSpecInterceptor null',
+      '  > CLEANUP_SPEC cleanupSpecMethodInterceptor null',
+      'cleanupSpec',
+      '  < CLEANUP_SPEC cleanupSpecMethodInterceptor null',
+      ' < CLEANUP_SPEC cleanupSpecInterceptor null',
+      '< SPEC_EXECUTION specInterceptor null',
+    ]
+  }
+}


### PR DESCRIPTION
Prior to this commit, the `SimpleFeatureNode` would run the `initializers` before the `feature` execution started which goes against the documented behavior. The problem doesn't exist for `ParameterizedFeatureNode`.