### PR TITLE
Call IRunListener.*Skipped for skipped specs/features

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/FeatureNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/FeatureNode.java
@@ -48,6 +48,12 @@ public abstract class FeatureNode extends SpockNode<FeatureInfo> {
   }
 
   @Override
+  public void nodeSkipped(SpockExecutionContext context, TestDescriptor testDescriptor, SkipResult result) {
+    FeatureInfo featureInfo = getNodeInfo();
+    featureInfo.getSpec().getListeners().forEach(iRunListener -> iRunListener.featureSkipped(featureInfo));
+  }
+
+  @Override
   public boolean mayRegisterTests() {
     return getNodeInfo().isParameterized();
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
@@ -51,6 +51,8 @@ public class PlatformSpecRunner {
     if (context.getErrorInfoCollector().hasErrors()) return;
 
     SpecInfo spec = context.getSpec();
+    if (spec.isExcluded()) return;
+
     supervisor.beforeSpec(spec);
     invoke(context, this, createMethodInfoForDoRunSpec(context, specRunner));
     supervisor.afterSpec(spec);
@@ -182,11 +184,6 @@ public class PlatformSpecRunner {
 
     FeatureInfo currentFeature = context.getCurrentFeature();
     if (currentFeature.isExcluded()) return;
-
-    if (currentFeature.isSkipped()) {
-      supervisor.featureSkipped(currentFeature); // todo notify in node isSkipped
-      return;
-    }
 
     supervisor.beforeFeature(currentFeature);
     invoke(context, this, createMethodInfoForDoRunFeature(context, feature));

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecNode.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecNode.java
@@ -1,5 +1,6 @@
 package org.spockframework.runtime;
 
+import org.junit.platform.engine.TestDescriptor;
 import org.spockframework.runtime.model.SpecInfo;
 import spock.config.RunnerConfiguration;
 
@@ -62,6 +63,12 @@ public class SpecNode extends SpockNode<SpecInfo> {
     SpockExecutionContext ctx = context.withErrorInfoCollector(errorInfoCollector);
     ctx.getRunner().runSpec(ctx, () -> sneakyInvoke(invocation, ctx));
     errorInfoCollector.assertEmpty();
+  }
+
+  @Override
+  public void nodeSkipped(SpockExecutionContext context, TestDescriptor testDescriptor, SkipResult result) {
+    SpecInfo specInfo = getNodeInfo();
+    specInfo.getListeners().forEach(iRunListener -> iRunListener.specSkipped(specInfo));
   }
 
   @Override

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/IgnoreExtension.groovy
@@ -17,7 +17,11 @@
 package org.spockframework.smoke.extension
 
 import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.AbstractRunListener
 import org.spockframework.runtime.InvalidSpecException
+import org.spockframework.runtime.extension.IGlobalExtension
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.SpecInfo
 import spock.lang.Issue
 
 /**
@@ -188,4 +192,66 @@ class Test extends Bar {
     false     | 1 + 0 + 3 + 4              | 1
     true      | 1                          | 3
   }
+
+  static ThreadLocal<SkipListener> injectedSkipListener = ThreadLocal.withInitial { new SkipListener() }
+
+  static class SkipReporterExtension implements IGlobalExtension {
+    @Override
+    void visitSpec(SpecInfo spec) {
+      spec.addListener(injectedSkipListener.get())
+    }
+  }
+
+  static class SkipListener extends AbstractRunListener {
+    List<String> skipMessages = []
+
+    @Override
+    void specSkipped(SpecInfo spec) {
+      skipMessages << spec.displayName
+    }
+
+    @Override
+    void featureSkipped(FeatureInfo feature) {
+      skipMessages << feature.displayName
+    }
+
+    void clearSkipMessages() {
+      skipMessages.clear()
+    }
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/1662")
+  def "ignored spec triggers run listener"() {
+    when:
+    injectedSkipListener.get().clearSkipMessages()
+    runner.extensionClasses = [SkipReporterExtension]
+    runner.runWithImports("""
+@Ignore
+class Foo extends Specification {
+  def foo() { expect: false }
+  def bar() { expect: false }
+}
+    """)
+
+    then:
+    injectedSkipListener.get().skipMessages == ['Foo']
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/1662")
+  def "ignored feature triggers run listener"() {
+    when:
+    injectedSkipListener.get().clearSkipMessages()
+    runner.extensionClasses = [SkipReporterExtension]
+    runner.runWithImports("""
+class Foo extends Specification {
+  @Ignore def foo() { expect: false }
+  def bar() { expect: true }
+  @Ignore def zot() { expect: false }
+}
+    """)
+
+    then:
+    injectedSkipListener.get().skipMessages == ['foo', 'zot']
+  }
+
 }


### PR DESCRIPTION
SpecNode.nodeSkipped overrides JUnit 5 platform's Node.nodeSkipped. It fetches the spec info and then calls IRunListener.specSkipped for all run listeners registered on the spec.

Note: We cannot use context.getRunner() here like in SpecNode.around, because the runner is null when the JUnit platform calls nodeSkipped.

Fixes #1662.

To do:
  - [x] Add automated test.
  - [x] A similar issue exists for ignored features, i.e. `IRunListener.featureSkipped` is not called when a feature is skipped.