### PR TITLE
Fix broken test

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/MethodParameters.groovy
@@ -263,6 +263,7 @@ def foo() {
         assert it.arguments.size() == 1
         assert it.arguments.first() == MISSING_ARGUMENT
         it.arguments[0] = 'foo'
+        it.proceed()
       }
     }
   }


### PR DESCRIPTION
The interceptor used in the test did not call proceed().
Due to that there was never any failure even if the test
condition should not hold.