### PR TITLE
Fix too many arguments being set as data values in iteration info

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformParameterizedSpecRunner.java
@@ -44,7 +44,7 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
     try (IDataIterator dataIterator = new DataIteratorFactory(supervisor).createFeatureDataIterator(context)) {
       IIterationRunner iterationRunner = createIterationRunner(context, childExecutor);
       IDataDriver dataDriver = feature.getDataDriver();
-      dataDriver.runIterations(dataIterator, iterationRunner, feature.getFeatureMethod().getParameters());
+      dataDriver.runIterations(dataIterator, iterationRunner, feature.getFeatureMethod().getParameters().subList(0, feature.getDataVariables().size()));
       childExecutor.awaitFinished();
     } catch (InterruptedException ie) {
       throw ie;
@@ -58,9 +58,9 @@ public class PlatformParameterizedSpecRunner extends PlatformSpecRunner {
       private final AtomicInteger iterationIndex = new AtomicInteger(0);
 
       @Override
-      public CompletableFuture<ExecutionResult> runIteration(Object[] args, int estimatedNumIterations) {
+      public CompletableFuture<ExecutionResult> runIteration(Object[] dataValues, int estimatedNumIterations) {
         int currIterationIndex = iterationIndex.getAndIncrement();
-        IterationInfo iterationInfo = createIterationInfo(context, currIterationIndex, args, estimatedNumIterations);
+        IterationInfo iterationInfo = createIterationInfo(context, currIterationIndex, dataValues, estimatedNumIterations);
         IterationNode iterationNode = new IterationNode(
           context.getParentId().append("iteration", String.valueOf(currIterationIndex)),
           context.getRunContext().getConfiguration(RunnerConfiguration.class), iterationInfo);

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IDataDriver.java
@@ -50,14 +50,14 @@ public interface IDataDriver {
    *
    * @param dataIterator the data iterator giving access to the data from the data providers. The data iterator is not to be closed by this method.
    * @param iterationRunner the iteration runner that will be used to run the test method for each iteration.
-   * @param parameters the parameters of the test method
+   * @param parameters the parameters of the test method representing data variables
    */
   void runIterations(IDataIterator dataIterator, IIterationRunner iterationRunner, List<ParameterInfo> parameters);
 
   /**
-   * Prepares the arguments for invocation of the test method.
+   * Prepares the arguments for the data variables for invocation of the test method.
    * <p>
-   * It is possible to have fewer arguments produced by the data driver than the number of parameters.
+   * It is possible to have fewer arguments produced by the data driver than the number of data variables.
    * In this case, the missing arguments are filled with {@link MethodInfo#MISSING_ARGUMENT}.
    * <p>
    * Custom implementations of IDataDriver should use this method to prepare the argument array.

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RepeatUntilFailureExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RepeatUntilFailureExtension.java
@@ -36,9 +36,9 @@ public class RepeatUntilFailureExtension implements IAnnotationDrivenExtension<R
       List<Object[]> data = new ArrayList<>(estimatedNumIterations);
       dataIterator.forEachRemaining(data::add);
       for (int attempt = 0; attempt < maxAttempts; attempt++) {
-        for (Object[] args : data) {
+        for (Object[] dataValues : data) {
           try {
-            ExecutionResult executionResult = iterationRunner.runIteration(args, maxIterations).get();
+            ExecutionResult executionResult = iterationRunner.runIteration(dataValues, maxIterations).get();
             if (executionResult == ExecutionResult.FAILED) {
               return;
             }


### PR DESCRIPTION
The iteration info holds a list of the data values for the current iteration.
The data driver logic had an error where it gave all parameter infos
to the data driver instead of only the ones representing data variables.
Data drivers only deal with data variables, not with additional arguments that
are supplied by extensions. Due to that the data values in the iteration info
had additional MISSING_ARGUMENT entries for the additional arguments which
then also broke things like unroll patterns, conditional annotations accessing data
values and so on