### PR TITLE
Make `@Use` on feature and fixture method parallel

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UseExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UseExtension.java
@@ -41,7 +41,6 @@ public class UseExtension implements IAnnotationDrivenExtension<Use> {
   @Override
   public void visitFeatureAnnotations(List<Use> annotations, FeatureInfo feature) {
     addInterceptor(annotations, feature.getFeatureMethod());
-    feature.setExecutionMode(ExecutionMode.SAME_THREAD);
   }
 
   @Override

--- a/spock-specs/src/test/groovy/spock/util/mop/UseSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/mop/UseSpec.groovy
@@ -16,8 +16,13 @@
 
 package spock.util.mop
 
+import org.spockframework.EmbeddedSpecification
 import org.spockframework.runtime.model.parallel.ExecutionMode
+import spock.lang.Isolated
+import spock.lang.Requires
 import spock.lang.Specification
+
+import java.util.concurrent.CountDownLatch
 
 class UseOnMethods extends Specification {
   // can be applied to a fixture method
@@ -30,12 +35,6 @@ class UseOnMethods extends Specification {
   def "can be applied to a feature method"() {
     expect:
     "foo".duplicate() == "foofoo"
-  }
-
-  @Use(StringExtensions)
-  def "sets feature execution mode to SAME_THREAD"() {
-    expect:
-    specificationContext.currentFeature.executionMode.get() == ExecutionMode.SAME_THREAD
   }
 
   @Use([StringExtensions, IntegerExtensions])
@@ -80,6 +79,78 @@ class UseOnMethods extends Specification {
       "foo".duplicate()
       assert false
     } catch (MissingMethodException expected) {}
+  }
+}
+
+@Isolated("Isolate from other tests to have full access to cores for the embedded tests.")
+@Requires({ Runtime.runtime.availableProcessors() >= 2 })
+class IsolatedUseSpec extends EmbeddedSpecification {
+  def setup() {
+    runner.addClassImport(Use)
+    runner.addClassImport(CountDownLatch)
+    runner.addClassImport(StringExtensions)
+    runner.addClassImport(ExecutionMode)
+    runner.configurationScript {
+      runner {
+        parallel {
+          enabled true
+          fixed(4)
+        }
+      }
+    }
+  }
+
+  def "executing iterations in parallel works with annotated specification if enabled"() {
+    when:
+    getSpecificationContext()
+    def result = runner.runWithImports '''
+      @Use(StringExtensions)
+      class ASpec extends Specification {
+        @Shared
+        CountDownLatch latch = new CountDownLatch(2)
+
+        @IgnoreIf({ instance.specificationContext.currentSpec.childExecutionMode.orElse(null) == ExecutionMode.SAME_THREAD })
+        def feature() {
+          given:
+          latch.countDown()
+          latch.await()
+
+          expect:
+          "foo".duplicate() == "foofoo"
+
+          where:
+          i << (1..2)
+        }
+      }
+    '''
+
+    then:
+    result.testsSucceededCount + result.testsAbortedCount == 3
+  }
+
+  def "executing iterations in parallel works with annotated feature"() {
+    when:
+    getSpecificationContext()
+    def result = runner.runSpecBody '''
+      @Shared
+      CountDownLatch latch = new CountDownLatch(2)
+
+      @Use(StringExtensions)
+      def feature() {
+        given:
+        latch.countDown()
+        latch.await()
+
+        expect:
+        "foo".duplicate() == "foofoo"
+
+        where:
+        i << (1..2)
+      }
+    '''
+
+    then:
+    result.testsSucceededCount + result.testsAbortedCount == 3
   }
 }
 

--- a/spock-specs/src/test/groovy/spock/util/mop/UseSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/mop/UseSpec.groovy
@@ -110,28 +110,15 @@ class IsolatedUseSpec extends EmbeddedSpecification {
     def result = runner.runWithImports '''
       @Use(StringExtensions)
       class ASpec extends Specification {
-        @Shared
-        CountDownLatch latch = new CountDownLatch(2)
-
-        @IgnoreIf({ instance.specificationContext.currentSpec.childExecutionMode.orElse(null) == ExecutionMode.SAME_THREAD })
         def feature() {
-          given:
-          latch.countDown()
-
           expect:
-          !latch.await(10, TimeUnit.SECONDS)
-
-          where:
-          i << (1..2)
+          specificationContext.currentSpec.childExecutionMode.orElse(null) == ExecutionMode.SAME_THREAD
         }
       }
     '''
 
     then:
-    verifyAll {
-      result.testsSucceededCount == 1
-      result.testsAbortedCount == 2
-    }
+    result.testsSucceededCount == 1
   }
 
   def "executing iterations in parallel works with annotated feature"() {


### PR DESCRIPTION
For `@Use` on a specification same-thread policy is necessary as the whole
spec execution is wrapped in a use-closure, so that also helper methods
can use the category methods.

For `@Use` on features or fixture method this is not necessary, as just the method invocation
is wrapped in the use-closure and this is then always run within one thread.
