### PR TITLE
Enable parameter injection for @TempDir and run as initialization interceptor for fields

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -533,7 +533,11 @@ def ignoreMyExceptions
 In order to generate a temporary directory for test and delete it after test, annotate a member field of type
 `java.io.File`, `java.nio.file.Path` or untyped using `def` in a spec class (`def` will inject a `Path`).
 Alternatively, you can annotate a field with a custom type that has a public constructor accepting either `java.io.File` or `java.nio.file.Path` as its single parameter (see <<utilities.adoc#file-stystem-fixture, FileSystemFixture>> for an example).
-If the annotated field is `@Shared`, the temporary directory will be shared in the corresponding specification, otherwise every feature method and every iteration per parametrized feature method will have their own temporary directories:
+If the annotated field is `@Shared`, the temporary directory will be shared in the corresponding specification, otherwise every feature method and every iteration per parametrized feature method will have their own temporary directories.
+
+Since Spock 2.4, you can also use parameter injection with `@TempDir`.
+The types follow the same rules as for field injection.
+Valid methods are `setup()`, `setupSpec()`, or any feature methods.
 
 [source,groovy,indent=0]
 ----

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -11,6 +11,9 @@ include::include.adoc[]
 
 === Misc
 * Add support for <<extensions.adoc#extension-store,keeping state in extensions>>
+* Add support for parameter injection of `@TempDir`
+* Improve `@TempDir` field injection, now it happens before field initialization, so it can be used by other field initializers.
+* Fix exception when configured `baseDir` was not existing, now `@TempDir` will create the baseDir directory if it is missing.
 
 == 2.4-M1 (2022-11-30)
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TempDirExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TempDirExtension.java
@@ -32,11 +32,9 @@ public class TempDirExtension implements IAnnotationDrivenExtension<TempDir> {
     // attach interceptor
     SpecInfo specInfo = field.getParent();
     if (field.isShared()) {
-      specInfo.getBottomSpec().addInterceptor(interceptor);
+      specInfo.getBottomSpec().addSharedInitializerInterceptor(interceptor);
     } else {
-      for (FeatureInfo featureInfo : specInfo.getBottomSpec().getAllFeatures()) {
-        featureInfo.addIterationInterceptor(interceptor);
-      }
+      specInfo.addInitializerInterceptor(interceptor);
     }
   }
 

--- a/spock-core/src/main/java/org/spockframework/util/IThrowableBiConsumer.java
+++ b/spock-core/src/main/java/org/spockframework/util/IThrowableBiConsumer.java
@@ -17,11 +17,11 @@
 package org.spockframework.util;
 
 /**
- * A function from domain D to co-domain C that may throw a checked exception.
+ * A BiConsumer that may throw a checked exception.
  *
  * @author Peter Niederwieser
  */
 @FunctionalInterface
-public interface IThrowableFunction<D, C, T extends Throwable> {
-  C apply(D value) throws T;
+public interface IThrowableBiConsumer<A, B, T extends Throwable> {
+  void accept(A a, B b) throws T;
 }

--- a/spock-core/src/main/java/org/spockframework/util/IThrowableBiConsumer.java
+++ b/spock-core/src/main/java/org/spockframework/util/IThrowableBiConsumer.java
@@ -1,17 +1,16 @@
 /*
- * Copyright 2009 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
 package org.spockframework.util;
@@ -19,7 +18,8 @@ package org.spockframework.util;
 /**
  * A BiConsumer that may throw a checked exception.
  *
- * @author Peter Niederwieser
+ * @author Leonard Brünings
+ * @since 2.4
  */
 @FunctionalInterface
 public interface IThrowableBiConsumer<A, B, T extends Throwable> {

--- a/spock-core/src/main/java/spock/lang/TempDir.java
+++ b/spock-core/src/main/java/spock/lang/TempDir.java
@@ -36,13 +36,17 @@ import java.nio.file.Path;
  * &#64;TempDir
  * FileSystemFixture fsFixture // will inject an instance of FileSystemFixture with the temp path injected via constructor
  * </code></pre>
+ * <p>
+ * Since Spock 2.4, {@code @TempDir} can be used to annotate a method parameter, with the same behavior as the field types.
+ * Use this if you want to use a temp directory in a single method only.
+ * Valid methods are {@code setup()}, {@code setupSpec()}, or any feature methods.
  *
  * @author dqyuan
  * @since 2.0
  */
 @Beta
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 @ExtensionAnnotation(TempDirExtension.class)
 public @interface TempDir {
 }

--- a/spock-specs/src/test/groovy/org/spockframework/docs/extension/TempDirDocSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/extension/TempDirDocSpec.groovy
@@ -29,12 +29,24 @@ class TempDirDocSpec extends Specification {
   @TempDir
   FileSystemFixture path4
 
-  def demo() {
+  // Use for parameter injection of a setupSpec method
+  def setupSpec(@TempDir Path sharedPath) {
+    assert sharedPath instanceof Path
+  }
+
+  // Use for parameter injection of a setup method
+  def setup(@TempDir Path setupPath) {
+    assert setupPath instanceof Path
+  }
+
+  // Use for parameter injection of a feature
+  def demo(@TempDir Path path5) {
     expect:
     path1 instanceof Path
     path2 instanceof File
     path3 instanceof Path
     path4 instanceof FileSystemFixture
+    path5 instanceof Path
   }
 
 // end::example[]

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/TempDirExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/TempDirExtensionSpec.groovy
@@ -86,7 +86,7 @@ class TempDirExtensionSpec extends EmbeddedSpecification {
 
   def "define temp directory location and keep temp directory using configuration script"() {
     given:
-    def userDefinedBase = Paths.get("build")
+    def userDefinedBase = untypedPath.resolve("build")
     runner.configurationScript {
       tempdir {
         baseDir userDefinedBase

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/TempDirExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/TempDirExtensionSpec.groovy
@@ -271,6 +271,38 @@ class CustomTempDirSpec extends Specification {
   }
 }
 
+class TempDirParameterSpec extends Specification {
+  @Shared
+  Path setupSpecParameter
+  @Shared
+  Path setupParameter
+  @Shared
+  def featureParameter
+
+  def setupSpec(@TempDir Path tempDir) {
+    setupSpecParameter = tempDir
+  }
+
+  def setup(@TempDir Path tempDir) {
+    setupParameter = tempDir
+  }
+
+  def "test"(@TempDir tempDir) {
+    given:
+    featureParameter = tempDir
+    expect:
+    tempDir instanceof Path
+    Files.isDirectory(setupSpecParameter)
+    Files.isDirectory(setupParameter)
+    Files.isDirectory(tempDir as Path)
+  }
+
+  def cleanupSpec() {
+    assert !Files.exists(setupParameter)
+    assert !Files.exists(featureParameter as Path)
+  }
+}
+
 class MyFile {
   File root
 


### PR DESCRIPTION
* Enable parameter injection for @TempDir.
* Prior to this commit @TempDir values where not available to other field initializers,
now they can be used to initialize other fields.
* Fixed exception when configured baseDir was not existing,
now @TempDir will create the baseDir directory if it is missing.
