### PR TITLE
Fix a typo in JavaDoc

### DIFF
--- a/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
+++ b/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
@@ -41,7 +41,7 @@ import org.spockframework.util.Beta;
  * }
  * </pre>
  *
- * Warning! Avoiding assert keyword in the clojure is only possible if the conditions object type is known
+ * Warning! Avoiding assert keyword in the closure is only possible if the conditions object type is known
  * during compilation (no "def" on the left side):
  * <pre>
  *   PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)


### PR DESCRIPTION
`(assert)` works just fine in Clojure, no reason to avoid it. :wink: