### PR TITLE
Limit data value name length in unrolled test

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/DataVariablesIterationNameProvider.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataVariablesIterationNameProvider.java
@@ -14,12 +14,12 @@
 
 package org.spockframework.runtime;
 
-import static java.lang.String.format;
-import static org.spockframework.util.RenderUtil.toStringOrDump;
-
 import org.spockframework.runtime.model.*;
+import org.spockframework.util.RenderUtil;
 
 import java.util.*;
+
+import static java.lang.String.format;
 
 public class DataVariablesIterationNameProvider implements NameProvider<IterationInfo> {
   private final boolean includeFeatureNameForIterations;
@@ -51,7 +51,11 @@ public class DataVariablesIterationNameProvider implements NameProvider<Iteratio
       dataVariables.forEach((name, value) -> {
         String valueString;
         try {
-          valueString = toStringOrDump(value);
+          valueString = RenderUtil.toStringOrDump(value);
+          int maxDataValueStringLength = 1024;
+          if (valueString.length() > maxDataValueStringLength) {
+            valueString = valueString.substring(0, maxDataValueStringLength) + "…";
+          }
         } catch (Exception e) {
           valueString = format("#Error:%s during rendering", e.getClass().getSimpleName());
         }

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/DataVariablesIterationNameProviderSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/DataVariablesIterationNameProviderSpec.groovy
@@ -23,10 +23,7 @@ class DataVariablesIterationNameProviderSpec extends Specification {
   @Subject
   DataVariablesIterationNameProvider testee = new DataVariablesIterationNameProvider()
 
-  def feature = new FeatureInfo().tap {
-    name = 'the feature'
-    reportIterations = true
-  }
+  def feature = new FeatureInfo(name: 'the feature', reportIterations: true)
 
   IterationInfo iteration = Stub {
     getFeature() >> feature
@@ -104,6 +101,16 @@ class DataVariablesIterationNameProviderSpec extends Specification {
 
     expect:
     testee.getName(iteration) == "x: [1], y: [a:2], z: [3], #$iteration.iterationIndex"
+  }
+
+  def 'renders data variables with limited length'() {
+    given:
+    testee = new DataVariablesIterationNameProvider(false)
+    def tooLongArray = (1..10_000_000).toArray() as int[]
+    iteration.getDataVariables() >> [x: tooLongArray]
+
+    expect:
+    testee.getName(iteration) == "x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 2…, #$iteration.iterationIndex"
   }
 
   def 'returns iteration index when reporting iterations but data variables are null and includeFeatureNameForIterations=false'() {

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/DataVariablesIterationNameProviderSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/DataVariablesIterationNameProviderSpec.groovy
@@ -106,7 +106,7 @@ class DataVariablesIterationNameProviderSpec extends Specification {
   def 'renders data variables with limited length'() {
     given:
     testee = new DataVariablesIterationNameProvider(false)
-    def tooLongArray = (1..10_000_000).toArray() as int[]
+    def tooLongArray = (1..1_000_000).toArray() as int[]
     iteration.getDataVariables() >> [x: tooLongArray]
 
     expect:


### PR DESCRIPTION
# Background

We're using Spock for testing of our product.
The other day, we found some tests using large size images in `where` clause were stacked and didn't finish at all.
I investigated the root cause, and it was the following reason.

1. Spock shows data name and value in test case name when we use `where` clause.
2. Even if we use objects which are represented by too long string in `where` clause, Spock tries to render the name.
3. Then, stacking will occur because showing too long string takes much time.

# Proposal
Limiting data value name length to avoid unintentional stacking.

# Sample project
I prepared https://github.com/T45K/spock-stack-sample 
You can reproduce my result by cloning it and importing into IDE (I'm using IntelliJ IDEA).

On [master](https://github.com/T45K/spock-stack-sample) branch, original Spock is used, and you will find `AppTest.stack because test target will be shown in test name` will take much time.

On [solution](https://github.com/T45K/spock-stack-sample/tree/solution) branch, I set Spock built in this PR. You will find the test is much faster.

# Others
I used 1024 as max length. This is just my preference (it is easy to understand because 2 ^ 10). If you have any recommendation, I'll follow.

Thank you.