### PR TITLE
Document @ConditionBlock Annotation in the Guide

### DIFF
--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -321,6 +321,28 @@ By using `notThrown()`, we make it clear that in particular a `NullPointerExcept
 contract of `Map.put()`, this would be the right thing to do for a map that doesn't support `null` keys.) However,
 the method will also fail if any other exception is thrown.
 
+===== Methods Accepting Implicit Conditions as Code Blocks
+
+Methods annotated with `@ConditionBlock` will treat `Closure` arguments as code blocks containing
+conditions allowing to leave off the `assert` keyword. As in `expect`-blocks and `then`-blocks, variable declarations
+and void method invocations will not be considered conditions.
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/utilities/ConditionBlockSpec.groovy[tag=ConditionBlock-usage]
+----
+
+NOTE: The `@ConditionBlock` only works, if the types involved are known at compile time (no `def` keyword). See below for more details.
+
+The `@ConditionBlock` annotation only takes effect if:
+
+* the `Closures` are passed as literals,
+and the Groovy compiler can (at compilation time) determine the target type of the method invocation
+referencing the annotated method,
+* the annotated method is called on object of type known at compilation time (no `def`).
+
+If the annotated method is overloaded, the closure arguments of all overloads are considered code blocks.
+
 ===== Interactions
 
 Whereas conditions describe an object's state, interactions describe how objects communicate with each other.

--- a/spock-specs/src/test/groovy/org/spockframework/docs/utilities/ConditionBlockSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/utilities/ConditionBlockSpec.groovy
@@ -1,0 +1,28 @@
+package org.spockframework.docs.utilities
+
+import org.spockframework.runtime.SpockAssertionError
+import spock.lang.FailsWith
+import spock.lang.Specification
+import spock.util.concurrent.AsyncConditions
+
+class ConditionBlockSpec extends Specification {
+
+  @FailsWith(SpockAssertionError)
+  def "evaluate fails with implicit condition using @ConditionBlock semantics"() {
+    // tag::ConditionBlock-usage[]
+    AsyncConditions conds = new AsyncConditions()
+
+    when:
+    Thread.start {
+      //The method AsyncConditions.evaluate() is annotated with @ConditionBlock
+      conds.evaluate {
+        //There is an implicit assert here
+        false
+      }
+    }
+
+    then:
+    conds.await()
+    // end::ConditionBlock-usage[]
+  }
+}


### PR DESCRIPTION
This adds a new section about @ConditionBlock usage into the Conditions. The ConditionBlockSpec is used as a code sample.

This fixes #1242