### PR TITLE
GenericTypeReflectorUtil.getReturnType() now resolves type variables

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/mock/Issue520Repository.java
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/Issue520Repository.java
@@ -1,0 +1,9 @@
+package org.spockframework.mock;
+
+import java.io.Serializable;
+
+public interface Issue520Repository {
+  //Note: we need to compile this with Java, because Groovy 2.5 can't compile this:
+  //unexpected token: <E extends Object, ID extends Serializable> ID persist(E e);
+  <E extends Object, ID extends Serializable> ID persist(E e);
+}

--- a/spock-specs/src/test/groovy/org/spockframework/mock/MockSpecInfoAnnotationSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/MockSpecInfoAnnotationSpec.groovy
@@ -1,0 +1,34 @@
+package org.spockframework.mock
+
+import org.spockframework.runtime.model.SpecInfo
+import org.spockframework.util.Nullable
+import spock.lang.Specification
+
+import java.lang.annotation.Annotation
+
+class MockSpecInfoAnnotationSpec extends Specification {
+
+  def "NodeInfo.getAnnotation() shall return valid Stub for Stub Issue #1163"() {
+    given:
+    def mockUtil = new MockUtil()
+    def spec = Stub(SpecInfo)
+
+    when:
+    def t = spec.getAnnotation(Nullable)
+
+    then:
+    t instanceof Annotation
+    mockUtil.isMock(t)
+  }
+
+  def "NodeInfo.getAnnotation() shall return null for Mock Issue #1163"() {
+    given:
+    def spec = Mock(SpecInfo)
+
+    when:
+    def t = spec.getAnnotation(Nullable)
+
+    then:
+    t == null
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/mock/MockSpecInfoAnnotationSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/MockSpecInfoAnnotationSpec.groovy
@@ -2,12 +2,14 @@ package org.spockframework.mock
 
 import org.spockframework.runtime.model.SpecInfo
 import org.spockframework.util.Nullable
+import spock.lang.Issue
 import spock.lang.Specification
 
 import java.lang.annotation.Annotation
 
 class MockSpecInfoAnnotationSpec extends Specification {
 
+  @Issue("https://github.com/spockframework/spock/issues/1163")
   def "NodeInfo.getAnnotation() shall return valid Stub for Stub Issue #1163"() {
     given:
     def mockUtil = new MockUtil()
@@ -21,6 +23,7 @@ class MockSpecInfoAnnotationSpec extends Specification {
     mockUtil.isMock(t)
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/1163")
   def "NodeInfo.getAnnotation() shall return null for Mock Issue #1163"() {
     given:
     def spec = Mock(SpecInfo)
@@ -30,5 +33,13 @@ class MockSpecInfoAnnotationSpec extends Specification {
 
     then:
     t == null
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/520")
+  def "Better support for generic return types with Stub() Issue #520"() {
+    when:
+    def stub = Stub(Issue520Repository)
+    then:
+    stub.persist(null) instanceof Serializable
   }
 }

--- a/spock-specs/src/test/groovy/spock/util/concurrent/BlockingVariablesSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/util/concurrent/BlockingVariablesSpec.groovy
@@ -20,6 +20,8 @@ import org.spockframework.runtime.SpockTimeoutError
 import spock.lang.*
 
 class BlockingVariablesSpec extends Specification {
+  @Retry
+  //Flaky execution on build-and-verify (windows-latest) machine
   def "passing example 1 - variable is read after it is written"() {
     def vars = new BlockingVariables()
 
@@ -33,6 +35,8 @@ class BlockingVariablesSpec extends Specification {
     vars.foo == 42
   }
 
+  @Retry
+  //Flaky execution on build-and-verify (windows-latest) machine
   def "passing example 2 - variable is read before it is written"() {
     def vars = new BlockingVariables()
 


### PR DESCRIPTION
The method `GenericTypeReflectorUtil.getReturnType()` now also tries to resolve TypeVariable, if these have bounds like the method:

`<T extends Annotation> T getAnnotation()`

Which now returns `Annotation` as return type instead of `Object`.

This was actually implemented with:
Replace gentyref code with geantyref library #1743.

This fixes #1163 "NodeInfo#getAnnotation returns instance of Cglib-generated that does not actually implement Annotation".
It also fixes #520 "Better support for generic return types with Stub()".