### PR TITLE
Open java.base/java.lang for ALL-UNNAMED for cglib users

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 groovy2 = '2.5.19'
-groovy3 = '3.0.13'
+groovy3 = '3.0.17'
 groovy4 = '4.0.6'
 jacoco = '0.8.10'
 

--- a/spock-guice/guice.gradle
+++ b/spock-guice/guice.gradle
@@ -24,3 +24,12 @@ tasks.named("jar", Jar) {
     )
   }
 }
+
+tasks.named("test", Test).configure {
+  if (rootProject.ext.javaVersion >= 17) {
+    jvmArgs(
+      //Guice Framework requires access to java.lang.ClassLoader.defineClass() from com.google.inject.internal.cglib.core.$ReflectUtils
+      "--add-opens=java.base/java.lang=ALL-UNNAMED"
+    )
+  }
+}

--- a/spock-specs/mock-integration/mock-integration.gradle
+++ b/spock-specs/mock-integration/mock-integration.gradle
@@ -28,11 +28,29 @@ codeGenerationLibraries.each { key, config ->
   tasks.register("test${key.capitalize()}WithoutObjenesis", Test) {
     systemProperty("org.spockframework.mock.testType", "${key.toLowerCase()} - objenesis")
     classpath += config
+
+    if (key == "cglib") {
+      if (rootProject.ext.javaVersion >= 17) {
+        jvmArgs(
+          //cglib requires access to java.lang.ClassLoader.defineClass() from net.sf.cglib.core.ReflectUtils
+          "--add-opens=java.base/java.lang=ALL-UNNAMED"
+        )
+      }
+    }
   }
   tasks.register("test${key.capitalize()}WithObjenesis", Test) {
     systemProperty("org.spockframework.mock.testType", "${key.toLowerCase()} + objenesis")
     classpath += config
     classpath += configurations.objenesis
+
+    if (key == "cglib") {
+      if (rootProject.ext.javaVersion >= 17) {
+        jvmArgs(
+          //cglib requires access to java.lang.ClassLoader.defineClass() from net.sf.cglib.core.ReflectUtils
+          "--add-opens=java.base/java.lang=ALL-UNNAMED"
+        )
+      }
+    }
   }
 }
 

--- a/spock-spring/spring3-test/spring3-test.gradle
+++ b/spock-spring/spring3-test/spring3-test.gradle
@@ -18,3 +18,13 @@ configurations.all {
     }
   }
 }
+
+
+tasks.named("test", Test).configure {
+  if (rootProject.ext.javaVersion >= 17) {
+    jvmArgs(
+      //Spring Framework requires access to java.lang.ClassLoader.defineClass() from org.springframework.cglib.core.ReflectUtils
+      "--add-opens=java.base/java.lang=ALL-UNNAMED"
+    )
+  }
+}

--- a/spock-spring/spring5-test/spring5-test.gradle
+++ b/spock-spring/spring5-test/spring5-test.gradle
@@ -19,3 +19,12 @@ configurations.all {
     }
   }
 }
+
+tasks.named("test", Test).configure {
+  if (rootProject.ext.javaVersion >= 17) {
+    jvmArgs(
+      //Spring Framework requires access to java.lang.ClassLoader.defineClass() from org.springframework.cglib.core.ReflectUtils
+      "--add-opens=java.base/java.lang=ALL-UNNAMED"
+    )
+  }
+}


### PR DESCRIPTION
Since jacoco 0.8.9 it does not open the java.lang package anymore, so we need to do that on our own.

See "Agent should not open java.lang package to unnamed module of the application class loader"

https://github.com/jacoco/jacoco/pull/1334