### PR TITLE
Added Groovy 4.0.7 test case for getProperty call

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-groovy2 = '2.5.19'
-groovy3 = '3.0.13'
-groovy4 = '4.0.6'
+groovy2 = '2.5.22'
+groovy3 = '3.0.18'
+groovy4 = '4.0.13'
 jacoco = '0.8.8'
 
 [libraries]

--- a/spock-core/src/main/java/org/spockframework/runtime/GroovyRuntimeUtil.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/GroovyRuntimeUtil.java
@@ -311,4 +311,15 @@ public abstract class GroovyRuntimeUtil {
     //Having isGroovy3() with just "startsWith("3.") there could be (in the future) no tests executed at all for Groovy 4
     return !isGroovy2();
   }
+
+  @Internal
+  public static boolean isGroovy3orOlder() {
+    return isGroovy2() || GroovySystem.getVersion().startsWith("3.");
+  }
+
+  @Internal
+  public static boolean isGroovy4orNewer() {
+    //Having isGroovy4() with just "startsWith("4.") there could be (in the future) no tests executed at all for Groovy 5
+    return !isGroovy3orOlder();
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaMocksForGroovyClasses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaMocksForGroovyClasses.groovy
@@ -72,13 +72,13 @@ class JavaMocksForGroovyClasses extends Specification {
     1 * mockMe.setBar("value")
   }
 
-  def "mock call to GroovyObject.getProperty"() {
+  @Requires({ GroovyRuntimeUtil.isGroovy3orOlder() })
+  def "mock call to GroovyObject.getProperty Groovy 2&3"() {
     when:
     def value = mockMe.getProperty("bar")
 
     then:
     1 * mockMe.getProperty("bar") >> "value"
-    0 * mockMe._
     value == "value"
 
     when:
@@ -86,7 +86,33 @@ class JavaMocksForGroovyClasses extends Specification {
 
     then:
     1 * mockMe.getProperty("bar") >> "value2"
-    0 * mockMe._
+    value2 == "value2"
+  }
+
+  /**
+   This is not really the correct test, but it is related to:
+   Better way to distinguish go.x and go.getProperty("x") in JavaMockInterceptor
+   https://github.com/spockframework/spock/issues/1076
+   and
+   https://github.com/spockframework/spock/pull/1717
+   where Groovy 4.0.7 changed the compilation to indy, which makes the mockMe.getProperty("bar") call not distinguishable from mockMe.bar
+   */
+  @Requires({ GroovyRuntimeUtil.isGroovy4orNewer() })
+  def "mock call to GroovyObject.getProperty Groovy >=4.0.7"() {
+    when:
+    def value = mockMe.getProperty("bar")
+
+    then:
+    //FIXME: this should be  1 * mockMe.getProperty("bar") >> "value" but does not work in Groovy >=4.0.7
+    1 * mockMe.getBar() >> "value"
+    value == "value"
+
+    when:
+    def value2 = mockMe.getProperty("bar")
+
+    then:
+    //FIXME: this should be  1 * mockMe.getProperty("bar") >> "value" but does not work in Groovy >=4.0.7
+    1 * mockMe.getBar() >> "value2"
     value2 == "value2"
   }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaMocksForGroovyClasses.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaMocksForGroovyClasses.groovy
@@ -78,6 +78,7 @@ class JavaMocksForGroovyClasses extends Specification {
 
     then:
     1 * mockMe.getProperty("bar") >> "value"
+    0 * mockMe._
     value == "value"
 
     when:
@@ -85,6 +86,7 @@ class JavaMocksForGroovyClasses extends Specification {
 
     then:
     1 * mockMe.getProperty("bar") >> "value2"
+    0 * mockMe._
     value2 == "value2"
   }
 


### PR DESCRIPTION
This adds a test case to reproduce the "false" behavior of 
mockMe.getProperty("bar") in Groovy 4.0.7 and onwards.