### PR TITLE
Support creation of global mocks for abstract classes

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -38,6 +38,7 @@ include::include.adoc[]
 * Spock-Compiler does not use wrapper types anymore spockPull:1765[]
 * Reduce lock contention of the `byte-buddy` mock maker, when multiple mocks are created concurrently spockPull:1778[]
 * Documentation for DetachedMockFactory spockPull:1728[]
+* Support creation of global Groovy mocks for abstract classes spockPull:1754[]
 
 == 2.4-M1 (2022-11-30)
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMockAbstractGlobalClass.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMockAbstractGlobalClass.groovy
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.mock
+
+import org.spockframework.mock.TooFewInvocationsError
+import org.spockframework.runtime.model.parallel.Resources
+import spock.lang.FailsWith
+import spock.lang.Issue
+import spock.lang.ResourceLock
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+//We need to execute it sequentially, because we change global metaClass state
+@Stepwise
+@ResourceLock(Resources.META_CLASS_REGISTRY)
+@SuppressWarnings('GroovyAssignabilityCheck')
+class GroovyMockAbstractGlobalClass extends Specification {
+  private static final String NAME = "Name"
+  private static final String MOCKED_NAME = "MockedName"
+
+  @Issue('https://github.com/spockframework/spock/issues/464')
+  def "Creating a Global GroovyMock from abstract class shall not fail"() {
+    given:
+    def m = GroovyMock(AbstractClassA, global: true)
+
+    when:
+    def result = AbstractClassA.getStaticName()
+
+    then:
+    1 * AbstractClassA.getStaticName() >> MOCKED_NAME
+    result == MOCKED_NAME
+    m instanceof AbstractClassA
+
+    expect:
+    AbstractClassA.staticName == null
+  }
+
+  @Issue('https://github.com/spockframework/spock/issues/464')
+  def "Creating a Global GroovySpy from abstract class shall not fail"() {
+    given:
+    def m = GroovySpy(AbstractClassA, global: true)
+
+    when:
+    def result = AbstractClassA.getStaticName()
+
+    then:
+    1 * AbstractClassA.getStaticName() >> MOCKED_NAME
+    result == MOCKED_NAME
+    m instanceof AbstractClassA
+
+    expect:
+    AbstractClassA.staticName == NAME
+  }
+
+  @Issue('https://github.com/spockframework/spock/issues/464')
+  @FailsWith(TooFewInvocationsError)
+  def "Asserting on a Global GroovySpy Class for call made on instance shall fail"() {
+    given:
+    AbstractClassA m = GroovySpy(global: true)
+
+    when:
+    m.getName()
+
+    then:
+    1 * AbstractClassA.getName() >> MOCKED_NAME
+  }
+
+  @Issue('https://github.com/spockframework/spock/issues/464')
+  def "Asserting on a Global GroovySpy object for call made on instance"() {
+    given:
+    AbstractClassA m = GroovySpy(global: true)
+
+    when:
+    def result = m.getName()
+
+    then:
+    1 * m.getName() >> MOCKED_NAME
+    result == MOCKED_NAME
+  }
+
+  @Issue('https://github.com/spockframework/spock/issues/464')
+  @FailsWith(TooFewInvocationsError)
+  def "Asserting on a Global GroovySpy object for static calls shall fail"() {
+    given:
+    AbstractClassA m = GroovySpy(global: true)
+
+    when:
+    AbstractClassA.staticName
+
+    then: "We are asserting on the instance not the Class, this shall fail"
+    1 * m.getStaticName() >> MOCKED_NAME
+  }
+
+  @Issue('https://github.com/spockframework/spock/issues/464')
+  @FailsWith(TooFewInvocationsError)
+  def "Asserting on a Global GroovySpy object for subclass instance call shall fail"() {
+    given:
+    AbstractClassA m = GroovySpy(global: true)
+
+    when:
+    def subObj = new SubClassA()
+    subObj.getName()
+
+    then: "Calls from subclasses are not tracked, so it shall fail"
+    1 * m.getName() >> MOCKED_NAME
+  }
+
+  def "Two global mocks"() {
+    given:
+    GroovySpy(AbstractClassA, global: true)
+    GroovySpy(ClassB, global: true)
+
+    when:
+    def result1 = AbstractClassA.getStaticName()
+    def result2 = ClassB.getStaticName()
+
+    then:
+    1 * AbstractClassA.getStaticName() >> MOCKED_NAME
+    1 * ClassB.getStaticName() >> "MockedName2"
+    result1 == MOCKED_NAME
+    result2 == "MockedName2"
+
+    expect:
+    AbstractClassA.staticName == NAME
+    ClassB.staticName == NAME
+  }
+
+  static abstract class AbstractClassA {
+    static String getStaticName() { NAME }
+
+    @SuppressWarnings('GrMethodMayBeStatic')
+    String getName() { NAME }
+  }
+
+  static class SubClassA extends AbstractClassA {}
+
+  static abstract class ClassB {
+    static String getStaticName() { NAME }
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMockFinalClass.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMockFinalClass.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.mock
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.mock.runtime.GroovyMockMetaClass
+import org.spockframework.runtime.GroovyRuntimeUtil
+
+class GroovyMockFinalClass extends EmbeddedSpecification {
+
+  def "Mock for final class shall only change meta class of instance"() {
+    given:
+    def originalMetaClass = GroovyRuntimeUtil.getMetaClass(FinalClass)
+    FinalClass mock = GroovyMock()
+    def afterMetaClass = GroovyRuntimeUtil.getMetaClass(FinalClass)
+
+    expect:
+    !(originalMetaClass instanceof GroovyMockMetaClass)
+
+    when:
+    def result = mock.method()
+
+    then:
+    1 * mock.method() >> "MockedName"
+    result == "MockedName"
+    
+    expect:
+    mock.getMetaClass() instanceof GroovyMockMetaClass
+    mock.getMetaClass() == afterMetaClass
+    afterMetaClass == originalMetaClass
+  }
+
+  static final class FinalClass {
+    String method() { return "Name" }
+  }
+}
+

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocksForInterfaces.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocksForInterfaces.groovy
@@ -14,6 +14,9 @@
 
 package org.spockframework.smoke.mock
 
+import org.spockframework.mock.CannotCreateMockException
+import org.spockframework.runtime.model.parallel.Resources
+import spock.lang.ResourceLock
 import spock.lang.Specification
 
 class GroovyMocksForInterfaces extends Specification {
@@ -109,9 +112,21 @@ class GroovyMocksForInterfaces extends Specification {
     1 * person.setMetaClass(null)
   }
 
+  @ResourceLock(Resources.META_CLASS_REGISTRY)
+  def "Mock global interface is not supported"() {
+    when:
+    GroovyMock(Runnable, global: true)
+
+    then:
+    CannotCreateMockException ex = thrown()
+    ex.message == "Cannot create mock for interface java.lang.Runnable. Global mocking is only possible for classes, but not for interfaces."
+  }
+
   interface Person {
     String getName()
+
     void setName(String name)
+
     void sing(String song)
   }
 }


### PR DESCRIPTION
This allows the GroovyMockFactory to spin a new subclass, if the global mock is an abstract class.

This fixes #464