### PR TITLE
Fix flaky Spring tests due to schema resolution

### DIFF
--- a/config/nohttp/allowlist.lines
+++ b/config/nohttp/allowlist.lines
@@ -9,4 +9,5 @@
 ^http://www.spockframework.org/spring$
 
 // Spring schemas from the Spring library classpath
+^http://www.springframework.org/schema/beans/spring-beans.xsd$
 ^http://www.springframework.org/schema/beans/spring-beans-2.5.xsd$

--- a/spock-spring/src/test/resources/org/spockframework/spring/docs/MockDocu-context.xml
+++ b/spock-spring/src/test/resources/org/spockframework/spring/docs/MockDocu-context.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:spock="http://www.spockframework.org/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           https://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.springframework.org/schema/beans/spring-beans.xsd
            http://www.spockframework.org/spring https://www.spockframework.org/spring/spock.xsd">
 
   <spock:mock id="serviceMock" class="org.spockframework.spring.docs.GreeterService"/>   <!--1-->


### PR DESCRIPTION
:spock-spring:spring4CgLibTest>DetachedXmlExample
fails with:
"Cannot find the declaration of element 'beans'."

Relates to #1735