### PR TITLE
Interactions in when blocks are not preserved

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -96,6 +96,9 @@ public class AstNodeCache {
   public final MethodNode MockController_LeaveScope =
       MockController.getDeclaredMethods(org.spockframework.mock.runtime.MockController.LEAVE_SCOPE).get(0);
 
+  public final MethodNode MockController_FreezeScope =
+    MockController.getDeclaredMethods(org.spockframework.mock.runtime.MockController.FREEZE_SCOPE).get(0);
+
   public final MethodNode SpecificationContext_GetMockController =
       SpecificationContext.getDeclaredMethods(org.spockframework.runtime.SpecificationContext.GET_MOCK_CONTROLLER).get(0);
 

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -439,10 +439,17 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     statsBeforeWhenBlock.addAll(interactions);
 
-    if (block.isFirstInChain())
+    if (block.isLastInChain()) {
+      //Insert a freezeScope after the last moved interaction from "then" block to guarantee correct Scope behavior for interactions in the "when" block
+      //See Ticket #1759: Interactions in when blocks are not preserved if the then block contains an interaction
+      statsBeforeWhenBlock.add(createMockControllerCall(nodeCache.MockController_FreezeScope));
+    }
+
+    if (block.isFirstInChain()) {
       // insert at beginning of then-block rather than end of when-block
       // s.t. it's outside of try-block inserted for exception conditions
       block.getAst().add(0, createMockControllerCall(nodeCache.MockController_LeaveScope));
+    }
   }
 
   private Statement createMockControllerCall(MethodNode method) {

--- a/spock-core/src/main/java/org/spockframework/compiler/model/Block.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/model/Block.java
@@ -80,5 +80,9 @@ public abstract class Block extends Node<Method, List<Statement>> {
     return isFirst() || getClass() != prev.getClass();
   }
 
+  public boolean isLastInChain() {
+    return isLast() || getClass() != next.getClass();
+  }
+
   public abstract BlockParseInfo getParseInfo();
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MockInteractionsIssue1754Spec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MockInteractionsIssue1754Spec.groovy
@@ -1,0 +1,89 @@
+package org.spockframework.smoke.mock
+
+import spock.lang.Issue
+import spock.lang.PendingFeature
+import spock.lang.Specification
+
+@Issue("https://github.com/spockframework/spock/pull/1754")
+class MockInteractionsIssue1754Spec extends Specification {
+
+  def "When block interaction still active after when block without verification"() {
+    given:
+    def m = Mock(Engine)
+    when:
+    m.isStarted() >> true
+    def result = m.isStarted()
+    m.start()
+    then:
+    m.isStarted()
+    result
+    when: "Here the isStarted() still reflect the when block above"
+    result = m.isStarted()
+    then:
+    m.isStarted()
+    result
+  }
+
+  def "When block interactions shall be preserved also if there are then interactions"() {
+    given:
+    def m = Mock(Engine)
+    when:
+    m.isStarted() >> true
+    def result = m.isStarted()
+    m.start()
+    then:
+    1 * m.start()
+    m.isStarted()
+    result
+    when:
+    result = m.isStarted()
+    then:
+    m.isStarted()
+    result
+  }
+
+  def "then block is last block in feature"() {
+    given:
+    def m = Mock(Engine)
+    when:
+    m.isStarted() >> true
+    def result = m.isStarted()
+    m.start()
+    then:
+    result
+    m.isStarted()
+    1 * m.start()
+  }
+
+  def "When block interactions with spread over overlapping ordered interactions"() {
+    def list = Mock(List)
+
+    when:
+    list.size() >> 2
+    list.add(1)
+    list.add(2)
+    list.add(2)
+    list.add(1)
+    assert list.size() == 2
+
+    then:
+    1 * list.add(!0)
+    list.size() == 2
+
+    then:
+    2 * list.add(2)
+    list.size() == 2
+
+    then:
+    1 * list.add(_)
+    list.size() == 2
+  }
+
+  static class Engine {
+    private boolean started
+
+    boolean isStarted() { return started }
+
+    void start() { started = true }
+  }
+}


### PR DESCRIPTION
Interactions in a when: block were not active after the following then: block, if the then: block contained an interactions.

Now the SpecRewriter inserts a "freezeScope" after the moved interactions from then blocks.
This let the MockController skip the scope and
use the outer scope for the interactions from the
when block code.

This fixes #1759