### PR TITLE
Mocking in given is ignored when mocked in setup method

### DIFF
--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -155,6 +155,38 @@ _ * subscriber.receive("hello")      // any number of calls, including zero
                                      // (rarely needed; see 'Strict Mocking')
 ----
 
+==== Interactions with Cardinality
+
+Interactions with cardinality are additive, this means if you specify two interactions with cardinality (with same target, method and argument)
+they are processed after each other:
+
+.Interactions with Cardinality are additive
+[source,groovy,indent=0]
+----
+include::{sourcedir}/interaction/InteractionDocSpec.groovy[tag=two-interactions-cardinality]
+----
+
+==== Interactions without Cardinality
+
+Interactions without cardinality are **not** additive.
+If you specify multiple interactions without cardinality (with same target, method and argument)
+only the last interaction is respected.
+
+That allows you to specify default interactions in the `setup` method, but override it in
+some of the `feature` methods.
+
+
+.Interactions without Cardinality are **not** additive
+[source,groovy,indent=0]
+----
+include::{sourcedir}/interaction/InteractionDocSpec.groovy[tag=two-interactions-without-cardinality]
+----
+
+NOTE: An interaction without cardinality will **not** override an interaction with cardinality and vice versa.
+
+CAUTION: Interactions in `then` blocks have always precedence over any other interactions regardless of their cardinality.
+         So an interaction in a `then` block will apply regardless what was specified in `setup`, `given` or the `when`.
+
 === Target Constraint
 
 The target constraint of an interaction describes which mock object is expected to receive the method call:

--- a/spock-core/src/main/java/org/spockframework/mock/DefaultInteraction.java
+++ b/spock-core/src/main/java/org/spockframework/mock/DefaultInteraction.java
@@ -15,9 +15,26 @@ package org.spockframework.mock;
 
 import org.spockframework.util.UnreachableCodeError;
 
+import java.util.Collections;
 import java.util.List;
 
 abstract class DefaultInteraction implements IMockInteraction {
+
+  @Override
+  public boolean isCardinalitySpecified() {
+    return false;
+  }
+
+  @Override
+  public List<IInvocationConstraint> getConstraints() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean isThisInteractionOverridableBy(IMockInteraction toCheck) {
+    return false;
+  }
+
   @Override
   public int getLine() {
     return -1;

--- a/spock-core/src/main/java/org/spockframework/mock/IArgumentConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IArgumentConstraint.java
@@ -22,6 +22,11 @@ package org.spockframework.mock;
  * @author Peter Niederwieser
  */
 public interface IArgumentConstraint {
+  /**
+   * @param other the other element
+   * @return {@code true}, if both elements represent the same {@link IArgumentConstraint} from the declaration point of view
+   */
+  boolean isDeclarationEqualTo(IArgumentConstraint other);
   boolean isSatisfiedBy(Object arg);
   String describeMismatch(Object arg);
 }

--- a/spock-core/src/main/java/org/spockframework/mock/IInvocationConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IInvocationConstraint.java
@@ -21,6 +21,11 @@ package org.spockframework.mock;
  * @author Peter Niederwieser
  */
 public interface IInvocationConstraint {
+  /**
+   * @param other the other element
+   * @return {@code true}, if both elements represent the same {@link IInvocationConstraint} from the declaration point of view
+   */
+  boolean isDeclarationEqualTo(IInvocationConstraint other);
   boolean isSatisfiedBy(IMockInvocation invocation);
   String describeMismatch(IMockInvocation invocation);
 }

--- a/spock-core/src/main/java/org/spockframework/mock/IMockInteraction.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IMockInteraction.java
@@ -32,6 +32,27 @@ public interface IMockInteraction {
 
   String getText();
 
+  /**
+   * @return {@code true}, if the user had specified cardinality
+   */
+  boolean isCardinalitySpecified();
+
+  List<IInvocationConstraint> getConstraints();
+
+  /**
+   * Returns {@code true}, if this interaction, can be overridden by the {@link IMockInteraction} {@code toCheck}.
+   *
+   * <p>This is possible if:
+   * <ul>
+   * <li>Both have no specified cardinality</li>
+   * <li>Both have the same {@link IInvocationConstraint}s, see {@link IInvocationConstraint#isDeclarationEqualTo(IInvocationConstraint)}</li>
+   * </ul>
+   *
+   * @param toCheck the element, which wants to override this.
+   * @return {@code true}, if this can be overridden.
+   */
+  boolean isThisInteractionOverridableBy(IMockInteraction toCheck);
+
   boolean matches(IMockInvocation invocation);
 
   @Nullable

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/CodeArgumentConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/CodeArgumentConstraint.java
@@ -21,15 +21,26 @@ import org.spockframework.runtime.GroovyRuntimeUtil;
 
 import groovy.lang.Closure;
 
+import java.util.Objects;
+
 /**
  *
  * @author Peter Niederwieser
  */
 public class CodeArgumentConstraint implements IArgumentConstraint {
-  private final Closure code;
+  private final Closure<?> code;
 
-  public CodeArgumentConstraint(Closure code) {
+  public CodeArgumentConstraint(Closure<?> code) {
     this.code = code;
+  }
+
+  @Override
+  public boolean isDeclarationEqualTo(IArgumentConstraint other) {
+    if (other instanceof CodeArgumentConstraint) {
+      CodeArgumentConstraint o = (CodeArgumentConstraint) other;
+      return Objects.equals(this.code, o.code);
+    }
+    return false;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/EqualArgumentConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/EqualArgumentConstraint.java
@@ -32,6 +32,15 @@ public class EqualArgumentConstraint implements IArgumentConstraint {
   }
 
   @Override
+  public boolean isDeclarationEqualTo(IArgumentConstraint other) {
+    if (other instanceof EqualArgumentConstraint) {
+      EqualArgumentConstraint o = (EqualArgumentConstraint) other;
+      return this.expected == o.expected;
+    }
+    return false;
+  }
+
+  @Override
   public boolean isSatisfiedBy(Object arg) {
     if (HamcrestFacade.isMatcher(expected)) {
       return HamcrestFacade.matches(expected, arg);

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/EqualMethodNameConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/EqualMethodNameConstraint.java
@@ -20,6 +20,8 @@ import org.spockframework.mock.*;
 import org.spockframework.runtime.Condition;
 import org.spockframework.util.CollectionUtil;
 
+import java.util.Objects;
+
 /**
  *
  * @author Peter Niederwieser
@@ -29,6 +31,15 @@ public class EqualMethodNameConstraint implements IInvocationConstraint {
 
   public EqualMethodNameConstraint(String methodName) {
     this.methodName = methodName;
+  }
+
+  @Override
+  public boolean isDeclarationEqualTo(IInvocationConstraint other) {
+    if (other instanceof EqualMethodNameConstraint) {
+      EqualMethodNameConstraint o = (EqualMethodNameConstraint) other;
+      return Objects.equals(this.methodName, o.methodName);
+    }
+    return false;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/EqualPropertyNameConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/EqualPropertyNameConstraint.java
@@ -14,9 +14,12 @@
 
 package org.spockframework.mock.constraint;
 
+import org.spockframework.mock.IInvocationConstraint;
 import org.spockframework.mock.IMockInvocation;
 import org.spockframework.runtime.Condition;
 import org.spockframework.util.CollectionUtil;
+
+import java.util.Objects;
 
 /**
  *
@@ -27,6 +30,15 @@ public class EqualPropertyNameConstraint extends PropertyNameConstraint {
 
   public EqualPropertyNameConstraint(String propertyName) {
     this.propertyName = propertyName;
+  }
+
+  @Override
+  public boolean isDeclarationEqualTo(IInvocationConstraint other) {
+    if (other instanceof EqualPropertyNameConstraint) {
+      EqualPropertyNameConstraint o = (EqualPropertyNameConstraint) other;
+      return Objects.equals(this.propertyName, o.propertyName);
+    }
+    return false;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/NamedArgumentListConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/NamedArgumentListConstraint.java
@@ -39,6 +39,17 @@ public class NamedArgumentListConstraint implements IInvocationConstraint {
   }
 
   @Override
+  public boolean isDeclarationEqualTo(IInvocationConstraint other) {
+    if (other instanceof NamedArgumentListConstraint) {
+      NamedArgumentListConstraint o = (NamedArgumentListConstraint) other;
+      return Objects.equals(this.argNames, o.argNames) &&
+        CollectionUtil.areListsEqual(this.argConstraints, o.argConstraints, IArgumentConstraint::isDeclarationEqualTo) &&
+        this.isMixed == o.isMixed;
+    }
+    return false;
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public boolean isSatisfiedBy(IMockInvocation invocation) {
     List<Object> args = invocation.getArguments();

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/NegatingArgumentConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/NegatingArgumentConstraint.java
@@ -30,6 +30,15 @@ public class NegatingArgumentConstraint implements IArgumentConstraint {
   }
 
   @Override
+  public boolean isDeclarationEqualTo(IArgumentConstraint other) {
+    if (other instanceof NegatingArgumentConstraint) {
+      NegatingArgumentConstraint o = (NegatingArgumentConstraint) other;
+      return this.constraint.isDeclarationEqualTo(o.constraint);
+    }
+    return false;
+  }
+
+  @Override
   public boolean isSatisfiedBy(Object arg) {
     return !constraint.isSatisfiedBy(arg);
   }

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/PositionalArgumentListConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/PositionalArgumentListConstraint.java
@@ -38,6 +38,15 @@ public class PositionalArgumentListConstraint implements IInvocationConstraint {
   }
 
   @Override
+  public boolean isDeclarationEqualTo(IInvocationConstraint other) {
+    if (other instanceof PositionalArgumentListConstraint) {
+      PositionalArgumentListConstraint o = (PositionalArgumentListConstraint) other;
+      return CollectionUtil.areListsEqual(this.argConstraints, o.argConstraints, IArgumentConstraint::isDeclarationEqualTo);
+    }
+    return false;
+  }
+
+  @Override
   public boolean isSatisfiedBy(IMockInvocation invocation) {
     List<Object> args = invocation.getArguments();
 

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/RegexMethodNameConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/RegexMethodNameConstraint.java
@@ -20,6 +20,7 @@ import org.spockframework.mock.*;
 import org.spockframework.runtime.Condition;
 import org.spockframework.util.CollectionUtil;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -31,6 +32,15 @@ public class RegexMethodNameConstraint implements IInvocationConstraint {
 
   public RegexMethodNameConstraint(String regex) {
     pattern = Pattern.compile(regex);
+  }
+
+  @Override
+  public boolean isDeclarationEqualTo(IInvocationConstraint other) {
+    if (other instanceof RegexMethodNameConstraint) {
+      RegexMethodNameConstraint o = (RegexMethodNameConstraint) other;
+      return Objects.equals(this.pattern.toString(), o.pattern.toString());
+    }
+    return false;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/RegexPropertyNameConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/RegexPropertyNameConstraint.java
@@ -18,6 +18,7 @@ import org.spockframework.mock.*;
 import org.spockframework.runtime.*;
 import org.spockframework.util.CollectionUtil;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -29,6 +30,15 @@ public class RegexPropertyNameConstraint extends PropertyNameConstraint {
 
   public RegexPropertyNameConstraint(String regex) {
     pattern = Pattern.compile(regex);
+  }
+
+  @Override
+  public boolean isDeclarationEqualTo(IInvocationConstraint other) {
+    if (other instanceof RegexPropertyNameConstraint) {
+      RegexPropertyNameConstraint o = (RegexPropertyNameConstraint) other;
+      return Objects.equals(this.pattern.toString(), o.pattern.toString());
+    }
+    return false;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/SpreadWildcardArgumentConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/SpreadWildcardArgumentConstraint.java
@@ -29,6 +29,11 @@ public class SpreadWildcardArgumentConstraint implements IArgumentConstraint {
   private SpreadWildcardArgumentConstraint() {}
 
   @Override
+  public boolean isDeclarationEqualTo(IArgumentConstraint other) {
+    return this == other;
+  }
+
+  @Override
   public boolean isSatisfiedBy(Object arg) {
     throw new InvalidSpecException("*_ may only appear at the end of an argument list");
   }

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/TargetConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/TargetConstraint.java
@@ -34,6 +34,15 @@ public class TargetConstraint implements IInvocationConstraint, IInteractionAwar
   }
 
   @Override
+  public boolean isDeclarationEqualTo(IInvocationConstraint other) {
+    if (other instanceof TargetConstraint) {
+      TargetConstraint o = (TargetConstraint) other;
+      return this.target == o.target;
+    }
+    return false;
+  }
+
+  @Override
   public boolean isSatisfiedBy(IMockInvocation invocation) {
     return invocation.getMockObject().matches(target, interaction);
   }

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/TypeArgumentConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/TypeArgumentConstraint.java
@@ -20,6 +20,8 @@ import org.spockframework.mock.IArgumentConstraint;
 import org.spockframework.runtime.Condition;
 import org.spockframework.util.CollectionUtil;
 
+import java.util.Objects;
+
 /**
  *
  * @author Peter Niederwieser
@@ -31,6 +33,16 @@ public class TypeArgumentConstraint implements IArgumentConstraint {
   public TypeArgumentConstraint(Class<?> type, IArgumentConstraint constraint) {
     this.type = type;
     this.constraint = constraint;
+  }
+
+  @Override
+  public boolean isDeclarationEqualTo(IArgumentConstraint other) {
+    if (other instanceof TypeArgumentConstraint) {
+      TypeArgumentConstraint o = (TypeArgumentConstraint) other;
+      return Objects.equals(this.type, o.type) &&
+        this.constraint.isDeclarationEqualTo(o.constraint);
+    }
+    return false;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/WildcardArgumentConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/WildcardArgumentConstraint.java
@@ -28,6 +28,11 @@ public class WildcardArgumentConstraint implements IArgumentConstraint {
   private WildcardArgumentConstraint() {}
 
   @Override
+  public boolean isDeclarationEqualTo(IArgumentConstraint other) {
+    return this == other;
+  }
+
+  @Override
   public boolean isSatisfiedBy(Object arg) {
     return true;
   }

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/WildcardMethodNameConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/WildcardMethodNameConstraint.java
@@ -25,6 +25,11 @@ public class WildcardMethodNameConstraint implements IInvocationConstraint {
   private WildcardMethodNameConstraint() {}
 
   @Override
+  public boolean isDeclarationEqualTo(IInvocationConstraint other) {
+    return this == other;
+  }
+
+  @Override
   public boolean isSatisfiedBy(IMockInvocation invocation) {
     return DefaultJavaLangObjectInteractions.INSTANCE.match(invocation) == null;
   }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/InteractionBuilder.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/InteractionBuilder.java
@@ -34,8 +34,11 @@ public class InteractionBuilder {
   private final int line;
   private final int column;
   private final String text;
-
-  private int minCount = 0;
+  /**
+   * Constant to mark if the user has specified a count/cardinality
+   */
+  private static final int COUNT_NOT_SPECIFIED = Integer.MIN_VALUE;
+  private int minCount = COUNT_NOT_SPECIFIED;
   private int maxCount = Integer.MAX_VALUE;
   private List<IInvocationConstraint> invConstraints = new ArrayList<>();
   private List<Object> argNames;
@@ -183,7 +186,12 @@ public class InteractionBuilder {
 
   public static final String BUILD = "build";
   public IMockInteraction build() {
-    return new MockInteraction(line, column, text, minCount, maxCount, invConstraints,
+    boolean hasCardinality = true;
+    if (minCount == COUNT_NOT_SPECIFIED) {
+      hasCardinality = false;
+      minCount = 0;
+    }
+    return new MockInteraction(line, column, text, hasCardinality, minCount, maxCount, invConstraints,
         responseGeneratorChain.isEmpty() ? new DefaultResponseGenerator() : responseGeneratorChain);
   }
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockInteraction.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockInteraction.java
@@ -17,6 +17,7 @@
 package org.spockframework.mock.runtime;
 
 import org.spockframework.mock.*;
+import org.spockframework.util.CollectionUtil;
 import org.spockframework.util.TextUtil;
 
 import java.util.*;
@@ -32,17 +33,24 @@ public class MockInteraction implements IMockInteraction {
   private final String text;
   private final int minCount;
   private final int maxCount;
+  private final boolean cardinalitySpecified;
   private final List<IInvocationConstraint> constraints;
   private final IResponseGenerator responseGenerator;
 
   private final List<IMockInvocation> acceptedInvocations = new ArrayList<>();
 
-  public MockInteraction(int line, int column, String text, int minCount,
-      int maxCount, List<IInvocationConstraint> constraints,
+  public MockInteraction(int line,
+                         int column,
+                         String text,
+                         boolean cardinalitySpecified,
+                         int minCount,
+                         int maxCount,
+                         List<IInvocationConstraint> constraints,
       IResponseGenerator responseGenerator) {
     this.line = line;
     this.column = column;
     this.text = text;
+    this.cardinalitySpecified = cardinalitySpecified;
     this.minCount = minCount;
     this.maxCount = maxCount;
     this.constraints = constraints;
@@ -53,6 +61,24 @@ public class MockInteraction implements IMockInteraction {
         ((IInteractionAware) constraint).setInteraction(this);
       }
     }
+  }
+
+  @Override
+  public boolean isCardinalitySpecified() {
+    return cardinalitySpecified;
+  }
+
+  @Override
+  public List<IInvocationConstraint> getConstraints() {
+    return Collections.unmodifiableList(constraints);
+  }
+
+  @Override
+  public boolean isThisInteractionOverridableBy(IMockInteraction toCheck) {
+    if (this.isCardinalitySpecified() || toCheck.isCardinalitySpecified()) {
+      return false;
+    }
+    return CollectionUtil.areListsEqual(this.constraints, toCheck.getConstraints(), IInvocationConstraint::isDeclarationEqualTo);
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockInteractionDecorator.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockInteractionDecorator.java
@@ -41,6 +41,21 @@ public abstract class MockInteractionDecorator implements IMockInteraction {
   }
 
   @Override
+  public boolean isCardinalitySpecified() {
+    return decorated.isCardinalitySpecified();
+  }
+
+  @Override
+  public List<IInvocationConstraint> getConstraints() {
+    return decorated.getConstraints();
+  }
+
+  @Override
+  public boolean isThisInteractionOverridableBy(IMockInteraction toCheck) {
+    return decorated.isThisInteractionOverridableBy(toCheck);
+  }
+
+  @Override
   public boolean matches(IMockInvocation invocation) {
     return decorated.matches(invocation);
   }

--- a/spock-core/src/main/java/org/spockframework/util/CollectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/CollectionUtil.java
@@ -16,6 +16,7 @@ package org.spockframework.util;
 
 import java.lang.reflect.Array;
 import java.util.*;
+import java.util.function.BiPredicate;
 
 import static java.util.Arrays.asList;
 
@@ -208,5 +209,19 @@ public abstract class CollectionUtil {
       index++;
     }
     return -1;
+  }
+
+  public static <T> boolean areListsEqual(List<T> l1, List<T> l2, BiPredicate<T, T> equalFunction) {
+    if (l1.size() != l2.size()) {
+      return false;
+    }
+    for (int i = 0; i < l1.size(); i++) {
+      T e1 = l1.get(i);
+      T e2 = l2.get(i);
+      if (!equalFunction.test(e1, e2)) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/docs/interaction/InteractionDocSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/interaction/InteractionDocSpec.groovy
@@ -3,6 +3,7 @@ package org.spockframework.docs.interaction
 import org.spockframework.mock.TooFewInvocationsError
 import spock.lang.*
 
+import java.util.function.Supplier
 import java.util.regex.Pattern
 
 import static org.hamcrest.CoreMatchers.endsWith
@@ -53,6 +54,30 @@ class InteractionDocSpec extends Specification {
 
     then:
     2 * _.receive(_)
+  }
+
+  def "Mock two interactions with cardinality"() {
+    // tag::two-interactions-cardinality[]
+    given:
+    Supplier supplier = Mock()
+    1 * supplier.get() >> "First"
+    1 * supplier.get() >> "Second"
+    expect:
+    supplier.get() == "First"
+    supplier.get() == "Second"
+    // end::two-interactions-cardinality[]
+  }
+
+  def "Mock two interactions without cardinality"() {
+    // tag::two-interactions-without-cardinality[]
+    given:
+    Supplier supplier = Mock()
+    supplier.get() >> "First"
+    supplier.get() >> "Second"
+    expect:
+    supplier.get() == "Second"
+    supplier.get() == "Second"
+    // end::two-interactions-without-cardinality[]
   }
 }
 

--- a/spock-specs/src/test/groovy/org/spockframework/mock/DefaultInteractionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/DefaultInteractionSpec.groovy
@@ -1,0 +1,42 @@
+package org.spockframework.mock
+
+import org.spockframework.util.UnreachableCodeError
+import spock.lang.Specification
+
+class DefaultInteractionSpec extends Specification {
+
+  def i = Spy(DefaultInteraction)
+
+  def "default implementation"() {
+    expect:
+    !i.isCardinalitySpecified()
+    i.constraints.isEmpty()
+    !i.isThisInteractionOverridableBy(i)
+    i.line == -1
+    i.column == -1
+    i.satisfied
+    !i.exhausted
+    !i.required
+  }
+
+  def "getAcceptedInvocations"() {
+    when:
+    i.getAcceptedInvocations()
+    then:
+    thrown(UnreachableCodeError)
+  }
+
+  def "computeSimilarityScore"() {
+    when:
+    i.computeSimilarityScore(null)
+    then:
+    thrown(UnreachableCodeError)
+  }
+
+  def "describeMismatch"() {
+    when:
+    i.describeMismatch(null)
+    then:
+    thrown(UnreachableCodeError)
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaMockInteractionOverridesSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaMockInteractionOverridesSpec.groovy
@@ -1,0 +1,519 @@
+package org.spockframework.smoke.mock
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.mock.TooFewInvocationsError
+import spock.lang.FailsWith
+import spock.lang.Issue
+import spock.lang.PendingFeature
+
+class JavaMockInteractionOverridesSpec extends EmbeddedSpecification {
+  def ifMock = Mock(InterfaceType)
+
+  def setup() {
+    ifMock.methodFromSetup() >> 1
+  }
+
+  def "given block two same interactions after each other, the second shall win due to no cardinality"() {
+    given:
+    ifMock.method() >> 1
+    //Second behavior shall win, because the first did no specify cardinality
+    ifMock.method() >> 2
+    when:
+    def result = ifMock.method()
+    then: "Only the second behavior shall apply, because nothing had cardinality"
+    result == 2
+    when:
+    result = ifMock.method()
+    then:
+    result == 2
+  }
+
+  def "when block two same interactions after each other, the second shall win due to no cardinality"() {
+    when:
+    ifMock.method() >> 1
+    //Second behavior shall win, because the first did no specify cardinality
+    ifMock.method() >> 2
+    def result = ifMock.method()
+    then: "Only the second behavior shall apply, because nothing had cardinality"
+    result == 2
+    when:
+    result = ifMock.method()
+    then:
+    result == 2
+  }
+
+  def "Second when block overrides first when block"() {
+    when:
+    ifMock.method() >> 1
+    def result = ifMock.method()
+    then:
+    result == 1
+    when:
+    ifMock.method() >> 2
+    result = ifMock.method()
+    then:
+    result == 2
+  }
+
+  def "then block two same interactions after each other, the second shall win due to no cardinality"() {
+    when:
+    def result1 = ifMock.method()
+    def result2 = ifMock.method()
+    then: "Only the second behavior shall apply, because nothing had cardinality"
+    ifMock.method() >> 1
+    //Second behavior shall win, because the first did not specify any cardinality
+    ifMock.method() >> 2
+    result1 == 2
+    result2 == 2
+  }
+
+  def "two interactions after each other, but first has any cardinality, the second shall not win"() {
+    given:
+    _ * ifMock.method() >> 1
+    //Second behavior shall not win, because the first did specify any cardinality
+    ifMock.method() >> 2
+    when:
+    def result = ifMock.method()
+    then:
+    result == 1
+    when:
+    result = ifMock.method()
+    then:
+    result == 1
+  }
+
+  def "two interactions with first with cardinality"() {
+    given:
+    1 * ifMock.method() >> 1
+    ifMock.method() >> 2
+    when:
+    def result = ifMock.method()
+    then:
+    result == 1
+    when:
+    result = ifMock.method()
+    then:
+    result == 2
+    when:
+    result = ifMock.method()
+    then: "Additional calls are allowed, because the second has no cardinality"
+    result == 2
+  }
+
+  def "given block two interactions with cardinality after each other"() {
+    given:
+    1 * ifMock.method() >> 1
+    1 * ifMock.method() >> 2
+    when:
+    def result = ifMock.method()
+    then:
+    result == 1
+    when:
+    result = ifMock.method()
+    then:
+    result == 2
+  }
+
+  def "when block two interactions with cardinality after each other"() {
+    when:
+    1 * ifMock.method() >> 1
+    1 * ifMock.method() >> 2
+    def result = ifMock.method()
+    then:
+    result == 1
+    when:
+    result = ifMock.method()
+    then:
+    result == 2
+  }
+
+  def "then block two interactions with cardinality after each other"() {
+    when:
+    def result1 = ifMock.method()
+    def result2 = ifMock.method()
+    then:
+    1 * ifMock.method() >> 1
+    1 * ifMock.method() >> 2
+    result1 == 1
+    result2 == 2
+  }
+
+  def "two then blocks two interactions with cardinality after each other"() {
+    when:
+    def result1 = ifMock.method()
+    def result2 = ifMock.method()
+    then:
+    1 * ifMock.method() >> 1
+    then:
+    1 * ifMock.method() >> 2
+    result1 == 1
+    result2 == 2
+  }
+
+  def "setup interaction"() {
+    when:
+    def result = ifMock.methodFromSetup()
+    then:
+    result == 1
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/962")
+  def "given interaction overrides setup, because nothing had cardinality"() {
+    given:
+    ifMock.methodFromSetup() >> 2
+    when:
+    def result = ifMock.methodFromSetup()
+    then:
+    result == 2
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/962")
+  def "when interaction overrides setup, because nothing had cardinality"() {
+    when:
+    ifMock.methodFromSetup() >> 2
+    def result = ifMock.methodFromSetup()
+    then:
+    result == 2
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/962")
+  def "when interaction overrides given, because nothing had cardinality"() {
+    given:
+    ifMock.method() >> 2
+    when:
+    ifMock.method() >> 3
+    def result = ifMock.method()
+    then:
+    result == 3
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/962")
+  def "when interaction overrides given ans setup, because nothing had cardinality"() {
+    given:
+    ifMock.methodFromSetup() >> 2
+    when:
+    ifMock.methodFromSetup() >> 3
+    def result = ifMock.methodFromSetup()
+    then:
+    result == 3
+  }
+
+  @FailsWith(TooFewInvocationsError)
+  def "given interaction shall not override setup, because given has cardinality"() {
+    given: "the given block can never be matched, because the setup defines it without cardinality"
+    1 * ifMock.methodFromSetup() >> 2
+    when:
+    def result = ifMock.methodFromSetup()
+    then:
+    result == 1
+  }
+
+  def "then block interaction without cardinality overrides given"() {
+    given:
+    ifMock.method() >> 2
+    when:
+    def result = ifMock.method()
+    then:
+    ifMock.method() >> 3
+    result == 3
+  }
+
+  @PendingFeature(reason = "https://github.com/spockframework/spock/pull/1761")
+  def "then block interaction without cardinality overrides when"() {
+    when:
+    ifMock.method() >> 2
+    def result = ifMock.method()
+    then:
+    ifMock.method() >> 3
+    result == 3
+  }
+
+  def "then block interaction with cardinality overrides given"() {
+    given:
+    ifMock.method() >> 2
+    when:
+    def result = ifMock.method()
+    then:
+    1 * ifMock.method() >> 3
+    result == 3
+  }
+
+  def "then block interaction with cardinality overrides when"() {
+    when:
+    ifMock.method() >> 2
+    def result = ifMock.method()
+    then:
+    1 * ifMock.method() >> 3
+    result == 3
+  }
+
+  def "then block interaction overrides setup"() {
+    when:
+    def result = ifMock.methodFromSetup()
+    then:
+    1 * ifMock.methodFromSetup() >> 2
+    result == 2
+  }
+
+  def "given interaction shall not override setup, because given has cardinality and setup has cardinality"() {
+    given:
+    runner.addClassImport(InterfaceType)
+    runner.runSpecBody("""
+  def ifMock = Mock(InterfaceType)
+
+  def setup() {
+    1 * ifMock.methodFromSetup() >> 1
+  }
+
+   def "test"() {
+    given:
+    1 * ifMock.methodFromSetup() >> 2
+    when:
+    def result = ifMock.methodFromSetup()
+    then:
+    result == 1
+    when:
+    result = ifMock.methodFromSetup()
+    then:
+    result == 2
+  }
+""")
+  }
+
+  def "Positional Arg override"() {
+    given:
+    ifMock.methodArg("A") >> 1
+    ifMock.methodArg("A") >> 2
+    expect:
+    ifMock.methodArg("A") == 2
+  }
+
+  def "type arg override"() {
+    given:
+    ifMock.methodArg(_ as String) >> 1
+    ifMock.methodArg(_ as String) >> 2
+    expect:
+    ifMock.methodArg("A") == 2
+  }
+
+  def "type arg wrong type override"() {
+    given:
+    ifMock.methodArg(_ as String) >> 1
+    ifMock.methodArg(_ as Object) >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "type arg exact method do no override"() {
+    given:
+    ifMock.methodArg(_ as String) >> 1
+    ifMock.methodArg("A") >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Wildcard method override"() {
+    given:
+    ifMock._ >> 1
+    ifMock._ >> 2
+    expect:
+    ifMock.methodArg("A") == 2
+  }
+
+  def "Wildcard Exact method do not override"() {
+    given:
+    ifMock.methodArg("A") >> 1
+    ifMock._ >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Exact method Wildcard do not override"() {
+    given:
+    ifMock._ >> 1
+    ifMock.methodArg("A") >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Exact method target constraint do not override"() {
+    given:
+    ifMock.methodArg("A") >> 1
+    _.methodArg("A") >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "target constraint exact method do not override"() {
+    given:
+    _.methodArg("A") >> 1
+    ifMock.methodArg("A") >> 2
+
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Regex method override"() {
+    given:
+    ifMock."method.*"(_) >> 1
+    ifMock."method.*"(_) >> 2
+    expect:
+    ifMock.methodArg("A") == 2
+  }
+
+  def "method explicit method regex do not override"() {
+    given:
+    ifMock.methodArg("A") >> 1
+    ifMock."method.*"(_) >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "method regex method explicit do not override"() {
+    given:
+    ifMock."method.*"(_) >> 1
+    ifMock.methodArg("A") >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Spread wildcard args override"() {
+    given:
+    ifMock.methodArg(*_) >> 1
+    ifMock.methodArg(*_) >> 2
+    expect:
+    ifMock.methodArg("A") == 2
+  }
+
+  def "Spread wildcard exact method do no override"() {
+    given:
+    ifMock.methodArg(*_) >> 1
+    ifMock.methodArg("A") >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "property override"() {
+    given:
+    ifMock.propA >> 1
+    ifMock.propA >> 2
+    expect:
+    ifMock.propA == 2
+  }
+
+  def "property regex override"() {
+    given:
+    ifMock."prop.*" >> 1
+    ifMock."prop.*" >> 2
+    expect:
+    ifMock.propA == 2
+  }
+
+  def "property explicit property regex do not override"() {
+    given:
+    ifMock.propA >> 1
+    ifMock."prop.*" >> 2
+    expect:
+    ifMock.propA == 1
+  }
+
+  def "property regex property explicit do not override"() {
+    given:
+    ifMock."prop.*" >> 1
+    ifMock.propA >> 2
+    expect:
+    ifMock.propA == 1
+  }
+
+  def "Positional Arg negate override"() {
+    given:
+    ifMock.methodArg(!"A") >> 1
+    ifMock.methodArg(!"A") >> 2
+    expect:
+    ifMock.methodArg("B") == 2
+  }
+
+  def "Positional Arg negate exact do not override"() {
+    given:
+    ifMock.methodArg(!"A") >> 1
+    ifMock.methodArg("A") >> 2
+    expect:
+    ifMock.methodArg("B") == 1
+  }
+
+  def "Positional Arg Wildcard Args do not override"() {
+    given:
+    ifMock.methodArg("A") >> 1
+    ifMock.methodArg(_) >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Named Arg override"() {
+    given:
+    ifMock.methodNamedArg(arg: "A") >> 1
+    ifMock.methodNamedArg(arg: "A") >> 2
+    expect:
+    ifMock.methodNamedArg(arg: "A") == 2
+  }
+
+  def "Named Arg do not override"() {
+    given:
+    ifMock.methodNamedArg(arg: "A") >> 1
+    ifMock.methodNamedArg(arg: "B") >> 2
+    expect:
+    ifMock.methodNamedArg(arg: "A") == 1
+  }
+
+  def "Code Arg do not override"() {
+    given:
+    ifMock.methodArg {} >> 1
+    ifMock.methodArg {} >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Code Arg Exact arg do not override"() {
+    given:
+    ifMock.methodArg("A") >> 1
+    ifMock.methodArg {} >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Code Arg Exact arg inverse do not override"() {
+    given:
+    ifMock.methodArg {} >> 1
+    ifMock.methodArg("A") >> 2
+    expect:
+    ifMock.methodArg("A") == 1
+  }
+
+  def "Named Arg Positional Arg do not override"() {
+    given:
+    ifMock.methodNamedArg(arg: "A") >> 1
+    ifMock.methodNamedArg("A") >> 2
+    expect:
+    ifMock.methodNamedArg(arg: "A") == 1
+  }
+
+  def "Named Arg Positional arg inverse do not override"() {
+    given:
+    ifMock.methodNamedArg("A") >> 1
+    ifMock.methodNamedArg(arg: "A") >> 2
+    expect:
+    ifMock.methodNamedArg(arg: "A") == 2
+  }
+
+  interface InterfaceType {
+    int methodFromSetup()
+
+    int method()
+
+    int methodArg(String arg)
+
+    int methodNamedArg(Map<String, Object> arg)
+
+    int getPropA();
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/util/CollectionUtilSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/CollectionUtilSpec.groovy
@@ -16,6 +16,8 @@ package org.spockframework.util
 
 import spock.lang.*
 
+import java.util.function.BiPredicate
+
 class CollectionUtilSpec extends Specification {
   def "copy an array"() {
     def array = [1, 2, 3] as Object[]
@@ -124,5 +126,24 @@ class CollectionUtilSpec extends Specification {
     CollectionUtil.addLastElement(l, 2)
     then:
     l == [1, 2]
+  }
+
+  private static final Closure<Boolean> EQUALS = { Object x, Object y -> x == y }
+
+  def "areListsEqual"(List l1, List l2, BiPredicate func, boolean expected) {
+    expect:
+    CollectionUtil.areListsEqual(l1, l2, func) == expected
+    where:
+    l1         | l2         | func              | expected
+    []         | []         | EQUALS            | true
+    ["A"]      | []         | EQUALS            | false
+    ["A"]      | ["B"]      | EQUALS            | false
+    ["A", "B"] | ["A", "B"] | EQUALS            | true
+    []         | ["A"]      | EQUALS            | false
+    ["A"]      | ["A"]      | EQUALS            | true
+    [1]        | [1]        | EQUALS            | true
+    []         | []         | { x, y -> false } | true
+    [1]        | [1]        | { x, y -> false } | false
+    [1, 2]     | [1]        | { x, y -> true }  | false
   }
 }


### PR DESCRIPTION
The Interactions now allow to override other interactions, if these are the same and do not specify a cardinality.

This can possibly be a breaking change, when someone relies on the existing strange behavior, but I think this can be neglected.
None of the existing spock test in this repo broke.

This fixes #962