### PR TITLE
Fixup LICENSE file after change to geantyref

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -7,10 +7,6 @@
 This product includes software developed by
 The Apache Software Foundation (https://www.apache.org/).
 
-It includes the following other software:
-
-gentyref (https://code.google.com/p/gentyref/)
-
 For licenses see the LICENSE file.
 
 If any software distributed with Spock does not have an Apache 2 License, its license is explicitly listed in the


### PR DESCRIPTION
This was missing in commit:
f00efe4c5 - Replace gentyref code with geantyref library (#1743)