### PR TITLE
Add check to prevent double global mocking

### DIFF
--- a/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/GroovyMockFactory.java
@@ -35,9 +35,13 @@ public class GroovyMockFactory implements IMockFactory {
 
   @Override
   public Object create(IMockConfiguration configuration, Specification specification) throws CannotCreateMockException {
-    final MetaClass oldMetaClass = GroovyRuntimeUtil.getMetaClass(configuration.getType());
-    GroovyMockMetaClass newMetaClass = new GroovyMockMetaClass(configuration, specification, oldMetaClass);
     final Class<?> type = configuration.getType();
+    final MetaClass oldMetaClass = GroovyRuntimeUtil.getMetaClass(configuration.getType());
+    if (oldMetaClass instanceof GroovyMockMetaClass) {
+      throw new CannotCreateMockException(type,
+        ". The given type is already mocked by Spock.");
+    }
+    GroovyMockMetaClass newMetaClass = new GroovyMockMetaClass(configuration, specification, oldMetaClass);
 
     if (configuration.isGlobal()) {
       if (type.isInterface()) {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocks.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GroovyMocks.groovy
@@ -1,11 +1,45 @@
 package org.spockframework.smoke.mock
 
+import org.spockframework.mock.CannotCreateMockException
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class GroovyMocks extends Specification {
   def "implement GroovyObject"() {
     expect:
     GroovyMock(List) instanceof GroovyObject
     GroovyMock(ArrayList) instanceof GroovyObject
+  }
+
+  @Unroll("A Groovy#typeB can't be created for a type that was already Groovy#typeA'd")
+  def "global GroovyMocks can't be created for a type that is already mocked"(String typeA, String typeB) {
+    given:
+    createMock(typeA)
+
+    when:
+    createMock(typeB)
+
+    then:
+    CannotCreateMockException e = thrown()
+    e.message == 'Cannot create mock for class java.util.ArrayList. The given type is already mocked by Spock.'
+
+    where:
+    [typeA, typeB] << ([['Mock', 'Stub', 'Spy']] * 2).combinations()
+  }
+
+  void createMock(String type) {
+    switch (type) {
+      case 'Mock':
+        GroovyMock(global: true, ArrayList)
+        break
+      case 'Stub':
+        GroovyStub(global: true, ArrayList)
+        break
+      case 'Spy':
+        GroovySpy(global: true, ArrayList)
+        break
+      default:
+        throw new IllegalArgumentException(type)
+    }
   }
 }


### PR DESCRIPTION
Previous to this commit, it was possible to create a global
GroovyMock/Stub/Spy for a type that was already a global mock,
this is problematic and leaked the modified meta-class.
