### PR TITLE
Validate argument amount in old(...) calls

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -5,6 +5,10 @@ include::include.adoc[]
 
 == 2.4 (tbd)
 
+=== Breaking Changes
+
+- Calling `old(...)` with multiple arguments is now a compilation error. Previously the additional arguments were simply ignored.
+
 == 2.4-M1 (2022-11-30)
 
 * Fix issues with Spring 6/Spring Boot 3 spockPull:1541[]

--- a/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
@@ -284,6 +284,11 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
 
     expr.setMethod(new ConstantExpression(expr.getMethodAsString() + "Impl"));
     List<Expression> args = AstUtil.getArgumentList(expr);
+    if (args.size() != 1) {
+      resources.getErrorReporter().error(expr, "old() must have exactly one argument");
+      return true;
+    }
+
     VariableExpression oldValue = resources.captureOldValue(args.get(0));
     args.set(0, oldValue);
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/AccessingOldValues.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/AccessingOldValues.groovy
@@ -116,6 +116,24 @@ class AccessingOldValues extends EmbeddedSpecification {
     e.line == 2
   }
 
+  def "old() must have exactly one argument"() {
+    when:
+    compiler.compileFeatureBody """
+    when: true
+    then: old($oldArguments)
+    """
+
+    then:
+    InvalidSpecCompileException e = thrown()
+    e.message == 'old() must have exactly one argument @ line 2, column 11.'
+
+    where:
+    oldArguments << [
+      '',
+      'null, null'
+    ]
+  }
+
   def "may occur outside of a condition"() {
     def list = [1,2,3]
 


### PR DESCRIPTION
Previously if you had multiple arguments to an `old(...)` call 2nd and on were simply ignored,
and if you had no argument the compiler throws a `NullPointerException`.

Now the compiler validates that there is exactly one argument to an `old(...)` call.

Due to the multiple arguments now being forbidden, this is theoretically a breaking change,
but until recently the whole feature was not even documented and probably very few people
use it at all, let alone with multiple arguments.
