### PR TITLE
Update gradle-build-action usage

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -16,10 +16,7 @@ runs:
     - name: Init Gradle Build Action
       uses: gradle/gradle-build-action@v2
       with:
-        # cache options only count for the first invocation
         cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-        arguments: --version
     - name: 'Gradle javaToolchains'
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: javaToolchains
+      run: ./gradlew --show-version javaToolchains
+      shell: bash

--- a/.github/workflows/branches-and-prs.yml
+++ b/.github/workflows/branches-and-prs.yml
@@ -63,8 +63,6 @@ jobs:
           ORG_GRADLE_PROJECT_spockBuildCacheUsername: ${{ secrets.SPOCK_BUILD_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_spockBuildCachePassword: ${{ secrets.SPOCK_BUILD_CACHE_PASSWORD }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --no-parallel --stacktrace ghActionsBuild "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}"
+        run: ./gradlew --no-parallel --stacktrace ghActionsBuild "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}"
       - name: 'Upload to Codecov.io'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,8 +57,6 @@ jobs:
       # we have to disable build cache for now as it seems to be necessary for the compiler to run during the build
       # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/troubleshooting-the-codeql-workflow#no-code-found-during-the-build
       - name: 'Build Spock Classes'
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --stacktrace --no-build-cache testClasses "-Dvariant=${{ matrix.variant }}"
+        run: ./gradlew --stacktrace --no-build-cache testClasses "-Dvariant=${{ matrix.variant }}"
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,7 @@ jobs:
           ORG_GRADLE_PROJECT_spockBuildCacheUsername: ${{ secrets.SPOCK_BUILD_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_spockBuildCachePassword: ${{ secrets.SPOCK_BUILD_CACHE_PASSWORD }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --no-parallel --stacktrace ghActionsBuild "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}"  "-Dscan.tag.main-build"
+        run: ./gradlew --no-parallel --stacktrace ghActionsBuild "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}"  "-Dscan.tag.main-build"
       - name: 'Stop Daemon'
         run: |
           ./gradlew --stop
@@ -89,9 +87,7 @@ jobs:
           ORG_GRADLE_PROJECT_spockBuildCacheUsername: ${{ secrets.SPOCK_BUILD_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_spockBuildCachePassword: ${{ secrets.SPOCK_BUILD_CACHE_PASSWORD }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --no-parallel --stacktrace ghActionsPublish "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}" "-Dscan.tag.main-publish"
+        run: ./gradlew --no-parallel --stacktrace ghActionsPublish "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}" "-Dscan.tag.main-publish"
 
   publish-release-docs:
     runs-on: ${{ matrix.os }}
@@ -116,6 +112,4 @@ jobs:
           ORG_GRADLE_PROJECT_spockBuildCacheUsername: ${{ secrets.SPOCK_BUILD_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_spockBuildCachePassword: ${{ secrets.SPOCK_BUILD_CACHE_PASSWORD }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --no-parallel --stacktrace ghActionsDocs "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}" "-Dscan.tag.main-docs"
+        run: ./gradlew --no-parallel --stacktrace ghActionsDocs "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}" "-Dscan.tag.main-docs"


### PR DESCRIPTION
Adapt to recommended usage of gradle/gradle-build-action, i.e.,
only call it once, and use ./gradlew for Gradle calls instead of
the arguments parameter.
