### PR TITLE
MockMaker API cleanup

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -1108,6 +1108,7 @@ The preferred mock maker will be used globally, if no mock maker is explicitly s
 include::{sourcedir}/extension/MockMakerConfigurationDocSpec.groovy[tag=mock-maker-preferredMockMaker]
 ----
 
+[[mock-makers-mockito]]
 ==== Mockito Mock Maker
 
 The `mockito` Mock Maker provides the ability to mock final types, enums and final methods.

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -5,6 +5,19 @@ include::include.adoc[]
 
 == 2.4 (tbd)
 
+* Spock now supports pluggable <<extensions.adoc#mock-makers,mock makers>> loaded via ServiceLoader spockPull:1746[]
+** This allows external libraries to contribute mocking logic to Spock and use the same API for the users
+** You can select the used mock maker during mock creation: `Mock(mockMaker:MockMakers.byteBuddy)`
+* Added <<extensions.adoc#mock-makers-mockito,mockito>> mock maker spockPull:1753[] which supports:
+** Mocking of final classes and final methods
+** Requires `org.mockito:mockito-core` >= 4.11 in the test class path
+* Fix issue with mocks of Groovy classes, where the Groovy MOP for `@Internal` methods was not honored by the `byte-buddy` mock maker spockPull:1729[]
+** This fixes multiple issues with Groovy MOP: spockIssue:1501[], spockIssue:1452[], spockIssue:1608[] and spockIssue:1145[]
+* Replaced `gentyref` code with https://github.com/leangen/geantyref[geantyref] library spockPull:1743[]
+** This is now a required dependency used by spock: `io.leangen.geantyref:geantyref:1.3.14`
+* Better support for generic return types for mocks spockPull:1731[]
+** This fixes the issues: spockIssue:520[], spockIssue:1163[]
+
 === Breaking Changes
 
 * Calling `old(...)` with multiple arguments is now a compilation error. Previously the additional arguments were simply ignored.
@@ -18,6 +31,11 @@ include::include.adoc[]
 * Improve `@TempDir` field injection, now it happens before field initialization, so it can be used by other field initializers.
 * Fix exception when configured `baseDir` was not existing, now `@TempDir` will create the baseDir directory if it is missing.
 * Fix bad error message for collection conditions, when one of the operands is `null`
+* Document `@ConditionBlock` Annotation spockPull:1709[]
+* Document `old`-Method spockPull:1708[]
+* Clarify documentation for global Mocks spockPull:1755[]
+* Spock-Compiler does not use wrapper types anymore spockPull:1765[]
+* Reduce lock contention of the `byte-buddy` mock maker, when multiple mocks are created concurrently spockPull:1778[]
 
 == 2.4-M1 (2022-11-30)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ jaxb = "javax.xml.bind:jaxb-api:2.3.1"
 junit4 = "junit:junit:4.13.2"
 log4j = "log4j:log4j:1.2.17"
 mockito4 = { module = "org.mockito:mockito-core", version.ref = "mockito4" }
+mockito4inline = { module = "org.mockito:mockito-inline", version.ref = "mockito4" }
 mockito5 = { module = "org.mockito:mockito-core", version.ref = "mockito5" }
 objenesis = "org.objenesis:objenesis:3.3"
 # This needs a classifier, but is has to be specified on the usage end https://melix.github.io/blog/2021/03/version-catalogs-faq.html#_why_can_t_i_use_excludes_or_classifiers

--- a/spock-core/src/main/java/org/spockframework/mock/IMockConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/mock/IMockConfiguration.java
@@ -1,6 +1,7 @@
 package org.spockframework.mock;
 
 import org.spockframework.mock.runtime.IMockMaker;
+import spock.mock.IMockMakerSettings;
 import org.spockframework.util.*;
 import spock.mock.MockingApi;
 
@@ -95,7 +96,7 @@ public interface IMockConfiguration {
    * @return the custom settings to use for the creation of the mock, or {@code null}
    */
   @Nullable
-  IMockMaker.IMockMakerSettings getMockMaker();
+  IMockMakerSettings getMockMaker();
 
   /**
    * Tells whether a mock object stands in for all objects of the mocked type, or just for itself.
@@ -106,7 +107,7 @@ public interface IMockConfiguration {
   boolean isGlobal();
 
   /**
-   * Tells whether invocations on the mock object should be verified. If (@code false}, invocations
+   * Tells whether invocations on the mock object should be verified. If {@code false}, invocations
    * on the mock object will not be matched against interactions that have a cardinality.
    *
    * @return whether invocations on the mock object should be verified

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockMaker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockMaker.java
@@ -20,6 +20,7 @@ import org.spockframework.mock.CannotCreateMockException;
 import org.spockframework.util.Nullable;
 import org.spockframework.util.ReflectionUtil;
 import org.spockframework.util.ThreadSafe;
+import spock.mock.MockMakerId;
 
 import java.util.Collections;
 import java.util.EnumSet;

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/CglibMockMaker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/CglibMockMaker.java
@@ -19,6 +19,7 @@ package org.spockframework.mock.runtime;
 import org.spockframework.mock.CannotCreateMockException;
 import org.spockframework.util.ReflectionUtil;
 import org.spockframework.util.ThreadSafe;
+import spock.mock.MockMakerId;
 import spock.util.environment.Jvm;
 
 import java.util.Collections;

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/JavaProxyMockMaker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/JavaProxyMockMaker.java
@@ -19,6 +19,7 @@ package org.spockframework.mock.runtime;
 import org.spockframework.mock.CannotCreateMockException;
 import org.spockframework.mock.ISpockMockObject;
 import org.spockframework.util.ThreadSafe;
+import spock.mock.MockMakerId;
 
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockConfiguration.java
@@ -16,6 +16,7 @@ package org.spockframework.mock.runtime;
 
 import org.spockframework.mock.*;
 import org.spockframework.util.*;
+import spock.mock.IMockMakerSettings;
 
 import java.lang.reflect.Type;
 import java.util.*;
@@ -36,7 +37,7 @@ public class MockConfiguration implements IMockConfiguration {
   private final boolean global;
   private final boolean verified;
   private final boolean useObjenesis;
-  private final IMockMaker.IMockMakerSettings mockMakerSettings;
+  private final IMockMakerSettings mockMakerSettings;
 
   public MockConfiguration(@Nullable String name, Type type, MockNature nature,
       MockImplementation implementation, Map<String, Object> options) {
@@ -57,7 +58,7 @@ public class MockConfiguration implements IMockConfiguration {
     this.global = getOption(options, "global", Boolean.class, false);
     this.verified = getOption(options, "verified", Boolean.class, this.nature.isVerified());
     this.useObjenesis = getOption(options, "useObjenesis", Boolean.class, this.nature.isUseObjenesis());
-    this.mockMakerSettings = getOption(options, "mockMaker", IMockMaker.IMockMakerSettings.class, null);
+    this.mockMakerSettings = getOption(options, "mockMaker", IMockMakerSettings.class, null);
   }
 
   @Override
@@ -123,7 +124,7 @@ public class MockConfiguration implements IMockConfiguration {
   }
 
   @Override
-  public IMockMaker.IMockMakerSettings getMockMaker() {
+  public IMockMakerSettings getMockMaker() {
     return mockMakerSettings;
   }
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockCreationSettings.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockCreationSettings.java
@@ -20,8 +20,10 @@ import org.spockframework.mock.IMockConfiguration;
 import org.spockframework.mock.MockNature;
 import org.spockframework.util.Beta;
 import org.spockframework.util.Nullable;
+import spock.mock.IMockMakerSettings;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -30,7 +32,7 @@ import static org.spockframework.util.ObjectUtil.uncheckedCast;
 @Beta
 public class MockCreationSettings implements IMockMaker.IMockCreationSettings {
 
-  private final IMockMaker.IMockMakerSettings mockMakerSettings;
+  private final IMockMakerSettings mockMakerSettings;
   private final Class<?> mockType;
   private final ClassLoader classLoader;
   private final boolean useObjenesis;
@@ -49,7 +51,7 @@ public class MockCreationSettings implements IMockMaker.IMockCreationSettings {
     return new MockCreationSettings(null, mockType, MockNature.MOCK, additionalInterfaces, null, interceptor, classLoader, useObjenesis, false);
   }
 
-  MockCreationSettings(@Nullable IMockMaker.IMockMakerSettings mockMakerSettings,
+  private MockCreationSettings(@Nullable IMockMakerSettings mockMakerSettings,
                        Class<?> mockType,
                        MockNature mockNature,
                        List<Class<?>> additionalInterfaces,
@@ -110,7 +112,7 @@ public class MockCreationSettings implements IMockMaker.IMockCreationSettings {
   }
 
   @Override
-  public <T extends IMockMaker.IMockMakerSettings> T getMockMakerSettings() {
+  public <T extends IMockMakerSettings> T getMockMakerSettings() {
     return uncheckedCast(mockMakerSettings);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockMakerConfiguration.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockMakerConfiguration.java
@@ -19,6 +19,7 @@ package org.spockframework.mock.runtime;
 import org.spockframework.util.Beta;
 import org.spockframework.util.Nullable;
 import spock.config.ConfigurationObject;
+import spock.mock.IMockMakerSettings;
 import spock.mock.MockMakers;
 
 /**
@@ -43,5 +44,5 @@ public class MockMakerConfiguration {
    * You can find the built-in mock makers in {@link MockMakers}.
    */
   @Nullable
-  public IMockMaker.IMockMakerSettings preferredMockMaker = null;
+  public IMockMakerSettings preferredMockMaker = null;
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockMakerRegistry.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockMakerRegistry.java
@@ -24,6 +24,8 @@ import org.spockframework.mock.runtime.IMockMaker.MockMakerCapability;
 import org.spockframework.util.InternalSpockError;
 import org.spockframework.util.Nullable;
 import org.spockframework.util.ThreadSafe;
+import spock.mock.IMockMakerSettings;
+import spock.mock.MockMakerId;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -38,8 +40,8 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-import static org.spockframework.mock.runtime.IMockMaker.MockMakerId;
-import static org.spockframework.mock.runtime.IMockMaker.IMockMakerSettings;
+import static java.util.Objects.requireNonNull;
+
 import static org.spockframework.mock.runtime.IMockMaker.IMockCreationSettings;
 import static org.spockframework.mock.runtime.IMockMaker.IMockabilityResult;
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/mockito/MockitoMockMaker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/mockito/MockitoMockMaker.java
@@ -21,6 +21,7 @@ import org.spockframework.mock.IMockObject;
 import org.spockframework.mock.runtime.IMockMaker;
 import org.spockframework.util.ReflectionUtil;
 import org.spockframework.util.ThreadSafe;
+import spock.mock.MockMakerId;
 
 import java.lang.reflect.Modifier;
 import java.util.Collections;

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/mockito/MockitoMockMakerImpl.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/mockito/MockitoMockMakerImpl.java
@@ -16,16 +16,19 @@
 
 package org.spockframework.mock.runtime.mockito;
 
-import org.mockito.MockMakers;
+import org.codehaus.groovy.runtime.InvokerHelper;
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
 import org.mockito.MockitoFramework;
+import org.mockito.creation.instance.InstantiationException;
 import org.mockito.exceptions.base.MockitoException;
+import org.mockito.internal.util.MockUtil;
 import org.mockito.invocation.Invocation;
 import org.mockito.invocation.InvocationContainer;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.MockMaker;
+import org.mockito.plugins.MockitoPlugins;
 import org.spockframework.mock.CannotCreateMockException;
 import org.spockframework.mock.IMockObject;
 import org.spockframework.mock.ISpockMockObject;
@@ -35,8 +38,12 @@ import org.spockframework.mock.runtime.IProxyBasedMockInterceptor;
 import org.spockframework.util.ExceptionUtil;
 import org.spockframework.util.ReflectionUtil;
 import org.spockframework.util.ThreadSafe;
+import spock.mock.IMockMakerSettings;
 
 import java.lang.reflect.Method;
+
+import static java.util.Objects.requireNonNull;
+import static org.mockito.MockMakers.INLINE;
 
 @ThreadSafe
 class MockitoMockMakerImpl {
@@ -46,9 +53,36 @@ class MockitoMockMakerImpl {
   private final Method spockMockMethod;
 
   MockitoMockMakerImpl() {
+    inlineMockMaker = resolveInlineMockMaker();
+    spockMockMethod = ReflectionUtil.getMethodByName(ISpockMockObject.class, "$spock_get");
+  }
+
+  /**
+   * Resolves the inline mock maker of Mockito, via different ways, depending on the Mockito version.
+   *
+   * @return The inline mock maker of Mockito
+   */
+  private MockMaker resolveInlineMockMaker() {
     MockitoFramework framework = Mockito.framework();
-    this.inlineMockMaker = framework.getPlugins().getInlineMockMaker();
-    this.spockMockMethod = ReflectionUtil.getMethodByName(ISpockMockObject.class, "$spock_get");
+    MockitoPlugins plugins = framework.getPlugins();
+    try {
+      //First: Try to retrieve the inline mockMaker used by Mockito >= 5.6.0 public API, to share the same mocking state.
+      MockMaker mockMaker = (MockMaker) InvokerHelper.invokeMethod(plugins, "getMockMaker", INLINE);
+      return requireNonNull(mockMaker);
+
+    } catch (Exception ignored) {
+      try {
+        //Second: Try to retrieve the inline mockMaker used by Mockito < 5.6.0 with private method, to share the same mocking state.
+        MockMaker mockMaker = (MockMaker) InvokerHelper.invokeStaticMethod(MockUtil.class, "getMockMaker", INLINE);
+        return requireNonNull(mockMaker);
+
+      } catch (Exception ignored2) {
+        //Fallback: Use our own InlineMockMaker instance from the Mockito public plugin API, but this will degrade the interoperability with Mockito static mocks.
+        //The own InlineMockMaker created here, does not share its state with the Mockito mock maker.
+        //It will work for all features, but if a class is mocked with both mock makers, it will yield strange behavior.
+        return plugins.getInlineMockMaker();
+      }
+    }
   }
 
   IMockObject asMockOrNull(Object object) {
@@ -64,7 +98,7 @@ class MockitoMockMakerImpl {
   Object makeMock(IMockMaker.IMockCreationSettings settings) throws CannotCreateMockException {
     try {
       MockSettings mockitoSettings = Mockito.withSettings();
-      mockitoSettings.mockMaker(MockMakers.INLINE);
+      mockitoSettings.mockMaker(INLINE);
       if (!settings.getAdditionalInterface().isEmpty()) {
         mockitoSettings.extraInterfaces(settings.getAdditionalInterface().toArray(CLASS_ARRAY));
       }
@@ -85,12 +119,12 @@ class MockitoMockMakerImpl {
 
       return inlineMockMaker.createMock(mockitoCreationSettings, handler);
     } catch (MockitoException ex) {
-      throw new CannotCreateMockException(settings.getMockType(), " with " + MockitoMockMaker.ID + ": " + ex.getMessage().trim(), ex);
+      throw cannotCreateMockException(settings.getMockType(), ex);
     }
   }
 
   private static void applyMockMakerSettingsFromUser(IMockMaker.IMockCreationSettings settings, MockSettings mockitoSettings) {
-    IMockMaker.IMockMakerSettings mockMakerSettings = settings.getMockMakerSettings();
+    IMockMakerSettings mockMakerSettings = settings.getMockMakerSettings();
     if (mockMakerSettings instanceof MockitoMockMakerSettings) {
       MockitoMockMakerSettings mockitoMakerSettings = (MockitoMockMakerSettings) mockMakerSettings;
       mockitoMakerSettings.applySettings(mockitoSettings);
@@ -105,7 +139,20 @@ class MockitoMockMakerImpl {
     return result::nonMockableReason;
   }
 
-  static class SpockMockHandler implements MockHandler<Object> {
+  private static CannotCreateMockException cannotCreateMockException(Class<?> mockType, MockitoException ex) {
+    final String mockitoMessage = extractMockitoExceptionMessage(ex);
+    return new CannotCreateMockException(mockType, " with " + MockitoMockMaker.ID + ": " + mockitoMessage, ex);
+  }
+
+  private static String extractMockitoExceptionMessage(MockitoException ex) {
+    Throwable exToUse = ex;
+    if (ex.getCause() instanceof InstantiationException) {
+      exToUse = ex.getCause();
+    }
+    return exToUse.getMessage().trim();
+  }
+
+  private static final class SpockMockHandler implements MockHandler<Object> {
     private final IProxyBasedMockInterceptor mockInterceptor;
 
     public SpockMockHandler(IProxyBasedMockInterceptor mockInterceptor) {

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/mockito/MockitoMockMakerSettings.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/mockito/MockitoMockMakerSettings.java
@@ -18,15 +18,15 @@ package org.spockframework.mock.runtime.mockito;
 
 import groovy.lang.Closure;
 import org.mockito.MockSettings;
-import org.spockframework.mock.runtime.IMockMaker;
+import spock.mock.IMockMakerSettings;
+import spock.mock.MockMakerId;
 import org.spockframework.runtime.GroovyRuntimeUtil;
 import spock.mock.MockMakers;
 
 import static java.util.Objects.requireNonNull;
-import static org.spockframework.mock.runtime.IMockMaker.MockMakerId;
 import static org.spockframework.util.ObjectUtil.uncheckedCast;
 
-public final class MockitoMockMakerSettings implements IMockMaker.IMockMakerSettings {
+public final class MockitoMockMakerSettings implements IMockMakerSettings {
   private final Closure<?> mockitoCode;
 
   public static MockitoMockMakerSettings createSettings(Closure<?> mockitoCode) {

--- a/spock-core/src/main/java/spock/mock/IMockMakerSettings.java
+++ b/spock-core/src/main/java/spock/mock/IMockMakerSettings.java
@@ -1,0 +1,45 @@
+package spock.mock;
+
+import groovy.lang.Closure;
+import org.spockframework.mock.runtime.IMockMaker;
+import org.spockframework.util.Beta;
+
+/**
+ * Settings passed to the {@link IMockMaker} and created explicitly for the requested mock maker.
+ * The user will create such an instance at the mocking site:
+ *
+ * <p>{@code Mock(mockMaker: yourMockSettings { yourProperty = true }, ClassToMock)}
+ *
+ * <p>The {@link IMockMaker} should define a static constant or method (see {@link MockMakers}),
+ * which let the user construct a custom {@link IMockMakerSettings}.
+ *
+ * <p>If you provide a method, you can define your settings in a typesafe manner for the user,
+ * e.g. with a {@link Closure} parameter to configure the mock.
+ *
+ * @since 2.4
+ */
+@Beta
+public interface IMockMakerSettings {
+
+  /**
+   * Creates a default {@code IMockMakerSettings} object with only an {@link MockMakerId}.
+   *
+   * @param id the mock maker ID.
+   * @return the settings object
+   */
+  static IMockMakerSettings settingsFor(MockMakerId id) {
+    return new IMockMakerSettings() {
+      @Override
+      public MockMakerId getMockMakerId() {
+        return id;
+      }
+
+      @Override
+      public String toString() {
+        return id + " default mock maker settings";
+      }
+    };
+  }
+
+  MockMakerId getMockMakerId();
+}

--- a/spock-core/src/main/java/spock/mock/MockMakerId.java
+++ b/spock-core/src/main/java/spock/mock/MockMakerId.java
@@ -1,0 +1,56 @@
+package spock.mock;
+
+import org.spockframework.mock.runtime.IMockMaker;
+import org.spockframework.util.Beta;
+import org.spockframework.util.Checks;
+import org.spockframework.util.Immutable;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Represents the ID of an {@link IMockMaker}.
+ *
+ * @since 2.4
+ */
+@Immutable
+@Beta
+public final class MockMakerId implements Comparable<MockMakerId> {
+  private static final Pattern VALID_ID = Pattern.compile("^[a-z][a-z0-9-]*+(?<!-)$");
+  private final String id;
+
+  public MockMakerId(String id) {
+    Checks.notNull(id, () -> "The ID is null.");
+    Checks.checkArgument(VALID_ID.matcher(id).matches(), () ->
+"The ID '" + id + "' is invalid. A valid ID must comply with the pattern: " + VALID_ID);
+
+    this.id = id;
+  }
+
+  @Override
+  public int compareTo(MockMakerId o) {
+    return this.id.compareTo(o.id);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MockMakerId that = (MockMakerId) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public String toString() {
+    return id;
+  }
+}

--- a/spock-core/src/main/java/spock/mock/MockMakers.java
+++ b/spock-core/src/main/java/spock/mock/MockMakers.java
@@ -30,7 +30,7 @@ import org.spockframework.mock.runtime.mockito.MockitoMockMakerSettings;
 
 import java.lang.reflect.Proxy;
 
-import static org.spockframework.mock.runtime.IMockMaker.IMockMakerSettings.simple;
+import static spock.mock.IMockMakerSettings.settingsFor;
 
 /**
  * Provides constants and factory methods for known built-in {@link IMockMaker} implementations.
@@ -55,7 +55,7 @@ public final class MockMakers {
    * <li>{@code EXPLICIT_CONSTRUCTOR_ARGUMENTS}</li>
    * </ul>
    */
-  public static final IMockMaker.IMockMakerSettings byteBuddy = simple(ByteBuddyMockMaker.ID);
+  public static final IMockMakerSettings byteBuddy = settingsFor(ByteBuddyMockMaker.ID);
 
   /**
    * Uses <a href="https://github.com/cglib/cglib">CGLIB</a> to create mocks.
@@ -68,7 +68,7 @@ public final class MockMakers {
    * <li>{@code EXPLICIT_CONSTRUCTOR_ARGUMENTS}</li>
    * </ul>
    */
-  public static final IMockMaker.IMockMakerSettings cglib = simple(CglibMockMaker.ID);
+  public static final IMockMakerSettings cglib = settingsFor(CglibMockMaker.ID);
 
   /**
    * Uses the Java {@link Proxy} API to create mocks of interfaces.
@@ -79,7 +79,7 @@ public final class MockMakers {
    * <li>{@code ADDITIONAL_INTERFACES}</li>
    * </ul>
    */
-  public static final IMockMaker.IMockMakerSettings javaProxy = simple(JavaProxyMockMaker.ID);
+  public static final IMockMakerSettings javaProxy = settingsFor(JavaProxyMockMaker.ID);
 
   /**
    * Uses <a href="https://site.mockito.org/">Mockito</a> to create mocks,
@@ -97,7 +97,7 @@ public final class MockMakers {
    * <p>It uses {@link org.mockito.MockMakers#INLINE} under the hood,
    * please see the Mockito manual for all pros and cons, when using {@code MockMakers.INLINE}.
    */
-  public static final IMockMaker.IMockMakerSettings mockito = simple(MockitoMockMaker.ID);
+  public static final IMockMakerSettings mockito = settingsFor(MockitoMockMaker.ID);
 
   /**
    * Uses <a href="https://site.mockito.org/">Mockito</a> to create mocks,
@@ -117,9 +117,9 @@ public final class MockMakers {
    *
    * @param settingsCode the code to execute to configure {@link MockSettings} for further configuration of the mock to create
    */
-  public static IMockMaker.IMockMakerSettings mockito(@DelegatesTo(type = "org.mockito.MockSettings", strategy = Closure.DELEGATE_FIRST)
-                                                      @ClosureParams(value = SimpleType.class, options = "org.mockito.MockSettings")
-                                                            Closure<?> settingsCode) {
+  public static IMockMakerSettings mockito(@DelegatesTo(type = "org.mockito.MockSettings", strategy = Closure.DELEGATE_FIRST)
+                                           @ClosureParams(value = SimpleType.class, options = "org.mockito.MockSettings")
+                                           Closure<?> settingsCode) {
     return MockitoMockMakerSettings.createSettings(settingsCode);
   }
 }

--- a/spock-core/src/main/java/spock/mock/MockingApi.java
+++ b/spock-core/src/main/java/spock/mock/MockingApi.java
@@ -173,7 +173,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options) {
     invalidMockCreation();
@@ -226,7 +226,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
@@ -288,7 +288,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
     Map<String, Object> options,
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
@@ -357,7 +357,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @DelegatesTo.Target
@@ -409,7 +409,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options) {
     invalidMockCreation();
@@ -463,7 +463,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
@@ -525,7 +525,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
@@ -594,7 +594,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @DelegatesTo.Target
@@ -646,7 +646,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options) {
     invalidMockCreation();
@@ -759,7 +759,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
@@ -819,7 +819,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
@@ -887,7 +887,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "defaultResponse", type = IDefaultResponse.class),
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @DelegatesTo.Target
@@ -940,7 +940,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options) {
     invalidMockCreation();
@@ -993,7 +993,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
@@ -1056,7 +1056,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
@@ -1126,7 +1126,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @DelegatesTo.Target
@@ -1179,7 +1179,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options) {
     invalidMockCreation();
@@ -1232,7 +1232,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
@@ -1295,7 +1295,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
@@ -1365,7 +1365,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @DelegatesTo.Target
@@ -1418,7 +1418,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options) {
     invalidMockCreation();
@@ -1471,7 +1471,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options, Class<T> type) {
     invalidMockCreation();
@@ -1532,7 +1532,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
@@ -1601,7 +1601,7 @@ public class MockingApi extends SpecInternals implements MockFactory {
       @NamedParam(value = "verified", type = Boolean.class),
       @NamedParam(value = "useObjenesis", type = Boolean.class),
       @NamedParam(value = "global", type = Boolean.class),
-      @NamedParam(value = "mockMaker", type = IMockMaker.IMockMakerSettings.class)
+      @NamedParam(value = "mockMaker", type = IMockMakerSettings.class)
     })
       Map<String, Object> options,
     @DelegatesTo.Target

--- a/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
+++ b/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
@@ -21,6 +21,8 @@ import org.spockframework.runtime.GroovyRuntimeUtil;
 import org.spockframework.runtime.SpockTimeoutError;
 import org.spockframework.util.Beta;
 
+import java.util.Locale;
+
 /**
  * Repeatedly evaluates one or more conditions until they are satisfied or a timeout has elapsed.
  * The timeout and delays between evaluation attempts are configurable. All durations are in seconds.
@@ -130,7 +132,7 @@ public class PollingConditions {
   }
 
   /**
-   * Sets the closure that is evaluated when a timeout is reached. 
+   * Sets the closure that is evaluated when a timeout is reached.
    * <p>
    * The closure can use a {@link Throwable} as an input parameter,
    * which is thrown by the test conditions when a timeout is reached. The result of this
@@ -197,9 +199,9 @@ public class PollingConditions {
       }
     }
 
-    String msg = String.format("Condition not satisfied after %1.2f seconds and %d attempts", elapsedTime / 1000d, attempts);
+    String msg = String.format(Locale.ENGLISH, "Condition not satisfied after %1.2f seconds and %d attempts", elapsedTime / 1000d, attempts);
     if (timeoutMessage != null) {
-      msg = String.format("%s: %s", msg, GroovyRuntimeUtil.invokeClosure(timeoutMessage, testException));
+      msg = String.format(Locale.ENGLISH, "%s: %s", msg, GroovyRuntimeUtil.invokeClosure(timeoutMessage, testException));
     }
     throw new SpockTimeoutError(seconds, msg, testException);
   }

--- a/spock-specs/mock-integration/mock-integration.gradle
+++ b/spock-specs/mock-integration/mock-integration.gradle
@@ -30,9 +30,28 @@ def codeGenerationLibraries = [
   mockito4 : configurations.mockito4
 ]
 
-if (rootProject.javaVersion >= 11) {
+def javaVersion = rootProject.javaVersion
+
+if (javaVersion >= 11) {
   //Mockito 5 requires at least Java 11 to run
   codeGenerationLibraries.put("mockito5", configurations.mockito5)
+}
+
+def configureTaskFilters = { String key, Test t ->
+  if (key == "cglib") {
+    if (javaVersion >= 17) {
+      t.jvmArgs(
+        //cglib requires access to java.lang.ClassLoader.defineClass() from net.sf.cglib.core.ReflectUtils
+        "--add-opens=java.base/java.lang=ALL-UNNAMED"
+      )
+
+      //Cglib does not support Java 21 anymore
+      t.onlyIf { javaVersion < 21 }
+    }
+  } else if (key == "mockito4") {
+    //Mockito 4 or to be more specific the old byte-buddy version used by mockito 4 does not support Java 21
+    t.onlyIf { javaVersion < 21 }
+  }
 }
 
 codeGenerationLibraries.each { key, config ->
@@ -40,38 +59,15 @@ codeGenerationLibraries.each { key, config ->
     systemProperty("org.spockframework.mock.testType", "${key.toLowerCase()} - objenesis")
     classpath += config
 
-    if (key == "cglib") {
-      if (rootProject.javaVersion >= 17) {
-        jvmArgs(
-          //cglib requires access to java.lang.ClassLoader.defineClass() from net.sf.cglib.core.ReflectUtils
-          "--add-opens=java.base/java.lang=ALL-UNNAMED"
-        )
-      }
-      onlyIf { rootProject.javaVersion < 21}
-    }
-    if (key == "mockito4") {
-      // mockito4 only supports up to Java 20
-      onlyIf { rootProject.javaVersion < 21}
-    }
+    configureTaskFilters(key, it)
   }
+
   tasks.register("test${key.capitalize()}WithObjenesis", Test) {
     systemProperty("org.spockframework.mock.testType", "${key.toLowerCase()} + objenesis")
     classpath += config
     classpath += configurations.objenesis
 
-    if (key == "cglib") {
-      if (rootProject.javaVersion >= 17) {
-        jvmArgs(
-          //cglib requires access to java.lang.ClassLoader.defineClass() from net.sf.cglib.core.ReflectUtils
-          "--add-opens=java.base/java.lang=ALL-UNNAMED"
-        )
-      }
-      onlyIf { rootProject.javaVersion < 21}
-    }
-    if (key == "mockito4") {
-      // mockito4 only supports up to Java 20
-      onlyIf { rootProject.javaVersion < 21}
-    }
+    configureTaskFilters(key, it)
   }
 }
 

--- a/spock-specs/mock-integration/src/test/groovy/MockingIntegrationSpec.groovy
+++ b/spock-specs/mock-integration/src/test/groovy/MockingIntegrationSpec.groovy
@@ -121,6 +121,7 @@ class MockingIntegrationSpec extends Specification {
 
     when:
     mock.run()
+
     then:
     1 * mock.run()
   }
@@ -128,10 +129,18 @@ class MockingIntegrationSpec extends Specification {
   @Requires({ TEST_TYPE.startsWith("mockito") })
   def "mockito - test mocking final class"() {
     given:
-    StringBuilder mock = Mock(mockMaker: MockMakers.mockito)
+    FinalClass mock = Mock(mockMaker: MockMakers.mockito)
+
     when:
-    mock.append(1)
+    mock.method()
+
     then:
-    1 * mock.append(1)
+    1 * mock.method()
+  }
+
+  private static final class FinalClass {
+
+    void method() {
+    }
   }
 }

--- a/spock-specs/specs.gradle
+++ b/spock-specs/specs.gradle
@@ -39,6 +39,7 @@ dependencies {
     testRuntimeOnly libs.mockito5
   } else {
     testRuntimeOnly libs.mockito4
+    testRuntimeOnly libs.mockito4inline
   }
 
   groovyConsole groovyConsoleExtraDependencies

--- a/spock-specs/src/test/groovy/org/spockframework/docs/extension/FancyMockMaker.java
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/extension/FancyMockMaker.java
@@ -19,6 +19,8 @@ package org.spockframework.docs.extension;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.spockframework.mock.runtime.IMockMaker;
+import spock.mock.IMockMakerSettings;
+import spock.mock.MockMakerId;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -76,7 +78,7 @@ public final class FancyMockMaker implements IMockMaker {
   }
 }
 
-final class FancyMockMakerSettings implements IMockMaker.IMockMakerSettings {
+final class FancyMockMakerSettings implements IMockMakerSettings {
   private boolean serialization;
   private final List<Type> specialTypes = new ArrayList<>();
 
@@ -92,7 +94,7 @@ final class FancyMockMakerSettings implements IMockMaker.IMockMakerSettings {
   }
 
   @Override
-  public IMockMaker.MockMakerId getMockMakerId() {
+  public MockMakerId getMockMakerId() {
     return FancyMockMaker.ID;
   }
 
@@ -109,7 +111,7 @@ final class FancyMockMakers {
   /**
    * Public static entry point for the User.
    */
-  public static IMockMaker.IMockMakerSettings fancyMock(
+  public static IMockMakerSettings fancyMock(
     @DelegatesTo(FancyMockMakerSettings.class)
     Closure<?> code) {
     FancyMockMakerSettings settings = new FancyMockMakerSettings();

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockFactoryConcurrentSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockFactoryConcurrentSpec.groovy
@@ -17,7 +17,7 @@
 package org.spockframework.mock.runtime
 
 import groovy.transform.Canonical
-import spock.lang.Retry
+import spock.lang.Isolated
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Timeout
@@ -27,6 +27,7 @@ import java.util.concurrent.Phaser
 import java.util.concurrent.TimeUnit
 import java.util.function.Function
 
+@Isolated("Run isolated, to prevent the test to be flaky under load")
 class ByteBuddyMockFactoryConcurrentSpec extends Specification {
   private static final String IfA = "IfA"
   private static final String IfB = "IfB"

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockMakerSpec.groovy
@@ -29,7 +29,7 @@ class ByteBuddyMockMakerSpec extends Specification {
   def "Verify ID and IMockMakerSettings"() {
     expect:
     MockMakers.byteBuddy.mockMakerId.toString() == "byte-buddy"
-    MockMakers.byteBuddy.toString() == "byte-buddy simple mock maker settings"
+    MockMakers.byteBuddy.toString() == "byte-buddy default mock maker settings"
   }
 
   def "Use specific MockMaker byteBuddy"() {

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/CglibMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/CglibMockMakerSpec.groovy
@@ -36,7 +36,7 @@ class CglibMockMakerSpec extends Specification {
   def "Verify ID and IMockMakerSettings"() {
     expect:
     MockMakers.cglib.mockMakerId.toString() == "cglib"
-    MockMakers.cglib.toString() == "cglib simple mock maker settings"
+    MockMakers.cglib.toString() == "cglib default mock maker settings"
   }
 
   def "Use specific MockMaker cglib"() {

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/JavaProxyMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/JavaProxyMockMakerSpec.groovy
@@ -27,7 +27,7 @@ class JavaProxyMockMakerSpec extends Specification {
   def "Verify ID and IMockMakerSettings"() {
     expect:
     MockMakers.javaProxy.mockMakerId.toString() == "java-proxy"
-    MockMakers.javaProxy.toString() == "java-proxy simple mock maker settings"
+    MockMakers.javaProxy.toString() == "java-proxy default mock maker settings"
   }
 
   def "Use specific MockMaker javaProxy"() {

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/MockMakerRegistrySpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/MockMakerRegistrySpec.groovy
@@ -23,14 +23,14 @@ import org.spockframework.runtime.RunContext
 import org.spockframework.util.InternalSpockError
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.mock.IMockMakerSettings
+import spock.mock.MockMakerId
 import spock.mock.MockMakers
 
 import java.util.concurrent.Callable
 
-import static org.spockframework.mock.runtime.IMockMaker.MockMakerId
 import static org.spockframework.mock.runtime.IMockMaker.MockMakerCapability
 import static org.spockframework.mock.runtime.IMockMaker.IMockCreationSettings
-import static org.spockframework.mock.runtime.IMockMaker.IMockMakerSettings
 import static org.spockframework.mock.runtime.IMockMaker.IMockabilityResult
 
 class MockMakerRegistrySpec extends Specification {
@@ -161,7 +161,7 @@ class MockMakerRegistrySpec extends Specification {
     }
     def cglib = new CglibMockMaker()
     when:
-    def r = new MockMakerRegistry([mockSamePriorityProxy, byteBuddy, cglib, sampleMockMaker, proxy], IMockMakerSettings.simple(TEST_ID))
+    def r = new MockMakerRegistry([mockSamePriorityProxy, byteBuddy, cglib, sampleMockMaker, proxy], IMockMakerSettings.settingsFor(TEST_ID))
     then:
     r.makerList == [sampleMockMaker, proxy, byteBuddy, mockSamePriorityProxy, cglib]
   }
@@ -197,7 +197,7 @@ class MockMakerRegistrySpec extends Specification {
 
   def "Mock with unknown MockMaker"() {
     when:
-    Mock(mockMaker: IMockMakerSettings.simple(new MockMakerId("unknown")), Runnable)
+    Mock(mockMaker: IMockMakerSettings.settingsFor(new MockMakerId("unknown")), Runnable)
     then:
     CannotCreateMockException ex = thrown()
     ex.message == "Cannot create mock for interface java.lang.Runnable because MockMaker with ID 'unknown' does not exist."

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/mockito/MockitoMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/mockito/MockitoMockMakerSpec.groovy
@@ -39,7 +39,7 @@ class MockitoMockMakerSpec extends Specification {
   def "Verify simple ID and IMockMakerSettings"() {
     expect:
     mockito.mockMakerId.toString() == ID
-    mockito.toString() == "$ID simple mock maker settings"
+    mockito.toString() == "$ID default mock maker settings"
   }
 
   def "Verify ID and IMockMakerSettings with Mockito settings"() {
@@ -179,6 +179,16 @@ class MockitoMockMakerSpec extends Specification {
     then:
     spy != startList
     spy.size() == 0
+  }
+
+  def "Fails to construct object without default constructor"() {
+    when:
+    Spy(FileInputStream, mockMaker: mockito, useObjenesis: false)
+
+    then:
+    CannotCreateMockException ex = thrown()
+    ex.message == """Cannot create mock for class java.io.FileInputStream with mockito: Unable to create instance of 'FileInputStream'.
+Please ensure that the target class has a 0-arg constructor."""
   }
 
   def "Additional interfaces"() {
@@ -437,6 +447,14 @@ Can not mock final classes with the following settings :
     then:
     CannotCreateMockException ex = thrown()
     ex.message == "Cannot create mock for class java.lang.Class. mockito: Cannot mock wrapper types, String.class or Class.class"
+  }
+
+  def "mockito mock setting without mockito settings shall not fail"() {
+    when:
+    Runnable mock = Mock(mockMaker: mockito {})
+
+    then:
+    mock != null
   }
 }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaSpies.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaSpies.groovy
@@ -15,6 +15,7 @@
 package org.spockframework.smoke.mock
 
 import org.spockframework.mock.CannotCreateMockException
+import org.spockframework.runtime.InvalidSpecException
 import org.spockframework.runtime.SpockException
 import org.spockframework.util.SpockDocLinks
 import spock.lang.*
@@ -192,6 +193,15 @@ class JavaSpies extends Specification {
     person.phoneNumber == "6789"
   }
 
+  def "can spy final methods with mockito with closure"() {
+    FinalMethodPerson person = Spy(mockMaker: MockMakers.mockito) {
+      phoneNumber >> 6789
+    }
+
+    expect:
+    person.phoneNumber == "6789"
+  }
+
   def "cannot spy final methods with byteBuddy"() {
     FinalMethodPerson person = Spy(mockMaker: MockMakers.byteBuddy)
     person.phoneNumber >> 6789
@@ -254,6 +264,22 @@ class JavaSpies extends Specification {
     CannotCreateMockException e = thrown()
     e.message == "Cannot create mock for class java.util.ArrayList. Cannot copy fields.\n" +
       SpockDocLinks.SPY_ON_JAVA_17.link
+  }
+
+  def "no static type specified"() {
+    when:
+    Stub()
+    then:
+    InvalidSpecException ex = thrown()
+    ex.message == "Mock object type cannot be inferred automatically. Please specify a type explicitly (e.g. 'Mock(Person)')."
+  }
+
+  def "specified instance is null"() {
+    when:
+    Spy((Object) null)
+    then:
+    SpockException ex = thrown()
+    ex.message == "Spy instance may not be null"
   }
 
   static class Constructable {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaStubs.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaStubs.groovy
@@ -141,6 +141,25 @@ class JavaStubs extends Specification {
     person.phoneNumber == "6789"
   }
 
+  def "can stub final methods with mockito with closure"() {
+    given:
+    FinalMethodPerson person = Stub(mockMaker: MockMakers.mockito) {
+      phoneNumber >> 6789
+    }
+
+    expect:
+    person.phoneNumber == "6789"
+  }
+
+  def "can stub final methods with mockito with closure and specified type"() {
+    FinalMethodPerson person = Stub(FinalMethodPerson, mockMaker: MockMakers.mockito) {
+      phoneNumber >> 6789
+    }
+
+    expect:
+    person.phoneNumber == "6789"
+  }
+
   def "cannot stub final methods with byteBuddy"() {
     FinalMethodPerson person = Stub(mockMaker: MockMakers.byteBuddy)
     person.phoneNumber >> 6789
@@ -164,6 +183,15 @@ class JavaStubs extends Specification {
     then:
     CannotCreateMockException e = thrown()
     e.message.contains("global")
+  }
+
+  def "no static type specified"() {
+    when:
+    Stub()
+
+    then:
+    InvalidSpecException ex = thrown()
+    ex.message == "Mock object type cannot be inferred automatically. Please specify a type explicitly (e.g. 'Mock(Person)')."
   }
 
   interface IPerson {

--- a/spock-specs/src/test/groovy/spock/mock/MockMakerIdSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/mock/MockMakerIdSpec.groovy
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-package org.spockframework.mock.runtime
+package spock.mock
 
 import spock.lang.Specification
-
-import static org.spockframework.mock.runtime.IMockMaker.MockMakerId
 
 class MockMakerIdSpec extends Specification {
 
@@ -37,11 +35,11 @@ class MockMakerIdSpec extends Specification {
     where:
     input          | expectedErrorMessage
     null           | "The ID is null."
-    ""             | "The ID is empty."
-    "with space"   | "The ID 'with space' is invalid. Valid id must comply to the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
-    "UpperCase"    | "The ID 'UpperCase' is invalid. Valid id must comply to the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
-    "0numberStart" | "The ID '0numberStart' is invalid. Valid id must comply to the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
-    "half-kebab-"  | "The ID 'half-kebab-' is invalid. Valid id must comply to the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
+    ""             | "The ID '' is invalid. A valid ID must comply with the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
+    "with space"   | "The ID 'with space' is invalid. A valid ID must comply with the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
+    "UpperCase"    | "The ID 'UpperCase' is invalid. A valid ID must comply with the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
+    "0numberStart" | "The ID '0numberStart' is invalid. A valid ID must comply with the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
+    "half-kebab-"  | "The ID 'half-kebab-' is invalid. A valid ID must comply with the pattern: ^[a-z][a-z0-9-]*+(?<!-)\$"
   }
 
   def "Equals/hashcode"() {


### PR DESCRIPTION
Moved MockMakerId to spock.mock package.
Added release notes for mock maker feature.

Try to ease flaky InvokingMocksFromMultipleThreads spec

PollingConditions change: Fix failing test when tests are executed with non english locale.
The formatting of the elapsedTime would not match the pattern in the test.
