### PR TITLE
Support mocking of classes from different classloaders

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -10,6 +10,7 @@ include::include.adoc[]
 ** You can select the used mock maker during mock creation: `Mock(mockMaker:MockMakers.byteBuddy)`
 * Added <<extensions.adoc#mock-makers-mockito,mockito>> mock maker spockPull:1753[] which supports:
 ** Mocking of final classes and final methods
+** Mocking of classes and interface from different classloaders spockPull:1878[]
 ** Requires `org.mockito:mockito-core` >= 4.11 in the test class path
 * Fix issue with mocks of Groovy classes, where the Groovy MOP for `@Internal` methods was not honored by the `byte-buddy` mock maker spockPull:1729[]
 ** This fixes multiple issues with Groovy MOP: spockIssue:1501[], spockIssue:1452[], spockIssue:1608[] and spockIssue:1145[]

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockMaker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockMaker.java
@@ -71,6 +71,6 @@ public class ByteBuddyMockMaker implements IMockMaker {
     if (!byteBuddyAvailable) {
       return () -> "The byte-buddy library is missing on the class path.";
     }
-    return IMockabilityResult.MOCKABLE;
+    return JavaProxyMockMaker.checkMockClassesAreVisibleInClassloader(settings);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/CglibMockMaker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/CglibMockMaker.java
@@ -65,6 +65,6 @@ public class CglibMockMaker implements IMockMaker {
     if(Jvm.getCurrent().isJava21Compatible()){
       return () -> "Mocking with cglib is not supported on Java 21 or newer.";
     }
-    return IMockabilityResult.MOCKABLE;
+    return JavaProxyMockMaker.checkMockClassesAreVisibleInClassloader(settings);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
@@ -314,4 +314,30 @@ public abstract class ReflectionUtil {
     }
     return object;
   }
+
+  /**
+   * Checks if the {@code classToCheck} is visible by the passed {@code classLoader}
+   *
+   * @param classToCheck the class to check
+   * @param classLoader  the classLoader
+   * @return {@code true} if the class is visible
+   */
+  public static boolean isClassVisibleInClassloader(Class<?> classToCheck, ClassLoader classLoader) {
+    try {
+      if (classToCheck.getClassLoader() == null) {
+        //Classes from the bootstrap classloader are always visible
+        return true;
+      }
+      if (classToCheck.getClassLoader() == classLoader) {
+        return true;
+      }
+      Class<?> loadedClass = classLoader.loadClass(classToCheck.getName());
+      if (loadedClass == classToCheck) {
+        return true;
+      }
+    } catch (ClassNotFoundException ignored) {
+      //Ignored
+    }
+    return false;
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockMakerSpec.groovy
@@ -124,6 +124,30 @@ class ByteBuddyMockMakerSpec extends Specification {
     then:
     s.stringField == "data"
   }
+
+  def "Mocking interface from different classloader shall fail for byteBuddy MockMaker"() {
+    given:
+    def tempClassLoader = new ByteBuddyTestClassLoader()
+    def interfaceClass = tempClassLoader.defineInterface("Interface")
+
+    when:
+    Mock(interfaceClass, mockMaker: MockMakers.byteBuddy)
+    then:
+    CannotCreateMockException ex = thrown()
+    ex.message.startsWith("Cannot create mock for interface Interface. byte-buddy: The class Interface is not visible by the classloader")
+  }
+
+  def "Mocking with additional interface from different classloader shall fail for byteBuddy MockMaker"() {
+    given:
+    def tempClassLoader = new ByteBuddyTestClassLoader()
+    def additionalInterfaceClass = tempClassLoader.defineInterface("AdditionalInterface")
+
+    when:
+    Mock(Runnable, mockMaker: MockMakers.byteBuddy, additionalInterfaces: [additionalInterfaceClass])
+    then:
+    CannotCreateMockException ex = thrown()
+    ex.message.startsWith("Cannot create mock for interface java.lang.Runnable. byte-buddy: The class AdditionalInterface is not visible by the classloader")
+  }
 }
 
 @SuppressWarnings('unused')

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockMakerSpec.groovy
@@ -132,6 +132,7 @@ class ByteBuddyMockMakerSpec extends Specification {
 
     when:
     Mock(interfaceClass, mockMaker: MockMakers.byteBuddy)
+    
     then:
     CannotCreateMockException ex = thrown()
     ex.message.startsWith("Cannot create mock for interface Interface. byte-buddy: The class Interface is not visible by the classloader")
@@ -144,6 +145,7 @@ class ByteBuddyMockMakerSpec extends Specification {
 
     when:
     Mock(Runnable, mockMaker: MockMakers.byteBuddy, additionalInterfaces: [additionalInterfaceClass])
+
     then:
     CannotCreateMockException ex = thrown()
     ex.message.startsWith("Cannot create mock for interface java.lang.Runnable. byte-buddy: The class AdditionalInterface is not visible by the classloader")

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyTestClassLoader.java
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyTestClassLoader.java
@@ -23,7 +23,7 @@ import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import java.util.HashMap;
 import java.util.Map;
 
-final class ByteBuddyTestClassLoader extends ClassLoader {
+public final class ByteBuddyTestClassLoader extends ClassLoader {
   private final Map<String, Class<?>> cache = new HashMap<>();
 
   private final ClassLoadingStrategy<ByteBuddyTestClassLoader> loadingStrategy = (loader, types) -> {
@@ -38,12 +38,24 @@ final class ByteBuddyTestClassLoader extends ClassLoader {
   };
 
   /**
+   * Creates a new {@link ByteBuddyTestClassLoader} and defines an interface with the passed name.
+   *
+   * @param name the interface name
+   * @return the classloader
+   */
+  public static ByteBuddyTestClassLoader withInterface(String name) {
+    ByteBuddyTestClassLoader cl = new ByteBuddyTestClassLoader();
+    cl.defineInterface(name);
+    return cl;
+  }
+
+  /**
    * Defines an empty interface with the passed {@code node}.
    *
    * @param name the name of the interface
    * @return the loaded {@code Class}
    */
-  synchronized Class<?> defineInterface(String name) {
+  public synchronized Class<?> defineInterface(String name) {
     //noinspection resource
     return cache.computeIfAbsent(name, nameKey -> new ByteBuddy()
       .makeInterface()

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/JavaProxyMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/JavaProxyMockMakerSpec.groovy
@@ -61,6 +61,7 @@ class JavaProxyMockMakerSpec extends Specification {
 
     when:
     Mock(interfaceClass, mockMaker: MockMakers.javaProxy)
+
     then:
     CannotCreateMockException ex = thrown()
     ex.message.startsWith("Cannot create mock for interface Interface. java-proxy: The class Interface is not visible by the classloader")
@@ -73,6 +74,7 @@ class JavaProxyMockMakerSpec extends Specification {
 
     when:
     Mock(Runnable, mockMaker: MockMakers.javaProxy, additionalInterfaces: [additionalInterfaceClass])
+
     then:
     CannotCreateMockException ex = thrown()
     ex.message.startsWith("Cannot create mock for interface java.lang.Runnable. java-proxy: The class AdditionalInterface is not visible by the classloader")

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/JavaProxyMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/JavaProxyMockMakerSpec.groovy
@@ -53,4 +53,28 @@ class JavaProxyMockMakerSpec extends Specification {
     CannotCreateMockException ex = thrown()
     ex.message == "Cannot create mock for interface java.lang.Runnable. java-proxy: Explicit constructor arguments are not supported."
   }
+
+  def "Mocking interface from different classloader shall fail for javaProxy MockMaker"() {
+    given:
+    def tempClassLoader = new ByteBuddyTestClassLoader()
+    def interfaceClass = tempClassLoader.defineInterface("Interface")
+
+    when:
+    Mock(interfaceClass, mockMaker: MockMakers.javaProxy)
+    then:
+    CannotCreateMockException ex = thrown()
+    ex.message.startsWith("Cannot create mock for interface Interface. java-proxy: The class Interface is not visible by the classloader")
+  }
+
+  def "Mocking with additional interface from different classloader shall fail for javaProxy MockMaker"() {
+    given:
+    def tempClassLoader = new ByteBuddyTestClassLoader()
+    def additionalInterfaceClass = tempClassLoader.defineInterface("AdditionalInterface")
+
+    when:
+    Mock(Runnable, mockMaker: MockMakers.javaProxy, additionalInterfaces: [additionalInterfaceClass])
+    then:
+    CannotCreateMockException ex = thrown()
+    ex.message.startsWith("Cannot create mock for interface java.lang.Runnable. java-proxy: The class AdditionalInterface is not visible by the classloader")
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/mockito/MockitoMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/mockito/MockitoMockMakerSpec.groovy
@@ -466,6 +466,7 @@ Can not mock final classes with the following settings :
 
     when:
     def m = Mock(interfaceClass, mockMaker: mockito)
+
     then:
     interfaceClass.isInstance(m)
     mockUtil.isMock(m)
@@ -479,11 +480,12 @@ Can not mock final classes with the following settings :
 
     when:
     def m = Mock(interfaceClass)
+
     then:
     interfaceClass.isInstance(m)
     mockUtil.isMock(m)
   }
-  
+
   def "Mocking with additional interface from different classloader works with mockito MockMaker"() {
     given:
     def mockUtil = new MockUtil()
@@ -492,6 +494,7 @@ Can not mock final classes with the following settings :
 
     when:
     Runnable m = Mock(mockMaker: mockito, additionalInterfaces: [additionalInterfaceClass])
+
     then:
     m instanceof Runnable
     additionalInterfaceClass.isInstance(m)

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/mockito/MockitoMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/mockito/MockitoMockMakerSpec.groovy
@@ -21,6 +21,7 @@ import org.mockito.Mockito
 import org.mockito.exceptions.base.MockitoException
 import org.spockframework.mock.CannotCreateMockException
 import org.spockframework.mock.MockUtil
+import org.spockframework.mock.runtime.ByteBuddyTestClassLoader
 import org.spockframework.runtime.GroovyRuntimeUtil
 import spock.lang.Issue
 import spock.lang.Requires
@@ -455,6 +456,46 @@ Can not mock final classes with the following settings :
 
     then:
     mock != null
+  }
+
+  def "Mocking interface from different classloader works with mockito MockMaker"() {
+    given:
+    def mockUtil = new MockUtil()
+    def tempClassLoader = new ByteBuddyTestClassLoader()
+    def interfaceClass = tempClassLoader.defineInterface("Interface")
+
+    when:
+    def m = Mock(interfaceClass, mockMaker: mockito)
+    then:
+    interfaceClass.isInstance(m)
+    mockUtil.isMock(m)
+  }
+
+  def "Mocking interface from different classloader works with default MockMaker"() {
+    given:
+    def mockUtil = new MockUtil()
+    def tempClassLoader = new ByteBuddyTestClassLoader()
+    def interfaceClass = tempClassLoader.defineInterface("Interface")
+
+    when:
+    def m = Mock(interfaceClass)
+    then:
+    interfaceClass.isInstance(m)
+    mockUtil.isMock(m)
+  }
+  
+  def "Mocking with additional interface from different classloader works with mockito MockMaker"() {
+    given:
+    def mockUtil = new MockUtil()
+    def tempClassLoader = new ByteBuddyTestClassLoader()
+    def additionalInterfaceClass = tempClassLoader.defineInterface("AdditionalInterface1")
+
+    when:
+    Runnable m = Mock(mockMaker: mockito, additionalInterfaces: [additionalInterfaceClass])
+    then:
+    m instanceof Runnable
+    additionalInterfaceClass.isInstance(m)
+    mockUtil.isMock(m)
   }
 }
 

--- a/spock-specs/src/test/groovy/org/spockframework/util/ReflectionUtilSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/ReflectionUtilSpec.groovy
@@ -15,6 +15,7 @@
 package org.spockframework.util
 
 import org.junit.platform.commons.annotation.Testable
+import org.spockframework.mock.runtime.ByteBuddyTestClassLoader
 import spock.lang.*
 
 import java.lang.annotation.Annotation
@@ -326,5 +327,19 @@ class ReflectionUtilSpec extends Specification {
   def "isToStringOverridden error"() {
     expect:
     !ReflectionUtil.isToStringOverridden(int.class)
+  }
+
+  def "isClassVisibleInClassloader"(Class<?> cls, ClassLoader loader, boolean expectedResult) {
+    expect:
+    ReflectionUtil.isClassVisibleInClassloader(cls, loader) == expectedResult
+
+    where:
+    cls        | loader                                                  | expectedResult
+    Runnable   | this.class.classLoader                                  | true
+    this.class | this.class.classLoader                                  | true
+    this.class | new URLClassLoader([] as URL[], this.class.classLoader) | true
+
+    this.class | new URLClassLoader([] as URL[], null as ClassLoader)    | false
+    this.class | ByteBuddyTestClassLoader.withInterface(this.class.name) | false
   }
 }


### PR DESCRIPTION
Now it is supported to mock classes and interfaces from different classloaders with the mockito mock maker.

The mock makers java-proxy, byte-buddy and cglib do not support that mode.

Previously the mocking failed, because the java-proxy and byte-budy mock maker would ave tried to load the different classes, 
but these would not be visible, if one if ther class or interface were not visible to the classloader used by the mock.