### PR TITLE
Fix preserving Mockito 4.x version by Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,12 @@
     // as we want to keep one for each major version.
     // The same applies for mockito as we test with both 4 and 5
     {
-      "matchPackagePrefixes": ["org.codehaus.groovy:", "org.apache.groovy:", "org.mockito:"],
+      matchPackagePrefixes: ["org.mockito:"],
+      matchCurrentValue: "/^4\\./",
+      allowedVersions: "(,5.0)"
+    },
+    {
+      "matchPackagePrefixes": ["org.codehaus.groovy:", "org.apache.groovy:"],
       "matchManagers": ["regex"],
       "matchUpdateTypes": ["major"],
       "enabled": false


### PR DESCRIPTION
With a suggestion from:
https://github.com/renovatebot/renovate/discussions/27303#discussioncomment-8473222

I will handle Groovy version handling separately, once Mockito is confirmed.

Fixes problem reported in https://github.com/spockframework/spock/pull/1871#issuecomment-1915675914.