### PR TITLE
[Renovate] Improve Groovy versions handling + minor tweaks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,12 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
+  extends: [
     "config:base"
   ],
   // Don't manage versions in spock modules
   // we want to keep low versions for baseline compatibility
-  "ignorePaths": ["spock-*/**"],
-  "packageRules": [
+  ignorePaths: ["spock-*/**"],
+  packageRules: [
     // Disable major version upgrades for Groovy versions
     // as we want to keep one for each major version.
     // The same applies for mockito as we test with both 4 and 5

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,15 +11,19 @@
     // as we want to keep one for each major version.
     // The same applies for mockito as we test with both 4 and 5
     {
-      matchPackagePrefixes: ["org.mockito:"],
+      matchPackagePrefixes: ["org.codehaus.groovy:"],
+      matchCurrentValue: "/^2\\./",
+      allowedVersions: "(,3.0)"
+    },
+    {
+      matchPackagePrefixes: ["org.apache.groovy:"],
       matchCurrentValue: "/^4\\./",
       allowedVersions: "(,5.0)"
     },
     {
-      "matchPackagePrefixes": ["org.codehaus.groovy:", "org.apache.groovy:"],
-      "matchManagers": ["regex"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
+      matchPackagePrefixes: ["org.mockito:"],
+      matchCurrentValue: "/^4\\./",
+      allowedVersions: "(,5.0)"
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:base"
+    "config:recommended"
   ],
   // Don't manage versions in spock modules
   // we want to keep low versions for baseline compatibility


### PR DESCRIPTION
Renovate has recently started supporting Gradle version catalog natively, so regex manager no longer handles that (see #1883).

This change implements the same logic (preserve major Groovy version for our variables) in a native way. Additionally, the simplified JSON5 syntax is applied and `config:recommended` is used after [changes in Renovate 36](https://docs.renovatebot.com/release-notes-for-major-versions/#version-36).