### PR TITLE
Execute Mock response handlers un-synchronized

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -35,7 +35,7 @@ include::include.adoc[]
 * Fix exception when configured `baseDir` was not existing, now `@TempDir` will create the baseDir directory if it is missing.
 * Fix bad error message for collection conditions, when one of the operands is `null`
 * Fix possible deadlock, when blocking in mock response generators spockPull:1885[]
-** This fixes the issues: spockIssue:583[], spockIssue:1182[]
+** This fixes the issues: spockIssue:583[], spockIssue:1882[]
 * Document `@ConditionBlock` Annotation spockPull:1709[]
 * Document `old`-Method spockPull:1708[]
 * Clarify documentation for global Mocks spockPull:1755[]

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -34,6 +34,8 @@ include::include.adoc[]
 * Improve `@TempDir` field injection, now it happens before field initialization, so it can be used by other field initializers.
 * Fix exception when configured `baseDir` was not existing, now `@TempDir` will create the baseDir directory if it is missing.
 * Fix bad error message for collection conditions, when one of the operands is `null`
+* Fix possible deadlock, when blocking in mock response generators spockPull:1885[]
+** This fixes the issues: spockIssue:583[], spockIssue:1182[]
 * Document `@ConditionBlock` Annotation spockPull:1709[]
 * Document `old`-Method spockPull:1708[]
 * Clarify documentation for global Mocks spockPull:1755[]

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockController.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockController.java
@@ -32,22 +32,32 @@ public class MockController implements IMockController {
   }
 
   @Override
-  public synchronized Object handle(IMockInvocation invocation) {
+  public Object handle(IMockInvocation invocation) {
+    Optional<IMockInteraction> interaction = findInteraction(invocation);
+    if (interaction.isPresent()) {
+      try {
+        return interaction.get().accept(invocation);
+      } catch (InteractionNotSatisfiedError e) {
+        synchronized (this) {
+          errors.add(e);
+        }
+        throw e;
+      }
+    }
+    return invocation.getMockObject().getDefaultResponse().respond(invocation);
+  }
+
+  private synchronized Optional<IMockInteraction> findInteraction(IMockInvocation invocation) {
     for (IInteractionScope scope : scopes) {
       IMockInteraction interaction = scope.match(invocation);
       if (interaction != null) {
-        try {
-          return interaction.accept(invocation);
-        } catch (InteractionNotSatisfiedError e) {
-          errors.add(e);
-          throw e;
-        }
+          return Optional.of(interaction);
       }
     }
     for (IInteractionScope scope : scopes) {
       scope.addUnmatchedInvocation(invocation);
     }
-    return invocation.getMockObject().getDefaultResponse().respond(invocation);
+    return Optional.empty();
   }
 
   public static final String ADD_INTERACTION = "addInteraction";

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MultiThreaded.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MultiThreaded.groovy
@@ -1,0 +1,34 @@
+package org.spockframework.smoke.mock
+
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class MultiThreaded extends Specification {
+
+  @Issue("https://github.com/spockframework/spock/issues/583")
+  def "mocks can block and wait on conditions"() {
+    given:
+    CountDownLatch latch = new CountDownLatch(2)
+    List aList = Mock ()
+    def exec = Executors.newFixedThreadPool(2)
+
+    when:
+    exec.submit { aList.get(0) }
+    exec.submit { aList.get(0) }
+    exec.shutdown()
+    latch.await()
+
+    then:
+    exec.awaitTermination(30, TimeUnit.SECONDS)
+
+    2 * aList.get(_) >> {
+      latch.countDown()
+      assert latch.await(30, TimeUnit.SECONDS)
+      42
+    }
+  }
+}


### PR DESCRIPTION
Prior to this commit the response handler of a mock was called in a
synchronized method. This could lead to deadlocks when one mock was
blocking in its response handler to wait on another mock.

fixes #583, #1882