### PR TITLE
Allow multiple @RepeatUntilFailure annotations within the same specification

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RepeatUntilFailureExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RepeatUntilFailureExtension.java
@@ -14,8 +14,8 @@ public class RepeatUntilFailureExtension implements IAnnotationDrivenExtension<R
     if (annotation.ignoreRest()) {
       feature.getSpec().getBottomSpec().getAllFeatures()
         .stream()
-        .filter(f -> f != feature)
-        .forEach(f -> f.skip("Focussed test run with @RepeatUntilFailure for a single feature."));
+        .filter(f -> (f != feature) && (f.getFeatureMethod().getAnnotation(RepeatUntilFailure.class) == null))
+        .forEach(f -> f.skip("Focussed test run with @RepeatUntilFailure."));
     }
 
     feature.setForceParameterized(true);

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RepeatUntilFailureExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RepeatUntilFailureExtensionSpec.groovy
@@ -41,7 +41,7 @@ class RepeatUntilFailureExtensionSpec extends EmbeddedSpecification {
     result.testsFailedCount == 0
   }
 
-  def "skips other tests in the same class"() {
+  def "skips other tests in the same class that do not have the same annotation too"() {
     when:
     def result = runner.runSpecBody """
       def "other test 1"() {
@@ -49,6 +49,7 @@ class RepeatUntilFailureExtensionSpec extends EmbeddedSpecification {
         true
       }
 
+      @RepeatUntilFailure(maxAttempts = 1)
       def "other test 2"() {
         expect:
         true
@@ -67,10 +68,10 @@ class RepeatUntilFailureExtensionSpec extends EmbeddedSpecification {
     """
 
     then:
-    result.testsStartedCount == 1 + 1
-    result.testsSucceededCount == 1 + 1
+    result.testsStartedCount == 2 + 2
+    result.testsSucceededCount == 2 + 2
     result.testsFailedCount == 0
-    result.testsSkippedCount == 3
+    result.testsSkippedCount == 2
   }
 
 


### PR DESCRIPTION
Currently if you do that, both skip the other one.
But sometimes you want to repeat multiple features in a specification,
especially when trying to reprodocue flaky race-conditon tests.