### PR TITLE
JDK 22 CI build

### DIFF
--- a/.github/workflows/branches-and-prs.yml
+++ b/.github/workflows/branches-and-prs.yml
@@ -21,14 +21,14 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         variant: ['2.5', '3.0', '4.0']
-        java: ['8', '11', '17', '21']
+        java: ['8', '11', '17', '22']
         exclude:
           - os: 'ubuntu-latest'
             variant: '2.5'
             java: '17'
           - os: 'ubuntu-latest'
             variant: '2.5'
-            java: '21'
+            java: '22'
         include:
           - os: 'windows-latest'
             variant: '2.5'

--- a/.github/workflows/branches-and-prs.yml
+++ b/.github/workflows/branches-and-prs.yml
@@ -19,35 +19,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
         variant: ['2.5', '3.0', '4.0']
         java: ['8', '11', '17', '22']
+        os: ['ubuntu-latest']
         exclude:
-          - os: 'ubuntu-latest'
-            variant: '2.5'
+          - variant: '2.5'
             java: '17'
-          - os: 'ubuntu-latest'
-            variant: '2.5'
+            os: 'ubuntu-latest'
+          - variant: '2.5'
             java: '22'
+            os: 'ubuntu-latest'
         include:
-          - os: 'windows-latest'
-            variant: '2.5'
+          - variant: '2.5'
             java: '8'
-          - os: 'windows-latest'
-            variant: '3.0'
+            os: 'windows-latest'
+          - variant: '3.0'
             java: '8'
-          - os: 'windows-latest'
-            variant: '4.0'
+            os: 'windows-latest'
+          - variant: '4.0'
             java: '8'
-          - os: 'macos-latest'
-            variant: '2.5'
+            os: 'windows-latest'
+          - variant: '2.5'
             java: '8'
-          - os: 'macos-latest'
-            variant: '3.0'
+            os: 'macos-latest'
+          - variant: '3.0'
             java: '8'
-          - os: 'macos-latest'
-            variant: '4.0'
+            os: 'macos-latest'
+          - variant: '4.0'
             java: '8'
+            os: 'macos-latest'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -24,11 +24,11 @@ jobs:
       - name: 'Set up JDKs'
         uses: ./.github/actions/setup-build-env
         with:
-          additional-java-version: 21
+          additional-java-version: 22
       - name: 'Install GraphViz'
         run: sudo apt update && sudo apt install --yes graphviz
       - name: 'Build Docs'
-        run: ./gradlew --no-parallel --stacktrace asciidoctor javadoc "-Dvariant=4.0" "-DjavaVersion=21"
+        run: ./gradlew --no-parallel --stacktrace asciidoctor javadoc "-Dvariant=4.0" "-DjavaVersion=22"
       - name: 'Archive and upload docs'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,35 +14,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
         variant: ['2.5', '3.0', '4.0']
         java: [ '8', '11', '17', '22' ]
+        os: [ 'ubuntu-latest' ]
         exclude:
-          - os: 'ubuntu-latest'
-            variant: '2.5'
+          - variant: '2.5'
             java: '17'
-          - os: 'ubuntu-latest'
-            variant: '2.5'
+            os: 'ubuntu-latest'
+          - variant: '2.5'
             java: '22'
+            os: 'ubuntu-latest'
         include:
-          - os: 'windows-latest'
-            variant: '2.5'
+          - variant: '2.5'
             java: '8'
-          - os: 'windows-latest'
-            variant: '3.0'
+            os: 'windows-latest'
+          - variant: '3.0'
             java: '8'
-          - os: 'windows-latest'
-            variant: '4.0'
+            os: 'windows-latest'
+          - variant: '4.0'
             java: '8'
-          - os: 'macos-latest'
-            variant: '2.5'
+            os: 'windows-latest'
+          - variant: '2.5'
             java: '8'
-          - os: 'macos-latest'
-            variant: '3.0'
+            os: 'macos-latest'
+          - variant: '3.0'
             java: '8'
-          - os: 'macos-latest'
-            variant: '4.0'
+            os: 'macos-latest'
+          - variant: '4.0'
             java: '8'
+            os: 'macos-latest'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,14 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         variant: ['2.5', '3.0', '4.0']
-        java: [ '8', '11', '17', '21' ]
+        java: [ '8', '11', '17', '22' ]
         exclude:
           - os: 'ubuntu-latest'
             variant: '2.5'
             java: '17'
           - os: 'ubuntu-latest'
             variant: '2.5'
-            java: '21'
+            java: '22'
         include:
           - os: 'windows-latest'
             variant: '2.5'
@@ -96,7 +96,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         variant: ['4.0']      # docs need the highest variant
-        java: ['21']          # docs need the highest java version
+        java: ['22']          # docs need the highest java version
     steps:
       - uses: actions/checkout@v4
       - name: 'Set up JDKs'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
   baseVersion = "2.4"
   snapshotVersion = true
   milestone = 0
-  javaVersions = [8, 11, 17, 21] // ensure that latest version is actually build on GH actions and added to gradle.properties, otherwise no docs get published
+  javaVersions = [8, 11, 17, 22] // ensure that latest version is actually build on GH actions and added to gradle.properties, otherwise no docs get published
   javaVersion = (System.getProperty("javaVersion") ?: 8) as int
   variants = [2.5, 3.0, 4.0]
   variant = System.getProperty("variant") as BigDecimal ?: variants.first()

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RequiresExtension.groovy
@@ -447,7 +447,7 @@ class Test extends Bar {
 
     @Requires({
       jvm.java8 || jvm.java9 || jvm.java10 || jvm.java11 || jvm.java12 || jvm.java13 || jvm.java14 || jvm.java15 || jvm.java16 || jvm.java17 ||
-        jvm.isJavaVersion(18) || jvm.java21
+        jvm.isJavaVersion(18) || jvm.java21 || jvm.java22
     })
     def "provides JVM information"() {
       expect: true


### PR DESCRIPTION
This PR adds JDK 22 CI build.

I don't see a good reason to build with both 21 LTS and 22, so the former is replaced by the later.

As a bonus, I also improved the visibility in GitHub Actions UI, the order of matrix variables has been changed (I might move it to a separate PR, if desired).

Before (JDK version and Groovy variant are not visible in the failing builds):
![image](https://github.com/spockframework/spock/assets/148013/ab55263c-cc88-41c1-921a-a1ec046a8561)


After:
![Screenshot from 2024-03-24 20-33-43](https://github.com/spockframework/spock/assets/148013/8eecf2f7-7311-4822-84f5-f00857a2fde3)
