### PR TITLE
Fix JDK 8 build on GH Actions with macos 14

### DIFF
--- a/.github/actions/setup-jdks/action.yml
+++ b/.github/actions/setup-jdks/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/setup-java@v4
       with:
         # Temurin JDK 8 for macos on ARM is not available: https://github.com/adoptium/adoptium/issues/96
-        distribution: 'zulu'
+        distribution: ${{ runner.os == 'macOS' && 'zulu' || 'temurin' }}
         java-version: 8
     - name: Prepare JDK8 env var
       shell: bash

--- a/.github/actions/setup-jdks/action.yml
+++ b/.github/actions/setup-jdks/action.yml
@@ -20,7 +20,8 @@ runs:
     - name: 'Set up JDK 8'
       uses: actions/setup-java@v4
       with:
-        distribution: 'temurin'
+        # Temurin JDK 8 for macos on ARM is not available: https://github.com/adoptium/adoptium/issues/96
+        distribution: 'zulu'
         java-version: 8
     - name: Prepare JDK8 env var
       shell: bash


### PR DESCRIPTION
By switching to Zulu - Temurin JDK 8 is not available for ARM - https://github.com/adoptium/adoptium/issues/96

It could be done more subtle, but changing the distro only for MacOS builds with JDK 8, if preferred.
