### PR TITLE
TypeArgumentConstraint handles primitive types constraints

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -10,6 +10,10 @@ include::include.adoc[]
 * Add support for combining two or more data providers using cartesian product spockIssue:1062[]
 * Add support for a `filter` block after a `where` block to filter out unwanted iterations
 
+=== Misc
+
+* Types constraints or arguments in interactions can now handle primitive types like `_ as int` spockIssue:1974[]
+
 == 2.4-M4 (2024-03-21)
 
 * Fix nested regex finding in conditions spockPull:1931[]

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/TypeArgumentConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/TypeArgumentConstraint.java
@@ -19,6 +19,7 @@ package org.spockframework.mock.constraint;
 import org.spockframework.mock.IArgumentConstraint;
 import org.spockframework.runtime.Condition;
 import org.spockframework.util.CollectionUtil;
+import org.spockframework.util.ReflectionUtil;
 
 /**
  *
@@ -35,15 +36,23 @@ public class TypeArgumentConstraint implements IArgumentConstraint {
 
   @Override
   public boolean isSatisfiedBy(Object argument) {
-    return type.isInstance(argument) && constraint.isSatisfiedBy(argument);
+    return isInstance(argument) && constraint.isSatisfiedBy(argument);
+  }
+
+  private boolean isInstance(Object argument) {
+    if (type.isInstance(argument))
+      return true;
+    if (type.isPrimitive())
+      return ReflectionUtil.getWrapperType(type).isInstance(argument);
+    return false;
   }
 
   @Override
   public String describeMismatch(Object argument) {
-    if (type.isInstance(argument)) {
+    if (isInstance(argument)) {
       return constraint.describeMismatch(argument);
     }
-    Condition condition = new Condition(CollectionUtil.listOf(  argument, type, false),
+    Condition condition = new Condition(CollectionUtil.listOf(argument, type, false),
       String.format("argument instanceof %s", type.getName()), null, null,
       null, null);
     return condition.getRendering();

--- a/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
@@ -256,7 +256,7 @@ public abstract class ReflectionUtil {
   }
 
   @SuppressWarnings("ConstantConditions")
-  private static Class<?> getWrapperType(Class<?> type) {
+  public static Class<?> getWrapperType(Class<?> type) {
     return type.isPrimitive() ? getDefaultValue(type).getClass()
                               : type;
   }

--- a/spock-specs/src/test/groovy/org/spockframework/mock/response/MockPrimitiveTypeResponsesSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/response/MockPrimitiveTypeResponsesSpec.groovy
@@ -33,6 +33,18 @@ class MockPrimitiveTypeResponsesSpec extends Specification {
     response == SUCCESS
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/1974")
+  def "Mock Response TypeArgumentConstraint with different primitive types Issue #1974"() {
+    given:
+    ObjClass client = Mock()
+
+    when: "invoke with other instance"
+    def response = client.test(123d, false)
+    then: "validate with int TypeArgumentConstraint (as int)"
+    0 * client.test(_ as int, _ as int)
+    response == null
+  }
+
   static class ObjClass {
     @SuppressWarnings('GrMethodMayBeStatic')
     String test(int a, int b) {

--- a/spock-specs/src/test/groovy/org/spockframework/mock/response/MockPrimitiveTypeResponsesSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/response/MockPrimitiveTypeResponsesSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spockframework.mock.response
+
+import spock.lang.Issue
+import spock.lang.Specification
+
+class MockPrimitiveTypeResponsesSpec extends Specification {
+  private static final String SUCCESS = "success"
+
+  @Issue("https://github.com/spockframework/spock/issues/1974")
+  def "Mock Response TypeArgumentConstraint with primitive type Issue #1974"() {
+    given:
+    ObjClass client = Mock()
+
+    when: "invoke with int"
+    def response = client.test(123, 456)
+    then: "validate with int TypeArgumentConstraint (as int)"
+    1 * client.test(_ as int, _ as int) >> SUCCESS
+    response == SUCCESS
+  }
+
+  static class ObjClass {
+    @SuppressWarnings('GrMethodMayBeStatic')
+    String test(int a, int b) {
+      return a + b
+    }
+  }
+}


### PR DESCRIPTION
Now the TypeArgumentConstraint also is satisfied when a type is a primitive type and the passed arg is a wrapper instance of that primitive type.

Fixes #1974