### PR TITLE
Fix trivial Gradle deprecations

### DIFF
--- a/build-logic/settings.gradle
+++ b/build-logic/settings.gradle
@@ -5,6 +5,7 @@ pluginManagement {
   }
 }
 
+rootProject.name = "build-logic"
 rootProject.buildFileName = 'build-logic.gradle'
 
 dependencyResolutionManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -223,7 +223,7 @@ tasks.register("collectTestXml") {
 
 
   doFirst {
-    def target = file("$buildDir/collected-test-results")
+    def target = layout.buildDirectory.dir("collected-test-results").get().asFile
     target.mkdirs()
     reportingProjects.each { rp ->
       rp.tasks.withType(Test).each { testTask ->
@@ -255,7 +255,7 @@ tasks.register("codeCoverageReport", JacocoReport) {
   reports {
     html.required = true
     xml.required = true
-    xml.outputLocation = file("${buildDir}/reports/jacoco/report.xml") // report must be here for codecov to pick it up
+    xml.outputLocation = layout.buildDirectory.file("reports/jacoco/report.xml") // report must be here for codecov to pick it up
     csv.required = false
   }
 }

--- a/spock-core/core.gradle
+++ b/spock-core/core.gradle
@@ -95,10 +95,10 @@ tasks.named("processResources") {
 
 tasks.register("coreConsole", JavaExec) {
   description = 'Start a groovy Console with Spock Core Classpath, useful for AST-Inspection'
-  main = variant == 2.5 ? "groovy.ui.Console" : "groovy.console.ui.Console"
+  mainClass = variant == 2.5 ? "groovy.ui.Console" : "groovy.console.ui.Console"
   classpath(sourceSets.named("main").map {it.runtimeClasspath }, configurations.named("coreConsoleRuntime"))
   workingDir = file('build/console')
-  ignoreExitValue = true
+  ignoreExitValue true
   args file('CoreConsole.groovy').absolutePath
   doFirst {
     workingDir.mkdirs()
@@ -109,7 +109,7 @@ tasks.register("coreConsole", JavaExec) {
 // task writes out the properties necessary for it to verify the OSGi
 // metadata.
 def osgiProperties = tasks.register('osgiProperties', WriteProperties) {
-  outputFile = layout.getBuildDirectory().file("verifyOSGiProperties.bndrun")
+  destinationFile = layout.getBuildDirectory().file("verifyOSGiProperties.bndrun")
   property('-standalone', true)
   property('-runee', "JavaSE-${javaVersion < 9 ? '1.' + javaVersion : javaVersion}")
   property('-runrequires', "osgi.identity;filter:='(osgi.identity=${project.name})'")

--- a/spock-specs/mock-integration/mock-integration.gradle
+++ b/spock-specs/mock-integration/mock-integration.gradle
@@ -57,6 +57,8 @@ def configureTaskFilters = { String key, Test t ->
 codeGenerationLibraries.each { key, config ->
   tasks.register("test${key.capitalize()}WithoutObjenesis", Test) {
     systemProperty("org.spockframework.mock.testType", "${key.toLowerCase()} - objenesis")
+    testClassesDirs = testing.suites.test.sources.output.classesDirs
+    classpath = testing.suites.test.sources.runtimeClasspath
     classpath += config
 
     configureTaskFilters(key, it)
@@ -64,6 +66,8 @@ codeGenerationLibraries.each { key, config ->
 
   tasks.register("test${key.capitalize()}WithObjenesis", Test) {
     systemProperty("org.spockframework.mock.testType", "${key.toLowerCase()} + objenesis")
+    testClassesDirs = testing.suites.test.sources.output.classesDirs
+    classpath = testing.suites.test.sources.runtimeClasspath
     classpath += config
     classpath += configurations.objenesis
 

--- a/spock-specs/specs.gradle
+++ b/spock-specs/specs.gradle
@@ -89,7 +89,7 @@ tasks.named("test", Test) {
 }
 
 tasks.register("groovyConsole", JavaExec) {
-  main = variant == 2.5 ? "groovy.ui.Console" : "groovy.console.ui.Console"
+  mainClass = variant == 2.5 ? "groovy.ui.Console" : "groovy.console.ui.Console"
   classpath(sourceSets.named("test").map {it.runtimeClasspath }, configurations.named("groovyConsole"))
 }
 

--- a/spock-testkit/testkit.gradle
+++ b/spock-testkit/testkit.gradle
@@ -34,10 +34,10 @@ tasks.named("test", Test) {
 
 tasks.register("consoleLauncherTest", JavaExec) {
   dependsOn(testClasses)
-  def reportsDir = file("$buildDir/test-results")
+  def reportsDir = layout.buildDirectory.dir("test-results")
   outputs.dir(reportsDir)
   classpath(sourceSets.named("test").map { it.runtimeClasspath })
-  main = "org.junit.platform.console.ConsoleLauncher"
+  mainClass = "org.junit.platform.console.ConsoleLauncher"
 //  jvmArgs "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
 //  args("--select-class", "spock.testkit.testsources.ExampleTestCase")
   args("--select-class", "spock.testkit.testsources.UnrollTestCase")


### PR DESCRIPTION
This PR fixes some trivial Gradle deprecations.

Imo, there is potential for further work in the Gradle Build of Spock like removing other deprecations or getting ready for configuration cache. But for now, this is a nice and simple fix for some of the deprecations.