### PR TITLE
ByteBuddy: Do not use Lookup for non-local mocks

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -20,6 +20,7 @@ include::include.adoc[]
 ** This enables loading of optional classes in e.g. OSGi environments
 * `EmbeddedSpecRunner` and `EmbeddedSpecCompiler` now support the construction with a custom `ClassLoader` spockPull:1988[]
 ** This allows the use of these classes in an OSGi environment, where the class imports in the embedded spec are not visible to the Spock OSGi bundle ClassLoader
+* Fix mocking issue with the ByteBuddy MockMaker when using multiple classloaders in Java 21 spockIssue:2017[]
 
 == 2.4-M4 (2024-03-21)
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
@@ -84,13 +84,14 @@ class ByteBuddyMockFactory {
   }
 
   /**
-   * {@return true, if the mock is considered local}
+   * Returns {@code true}, if the mock is considered local
    * <p>
    * A mock is considered local, if all additional interfaces of the mock (including {@link ISpockMockObject}) are
    * loadable by the target class' classloader.
    *
    * @param targetClass The to-be-mocked class
    * @param additionalInterfaces Additional interfaces of the to-be-mocked type
+   * @return true, if this is a local mock. Otherwise false
    */
   @VisibleForTesting
   static boolean isLocalMock(Class<?> targetClass, Collection<Class<?>> additionalInterfaces) {

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyMockMakerSpec.groovy
@@ -18,6 +18,7 @@ package org.spockframework.mock.runtime
 
 import net.bytebuddy.dynamic.loading.MultipleParentClassLoader
 import org.spockframework.mock.CannotCreateMockException
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 import spock.mock.DetachedMockFactory
@@ -154,13 +155,16 @@ class ByteBuddyMockMakerSpec extends Specification {
     ex.message.startsWith("Cannot create mock for interface java.lang.Runnable. byte-buddy: The class AdditionalInterface is not visible by the classloader")
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/2017")
   def "ByteBuddy Mocks with interfaces that are not visible to the mocked type's classloader"() {
+    given:
     def testCl1 = new ByteBuddyTestClassLoader()
     def testCl2 = new ByteBuddyTestClassLoader()
     testCl1.defineInterface("foo.Bar")
     testCl2.defineClass("iam.Mocked")
     def cl = new MultipleParentClassLoader([getClass().classLoader, testCl1, testCl2])
     def runner = new EmbeddedSpecRunner(cl)
+
     when: "A type is mocked with an additional interface from a classloader outside the mocked type's parent chain"
     runner.addClassImport(MockMakers)
     runner.runFeatureBody("""
@@ -168,6 +172,7 @@ def mock = Mock(iam.Mocked, mockMaker: MockMakers.byteBuddy, additionalInterface
 expect:
 true
 """)
+
     then:
     noExceptionThrown()
   }

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyTestClassLoader.java
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/ByteBuddyTestClassLoader.java
@@ -50,7 +50,7 @@ public final class ByteBuddyTestClassLoader extends ClassLoader {
   }
 
   /**
-   * Defines an empty interface with the passed {@code node}.
+   * Defines an empty interface with the passed {@code name}.
    *
    * @param name the name of the interface
    * @return the loaded {@code Class}
@@ -59,6 +59,22 @@ public final class ByteBuddyTestClassLoader extends ClassLoader {
     //noinspection resource
     return cache.computeIfAbsent(name, nameKey -> new ByteBuddy()
       .makeInterface()
+      .name(nameKey)
+      .make()
+      .load(this, loadingStrategy)
+      .getLoaded());
+  }
+
+  /**
+   * Defines an empty class with the passed {@code name}
+   *
+   * @param name the name of the class
+   * @return the loaded {@link  Class}
+   */
+  public synchronized Class<?> defineClass(String name) {
+    //noinspection resource
+    return cache.computeIfAbsent(name, nameKey -> new ByteBuddy()
+      .subclass(Object.class)
       .name(nameKey)
       .make()
       .load(this, loadingStrategy)


### PR DESCRIPTION
ByteBuddy: Do not use Lookup for non-local mocks

This PR introduces the concept of local mocks. A mock is considered to be local if the target class' classloader can also load all additional interfaces (incl. `ISpockMockObject`).

The lookup classloading strategy may only be used if a mock is local.
Otherwise we have to defer to other strategies.

Fixes #2017