### PR TITLE
Introducing Spock Framework Guru on Gurubase.io

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,6 +12,7 @@ https://codecov.io/gh/spockframework/spock[image:https://codecov.io/gh/spockfram
 https://gitter.im/spockframework/spock?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge[image:https://badges.gitter.im/spockframework/spock.svg[Gitter]]
 https://ge.spockframework.org/scans[image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A[Revved
 up by Develocity]]
+https://gurubase.io/g/spock-framework[image:https://img.shields.io/badge/Gurubase-Ask%20Spock%20Framework%20Guru-006BFF[Gurubase]]
 
 image::docs/images/spock-main-logo.png[width=100px,float=right]
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Spock Framework Guru](https://gurubase.io/g/spock-framework) to Gurubase. Spock Framework Guru uses the data from this repo and data from the [docs](https://spockframework.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "Spock Framework Guru", which highlights that Spock Framework now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Spock Framework Guru in Gurubase, just let me know that's totally fine.
