### PR TITLE
Add `IStatelessAnnotationDrivenExtension` ...

### DIFF
--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -900,6 +900,9 @@ and also attached one annotation directly.
 Repeatable annotations are not supported for parameter annotations,
 as they are primarily intended to provide a value and only a singular value is allowed.
 
+NOTE: Since Spock 2.4 the new subtype `IStatelessAnnotationDrivenExtension` is available, which should be used if the extension does not need to store Specification specific state.
+Otherwise, it behaves the same as `IAnnotationDrivenExtension`.
+
 `IAnnotationDrivenExtension` has the following nine methods, where in each you can prepare a specification with your
 extension magic, like attaching interceptors to various interception points as described in the chapter
 <<Interceptors>>:

--- a/docs/extensions.adoc
+++ b/docs/extensions.adoc
@@ -900,7 +900,7 @@ and also attached one annotation directly.
 Repeatable annotations are not supported for parameter annotations,
 as they are primarily intended to provide a value and only a singular value is allowed.
 
-NOTE: Since Spock 2.4 the new subtype `IStatelessAnnotationDrivenExtension` is available, which should be used if the extension does not need to store Specification specific state.
+NOTE: Since Spock 2.4 the new subtype `IStatelessAnnotationDrivenExtension` is available, which should be used if the extension does not need to store `Specification` specific state and is thread-safe.
 Otherwise, it behaves the same as `IAnnotationDrivenExtension`.
 
 `IAnnotationDrivenExtension` has the following nine methods, where in each you can prepare a specification with your

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -15,7 +15,7 @@ include::include.adoc[]
 * Add `globalTimeout` to  `@Timeout` extension, to apply a timeout to all features in a specification, configurable via the spock configuration file spockPull:1986[]
 * Add new <<extensions.adoc#default-value-provider,`IDefaultValueProviderExtension`>> extension point to add support for special classes in the Stub's default `EmptyOrDummyResponse` spockPull:1994[]
 * Add support for Groovy-4-style range expressions spockIssue:1956[]
-* Add `IStatelessAnnotationDrivenExtension` to allow a single extension instance to be reused across all specifications
+* Add `IStatelessAnnotationDrivenExtension` to allow a single extension instance to be reused across all specifications spockPull:2055[]
 * Improve `@Timeout` extension will now use virtual threads if available spockPull:1986[]
 * Improve mock argument matching, types constraints or arguments in interactions can now handle primitive types like `_ as int` spockIssue:1974[]
 * Improve `verifyEach` to accept an optional second index parameter for the assertion block closure spockPull:2043[]

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -16,6 +16,7 @@ include::include.adoc[]
 * Add new <<extensions.adoc#default-value-provider,`IDefaultValueProviderExtension`>> extension point to add support for special classes in the Stub's default `EmptyOrDummyResponse` spockPull:1994[]
 * Add support for Groovy-4-style range expressions spockIssue:1956[]
 * Add `IStatelessAnnotationDrivenExtension` to allow a single extension instance to be reused across all specifications spockPull:2055[]
+** Built-in extensions have been updated to use this new interface where applicable.
 * Improve `@Timeout` extension will now use virtual threads if available spockPull:1986[]
 * Improve mock argument matching, types constraints or arguments in interactions can now handle primitive types like `_ as int` spockIssue:1974[]
 * Improve `verifyEach` to accept an optional second index parameter for the assertion block closure spockPull:2043[]

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -15,6 +15,7 @@ include::include.adoc[]
 * Add `globalTimeout` to  `@Timeout` extension, to apply a timeout to all features in a specification, configurable via the spock configuration file spockPull:1986[]
 * Add new <<extensions.adoc#default-value-provider,`IDefaultValueProviderExtension`>> extension point to add support for special classes in the Stub's default `EmptyOrDummyResponse` spockPull:1994[]
 * Add support for Groovy-4-style range expressions spockIssue:1956[]
+* Add `IStatelessAnnotationDrivenExtension` to allow a single extension instance to be reused across all specifications
 * Improve `@Timeout` extension will now use virtual threads if available spockPull:1986[]
 * Improve mock argument matching, types constraints or arguments in interactions can now handle primitive types like `_ as int` spockIssue:1974[]
 * Improve `verifyEach` to accept an optional second index parameter for the assertion block closure spockPull:2043[]

--- a/spock-core/src/main/java/org/spockframework/runtime/ExtensionRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ExtensionRunner.java
@@ -15,10 +15,7 @@
 
 package org.spockframework.runtime;
 
-import org.spockframework.runtime.extension.ExtensionAnnotation;
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
-import org.spockframework.runtime.extension.IGlobalExtension;
-import org.spockframework.runtime.extension.RepeatedExtensionAnnotations;
+import org.spockframework.runtime.extension.*;
 import org.spockframework.runtime.model.*;
 import org.spockframework.util.Nullable;
 import org.spockframework.util.Pair;
@@ -163,7 +160,11 @@ public class ExtensionRunner {
   }
 
 
+  @SuppressWarnings("unchecked")
   private IAnnotationDrivenExtension getOrCreateExtension(Class<? extends IAnnotationDrivenExtension> clazz) {
+    if (IStatelessAnnotationDrivenExtension.class.isAssignableFrom(clazz)) {
+      return extensionRegistry.getStatelessAnnotationDrivenExtension((Class<? extends IStatelessAnnotationDrivenExtension<?>>)clazz);
+    }
     return localExtensions.computeIfAbsent(clazz, configurationRegistry::instantiateExtension);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/ExtensionRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ExtensionRunner.java
@@ -163,7 +163,8 @@ public class ExtensionRunner {
   @SuppressWarnings("unchecked")
   private IAnnotationDrivenExtension getOrCreateExtension(Class<? extends IAnnotationDrivenExtension> clazz) {
     if (IStatelessAnnotationDrivenExtension.class.isAssignableFrom(clazz)) {
-      return extensionRegistry.getStatelessAnnotationDrivenExtension((Class<? extends IStatelessAnnotationDrivenExtension<?>>)clazz);
+      // we need to add the extension to the local extensions map to ensure that `visitSpec` is called for it at the end
+      return localExtensions.computeIfAbsent(clazz, __ -> extensionRegistry.getStatelessAnnotationDrivenExtension((Class<? extends IStatelessAnnotationDrivenExtension<?>>) clazz));
     }
     return localExtensions.computeIfAbsent(clazz, configurationRegistry::instantiateExtension);
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/ExtensionRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/ExtensionRunner.java
@@ -164,7 +164,7 @@ public class ExtensionRunner {
   private IAnnotationDrivenExtension getOrCreateExtension(Class<? extends IAnnotationDrivenExtension> clazz) {
     if (IStatelessAnnotationDrivenExtension.class.isAssignableFrom(clazz)) {
       // we need to add the extension to the local extensions map to ensure that `visitSpec` is called for it at the end
-      return localExtensions.computeIfAbsent(clazz, __ -> extensionRegistry.getStatelessAnnotationDrivenExtension((Class<? extends IStatelessAnnotationDrivenExtension<?>>) clazz));
+      return localExtensions.computeIfAbsent(clazz, c -> extensionRegistry.getStatelessAnnotationDrivenExtension((Class<? extends IStatelessAnnotationDrivenExtension<?>>) c));
     }
     return localExtensions.computeIfAbsent(clazz, configurationRegistry::instantiateExtension);
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/GlobalExtensionRegistry.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/GlobalExtensionRegistry.java
@@ -34,6 +34,8 @@ public class GlobalExtensionRegistry implements IExtensionRegistry, IConfigurati
   private final List<Class<? extends IGlobalExtension>> globalExtensionClasses;
   private final Map<Class<?>, Object> configurationsByType = new HashMap<>();
   private final Map<String, Object> configurationsByName = new HashMap<>();
+  private final Map<Class<? extends IStatelessAnnotationDrivenExtension<?>>, IStatelessAnnotationDrivenExtension<?>> statelessExtensions = new HashMap<>();
+
 
   private final List<IGlobalExtension> globalExtensions = new ArrayList<>();
 
@@ -74,6 +76,11 @@ public class GlobalExtensionRegistry implements IExtensionRegistry, IConfigurati
   @Override
   public List<IGlobalExtension> getGlobalExtensions() {
     return globalExtensions;
+  }
+
+  @Override
+  public <T extends IStatelessAnnotationDrivenExtension<?>> T getStatelessAnnotationDrivenExtension(Class<T> extensionClass) {
+    return extensionClass.cast(statelessExtensions.computeIfAbsent(extensionClass, this::instantiateAndConfigureExtension));
   }
 
   private void verifyGlobalExtension(Class<?> clazz) {

--- a/spock-core/src/main/java/org/spockframework/runtime/IExtensionRegistry.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IExtensionRegistry.java
@@ -15,9 +15,11 @@
 package org.spockframework.runtime;
 
 import org.spockframework.runtime.extension.IGlobalExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 
 import java.util.List;
 
 public interface IExtensionRegistry {
   List<IGlobalExtension> getGlobalExtensions();
+  <T extends IStatelessAnnotationDrivenExtension<?>> T getStatelessAnnotationDrivenExtension(Class<T> extensionClass);
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/ExtensionAnnotation.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/ExtensionAnnotation.java
@@ -19,7 +19,10 @@ package org.spockframework.runtime.extension;
 import java.lang.annotation.*;
 
 /**
+ * Marks an annotation as a Spock extension annotation.
+ *
  * @author Peter Niederwieser
+ * @see IAnnotationDrivenExtension
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IAnnotationDrivenExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IAnnotationDrivenExtension.java
@@ -24,7 +24,16 @@ import org.spockframework.runtime.model.*;
 import org.spockframework.util.Beta;
 
 /**
+ * Describes an extension that is driven by annotations.
+ * <p>
+ * A new instance of the extension is created for each Specification where the annotation is used.
+ * <p>
+ * If the extension is stateless and does not require a new instance for each usage, use {@link IStatelessAnnotationDrivenExtension}.
+ *
  * @author Peter Niederwieser
+ * @see IStatelessAnnotationDrivenExtension
+ * @see ExtensionAnnotation
+ * @see spock.config.ConfigurationObject
  */
 public interface IAnnotationDrivenExtension<T extends Annotation> {
   /**

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IStatelessAnnotationDrivenExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IStatelessAnnotationDrivenExtension.java
@@ -24,7 +24,8 @@ import org.spockframework.util.Beta;
  * Use this interface if the extension does not need to store any use specific state.
  * Injecting a configuration object is still allowed.
  * You can use the {@link IStore} to store state that should be shared.
- *
+ * <p>
+ * Implementations of this interface must be thread-safe.
  * @since 2.4
  * @see ExtensionAnnotation
  * @see spock.config.ConfigurationObject

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/IStatelessAnnotationDrivenExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/IStatelessAnnotationDrivenExtension.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2024 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.runtime.extension;
+
+import java.lang.annotation.Annotation;
+
+import org.spockframework.util.Beta;
+
+/**
+ * A variant of the {@link IAnnotationDrivenExtension} that is stateless and does not create a new instance for each Specification.
+ * <p>
+ * Use this interface if the extension does not need to store any use specific state.
+ * Injecting a configuration object is still allowed.
+ * You can use the {@link IStore} to store state that should be shared.
+ *
+ * @since 2.4
+ * @see ExtensionAnnotation
+ * @see spock.config.ConfigurationObject
+ * @see IStore
+ */
+@Beta
+public interface IStatelessAnnotationDrivenExtension<T extends Annotation> extends IAnnotationDrivenExtension<T> {
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/AutoCleanupExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/AutoCleanupExtension.java
@@ -14,7 +14,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FieldInfo;
 import org.spockframework.runtime.model.SpecInfo;
 
@@ -23,7 +23,7 @@ import spock.lang.AutoCleanup;
 /**
  * @author Peter Niederwieser
  */
-public class AutoCleanupExtension implements IStatelessAnnotationDrivenExtension<AutoCleanup> {
+public class AutoCleanupExtension implements IAnnotationDrivenExtension<AutoCleanup> {
   private final AutoCleanupInterceptor sharedFieldInterceptor = new AutoCleanupInterceptor();
   private final AutoCleanupInterceptor instanceFieldInterceptor = new AutoCleanupInterceptor();
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/AutoCleanupExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/AutoCleanupExtension.java
@@ -14,7 +14,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FieldInfo;
 import org.spockframework.runtime.model.SpecInfo;
 
@@ -23,7 +23,7 @@ import spock.lang.AutoCleanup;
 /**
  * @author Peter Niederwieser
  */
-public class AutoCleanupExtension implements IAnnotationDrivenExtension<AutoCleanup> {
+public class AutoCleanupExtension implements IStatelessAnnotationDrivenExtension<AutoCleanup> {
   private final AutoCleanupInterceptor sharedFieldInterceptor = new AutoCleanupInterceptor();
   private final AutoCleanupInterceptor instanceFieldInterceptor = new AutoCleanupInterceptor();
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConfineMetaClassChangesExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ConfineMetaClassChangesExtension.java
@@ -16,7 +16,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import org.spockframework.runtime.model.parallel.*;
 import spock.util.mop.ConfineMetaClassChanges;
@@ -29,7 +29,7 @@ import static java.util.stream.Collectors.toSet;
  * @author Luke Daley
  * @author Peter Niederwieser
  */
-public class ConfineMetaClassChangesExtension implements IAnnotationDrivenExtension<ConfineMetaClassChanges> {
+public class ConfineMetaClassChangesExtension implements IStatelessAnnotationDrivenExtension<ConfineMetaClassChanges> {
 
   private static final ExclusiveResource EXCLUSIVE_RESOURCE = new ExclusiveResource(Resources.META_CLASS_REGISTRY,
     ResourceAccessMode.READ_WRITE);

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ExecutionExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ExecutionExtension.java
@@ -1,13 +1,13 @@
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import spock.lang.Execution;
 
 /**
  * @since 2.0
  */
-public class ExecutionExtension implements IAnnotationDrivenExtension<Execution> {
+public class ExecutionExtension implements IStatelessAnnotationDrivenExtension<Execution> {
   @Override
   public void visitSpecAnnotation(Execution annotation, SpecInfo spec) {
     spec.getBottomSpec().setExecutionMode(annotation.value());

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/FailsWithExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/FailsWithExtension.java
@@ -17,14 +17,14 @@
 package org.spockframework.runtime.extension.builtin;
 
 import org.spockframework.runtime.InvalidSpecException;
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import spock.lang.FailsWith;
 
 /**
  * @author Peter Niederwieser
  */
-public class FailsWithExtension implements IAnnotationDrivenExtension<FailsWith> {
+public class FailsWithExtension implements IStatelessAnnotationDrivenExtension<FailsWith> {
   @Override
   public void visitSpecAnnotation(FailsWith failsWith, SpecInfo spec) {
     checkRefersToException(failsWith);

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IgnoreExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IgnoreExtension.java
@@ -16,7 +16,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import spock.lang.Ignore;
 
@@ -28,7 +28,7 @@ import java.util.List;
  */
 // we cannot easily support @Ignore on fixture methods because
 // setup() and setupSpec() perform initialization of user-defined and internal fields
-public class IgnoreExtension implements IAnnotationDrivenExtension<Ignore> {
+public class IgnoreExtension implements IStatelessAnnotationDrivenExtension<Ignore> {
 
   public static final String DEFAULT_REASON = "Ignored via @Ignore";
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IgnoreIfExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IgnoreIfExtension.java
@@ -18,6 +18,7 @@ package org.spockframework.runtime.extension.builtin;
 
 import org.opentest4j.TestAbortedException;
 import org.spockframework.runtime.extension.IMethodInvocation;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import spock.lang.IgnoreIf;
 
@@ -30,7 +31,7 @@ import static java.util.Collections.singletonList;
 /**
  * @author Peter Niederwieser
  */
-public class IgnoreIfExtension extends ConditionalExtension<IgnoreIf> {
+public class IgnoreIfExtension extends ConditionalExtension<IgnoreIf> implements IStatelessAnnotationDrivenExtension<IgnoreIf> {
 
   private static final String DEFAULT_MESSAGE = "Ignored via @" + IgnoreIf.class.getSimpleName();
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IgnoreRestExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IgnoreRestExtension.java
@@ -16,7 +16,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.SpecInfo;
 
@@ -25,7 +25,7 @@ import spock.lang.IgnoreRest;
 /**
  * @author Peter Niederwieser
  */
-public class IgnoreRestExtension implements IAnnotationDrivenExtension<IgnoreRest> {
+public class IgnoreRestExtension implements IStatelessAnnotationDrivenExtension<IgnoreRest> {
   @Override
   public void visitFeatureAnnotation(IgnoreRest ignoreRest, FeatureInfo feature) {} // do nothing
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IsolatedExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IsolatedExtension.java
@@ -1,13 +1,13 @@
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.SpecInfo;
 import org.spockframework.runtime.model.parallel.*;
 import spock.lang.Isolated;
 
 import java.util.List;
 
-public class IsolatedExtension implements IAnnotationDrivenExtension<Isolated> {
+public class IsolatedExtension implements IStatelessAnnotationDrivenExtension<Isolated> {
 
   private static final ExclusiveResource GLOBAL_LOCK = new ExclusiveResource(
     org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY, ResourceAccessMode.READ_WRITE);

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IssueExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/IssueExtension.java
@@ -14,12 +14,12 @@
 package org.spockframework.runtime.extension.builtin;
 
 import org.spockframework.report.log.ReportLogConfiguration;
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 
 import spock.lang.Issue;
 
-public class IssueExtension implements IAnnotationDrivenExtension<Issue> {
+public class IssueExtension implements IStatelessAnnotationDrivenExtension<Issue> {
   private final ReportLogConfiguration configuration;
 
   public IssueExtension(ReportLogConfiguration configuration) {

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/NarrativeExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/NarrativeExtension.java
@@ -14,12 +14,12 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.SpecInfo;
 
 import spock.lang.Narrative;
 
-public class NarrativeExtension implements IAnnotationDrivenExtension<Narrative> {
+public class NarrativeExtension implements IStatelessAnnotationDrivenExtension<Narrative> {
   @Override
   public void visitSpecAnnotation(Narrative narrative, SpecInfo spec) {
     spec.setNarrative(narrative.value().trim());

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/PendingFeatureExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/PendingFeatureExtension.java
@@ -1,13 +1,13 @@
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FeatureInfo;
 import spock.lang.PendingFeature;
 
 /**
  * @author Leonard Brünings
  */
-public class PendingFeatureExtension implements IAnnotationDrivenExtension<PendingFeature> {
+public class PendingFeatureExtension implements IStatelessAnnotationDrivenExtension<PendingFeature> {
 
   private static final String PENDING_FEATURE = "@PendingFeature";
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/PendingFeatureIfExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/PendingFeatureIfExtension.java
@@ -2,10 +2,11 @@ package org.spockframework.runtime.extension.builtin;
 
 import groovy.lang.Closure;
 import org.spockframework.runtime.extension.IMethodInvocation;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FeatureInfo;
 import spock.lang.PendingFeatureIf;
 
-public class PendingFeatureIfExtension extends ConditionalExtension<PendingFeatureIf> {
+public class PendingFeatureIfExtension extends ConditionalExtension<PendingFeatureIf> implements IStatelessAnnotationDrivenExtension<PendingFeatureIf> {
 
   private static final String PENDING_FEATURE_IF = "@PendingFeatureIf";
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RepeatUntilFailureExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RepeatUntilFailureExtension.java
@@ -1,6 +1,5 @@
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.DataIteratorFactory;
 import org.spockframework.runtime.IDataIterator;
 import org.spockframework.runtime.extension.*;
 import org.spockframework.runtime.model.*;
@@ -11,7 +10,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.spockframework.runtime.DataIteratorFactory.UNKNOWN_ITERATIONS;
 
-public class RepeatUntilFailureExtension implements IAnnotationDrivenExtension<RepeatUntilFailure> {
+public class RepeatUntilFailureExtension implements IStatelessAnnotationDrivenExtension<RepeatUntilFailure> {
   @Override
   public void visitFeatureAnnotation(RepeatUntilFailure annotation, FeatureInfo feature) {
     if (annotation.ignoreRest()) {

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RequiresExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RequiresExtension.java
@@ -18,6 +18,7 @@ package org.spockframework.runtime.extension.builtin;
 
 import org.opentest4j.TestAbortedException;
 import org.spockframework.runtime.extension.IMethodInvocation;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import spock.lang.Requires;
 
@@ -30,7 +31,7 @@ import static java.util.Collections.singletonList;
 /**
  * @author Peter Niederwieser
  */
-public class RequiresExtension extends ConditionalExtension<Requires> {
+public class RequiresExtension extends ConditionalExtension<Requires> implements IStatelessAnnotationDrivenExtension<Requires> {
 
   private static final String DEFAULT_MESSAGE = "Ignored via @" + Requires.class.getSimpleName();
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ResourceLockExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/ResourceLockExtension.java
@@ -1,6 +1,6 @@
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import org.spockframework.runtime.model.parallel.ExclusiveResource;
 import spock.lang.ResourceLock;
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * @since 2.0
  */
-public class ResourceLockExtension implements IAnnotationDrivenExtension<ResourceLock> {
+public class ResourceLockExtension implements IStatelessAnnotationDrivenExtension<ResourceLock> {
   @Override
   public void visitFeatureAnnotations(List<ResourceLock> annotations, FeatureInfo feature) {
     annotations.forEach( lockResource -> feature.addExclusiveResource(

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RestoreSystemPropertiesExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RestoreSystemPropertiesExtension.java
@@ -16,12 +16,12 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import org.spockframework.runtime.model.parallel.*;
 import spock.util.environment.RestoreSystemProperties;
 
-public class RestoreSystemPropertiesExtension implements IAnnotationDrivenExtension<RestoreSystemProperties> {
+public class RestoreSystemPropertiesExtension implements IStatelessAnnotationDrivenExtension<RestoreSystemProperties> {
 
   private static final ExclusiveResource EXCLUSIVE_RESOURCE = new ExclusiveResource(Resources.SYSTEM_PROPERTIES,
     ResourceAccessMode.READ_WRITE);

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryExtension.java
@@ -16,7 +16,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import spock.lang.Retry;
 
@@ -24,7 +24,7 @@ import spock.lang.Retry;
  * @author Leonard Brünings
  * @since 1.2
  */
-public class RetryExtension implements IAnnotationDrivenExtension<Retry> {
+public class RetryExtension implements IStatelessAnnotationDrivenExtension<Retry> {
   @Override
   public void visitSpecAnnotation(Retry annotation, SpecInfo spec) {
     if (noSubSpecWithRetryAnnotation(spec.getSubSpec())) {

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/SeeExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/SeeExtension.java
@@ -1,6 +1,6 @@
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.Attachment;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.SpecElementInfo;
@@ -8,7 +8,7 @@ import org.spockframework.runtime.model.SpecInfo;
 
 import spock.lang.See;
 
-public class SeeExtension implements IAnnotationDrivenExtension<See> {
+public class SeeExtension implements IStatelessAnnotationDrivenExtension<See> {
   @Override
   public void visitSpecAnnotation(See see, SpecInfo spec) {
     addAttachments(see, spec);

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/SnapshotExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/SnapshotExtension.java
@@ -15,9 +15,9 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
 import org.spockframework.runtime.extension.IMethodInterceptor;
 import org.spockframework.runtime.extension.IMethodInvocation;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.extension.ParameterResolver;
 import org.spockframework.runtime.model.FieldInfo;
 import org.spockframework.runtime.model.MethodInfo;
@@ -31,7 +31,7 @@ import spock.lang.Snapshotter;
 
 import java.nio.charset.Charset;
 
-public class SnapshotExtension implements IAnnotationDrivenExtension<Snapshot> {
+public class SnapshotExtension implements IStatelessAnnotationDrivenExtension<Snapshot> {
   private final SnapshotConfig config;
 
   public SnapshotExtension(SnapshotConfig config) {

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/StepwiseExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/StepwiseExtension.java
@@ -16,14 +16,14 @@ package org.spockframework.runtime.extension.builtin;
 
 import org.spockframework.runtime.AbstractRunListener;
 import org.spockframework.runtime.InvalidSpecException;
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import org.spockframework.runtime.model.parallel.ExecutionMode;
 import spock.lang.Stepwise;
 
 import java.util.List;
 
-public class StepwiseExtension implements IAnnotationDrivenExtension<Stepwise> {
+public class StepwiseExtension implements IStatelessAnnotationDrivenExtension<Stepwise> {
   @Override
   public void visitSpecAnnotation(Stepwise annotation, final SpecInfo spec) {
     sortFeaturesInDeclarationOrder(spec);

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TagExtension.java
@@ -1,7 +1,6 @@
 package org.spockframework.runtime.extension.builtin;
 
-import org.jetbrains.annotations.NotNull;
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.SpecInfo;
 import org.spockframework.runtime.model.TestTag;
@@ -11,7 +10,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
-public class TagExtension implements IAnnotationDrivenExtension<Tag> {
+public class TagExtension implements IStatelessAnnotationDrivenExtension<Tag> {
   @Override
   public void visitSpecAnnotations(List<Tag> annotations, SpecInfo spec) {
     List<TestTag> tags = toTestTags(annotations);
@@ -23,7 +22,6 @@ public class TagExtension implements IAnnotationDrivenExtension<Tag> {
     toTestTags(annotations).forEach(feature::addTestTag);
   }
 
-  @NotNull
   private List<TestTag> toTestTags(List<Tag> annotations) {
     return annotations.stream().map(Tag::value).map(TestTag::create).collect(toList());
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TempDirExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TempDirExtension.java
@@ -15,8 +15,8 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
 import org.spockframework.runtime.extension.IMethodInterceptor;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import org.spockframework.tempdir.TempDirConfiguration;
 import org.spockframework.util.Beta;
@@ -32,7 +32,7 @@ import java.util.Set;
  * @since 2.0
  */
 @Beta
-public class TempDirExtension implements IAnnotationDrivenExtension<TempDir> {
+public class TempDirExtension implements IStatelessAnnotationDrivenExtension<TempDir> {
 
   private static final Set<MethodKind> VALID_METHOD_KINDS = EnumSet.of(MethodKind.SETUP, MethodKind.SETUP_SPEC, MethodKind.FEATURE);
   private final TempDirConfiguration configuration;

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TimeoutExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TimeoutExtension.java
@@ -14,7 +14,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.MethodInfo;
 import org.spockframework.runtime.model.SpecInfo;
@@ -25,7 +25,7 @@ import java.time.Duration;
 /**
  * @author Peter Niederwieser
  */
-public class TimeoutExtension implements IAnnotationDrivenExtension<Timeout> {
+public class TimeoutExtension implements IStatelessAnnotationDrivenExtension<Timeout> {
 
   private final TimeoutConfiguration configuration;
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TitleExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TitleExtension.java
@@ -14,12 +14,12 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.SpecInfo;
 
 import spock.lang.Title;
 
-public class TitleExtension implements IAnnotationDrivenExtension<Title> {
+public class TitleExtension implements IStatelessAnnotationDrivenExtension<Title> {
   @Override
   public void visitSpecAnnotation(Title title, SpecInfo spec) {
     spec.setDisplayName(title.value().trim());

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UseExtension.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/UseExtension.java
@@ -16,7 +16,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.IInterceptable;
 import org.spockframework.runtime.model.MethodInfo;
@@ -29,7 +29,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toSet;
 
-public class UseExtension implements IAnnotationDrivenExtension<Use> {
+public class UseExtension implements IStatelessAnnotationDrivenExtension<Use> {
   @Override
   public void visitSpecAnnotations(List<Use> annotations, SpecInfo spec) {
     addInterceptor(annotations, spec.getBottomSpec());

--- a/spock-core/src/main/java/spock/mock/AutoAttachExtension.java
+++ b/spock-core/src/main/java/spock/mock/AutoAttachExtension.java
@@ -19,7 +19,7 @@ import org.spockframework.runtime.extension.*;
 import org.spockframework.runtime.model.*;
 import spock.lang.Specification;
 
-public class AutoAttachExtension implements IAnnotationDrivenExtension<AutoAttach> {
+public class AutoAttachExtension implements IStatelessAnnotationDrivenExtension<AutoAttach> {
   private static final MockUtil MOCK_UTIL = new MockUtil();
 
   @Override

--- a/spock-specs/src/test/groovy/org/spockframework/runtime/extension/AnnotationDrivenExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/runtime/extension/AnnotationDrivenExtensionSpec.groovy
@@ -1,0 +1,201 @@
+/*
+ *  Copyright 2024 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.runtime.extension
+
+import spock.config.ConfigurationObject
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.FieldInfo
+import org.spockframework.runtime.model.MethodInfo
+import org.spockframework.runtime.model.SpecInfo
+
+class AnnotationDrivenExtensionSpec extends EmbeddedSpecification {
+
+  def setup() {
+    runner.addClassImport(Stateful)
+    runner.addClassImport(Stateless)
+    runner.configClasses << ExtensionCounter
+  }
+
+  def "stateless extensions get re-used and stateful extensions get fresh instances per spec"() {
+    given:
+    def stateful = new AtomicInteger()
+    def stateless = new AtomicInteger()
+    runner.configurationScript {
+      extensionCounter {
+        statefulCounter stateful
+        statelessCounter stateless
+      }
+    }
+
+    when:
+    runner.runWithImports('''
+    @Stateful
+    @Stateless
+    class ASpec extends Specification {
+      def "a feature"() {
+        expect: true
+      }
+    }
+    
+    @Stateful
+    @Stateless
+    class BSpec extends Specification {
+      def "b feature"() {
+        expect: true
+      }
+    }
+    
+    @Stateful
+    @Stateless
+    class CSpec extends Specification {
+      def "c feature"() {
+        expect: true
+      }
+    }
+    ''')
+
+    then:
+    stateful.get() == 3
+    stateless.get() == 1
+  }
+
+  def "both stateful and stateless only have one instance per spec regardless of use"() {
+    given:
+    def stateful = new AtomicInteger()
+    def stateless = new AtomicInteger()
+    runner.configurationScript {
+      extensionCounter {
+        statefulCounter stateful
+        statelessCounter stateless
+      }
+    }
+
+    when:
+    runner.runWithImports('''
+    @Stateful
+    @Stateless
+    class ASpec extends Specification {
+      
+      @Stateful
+      @Stateless
+      int a
+      
+      @Stateful
+      @Stateless
+      int b
+      
+      @Stateful
+      @Stateless
+      def setupSpec() {
+      }
+      
+      @Stateful
+      @Stateless
+      def setup() {
+      }
+   
+      
+      @Stateful
+      @Stateless
+      def "a feature"() {
+        expect: true
+      }
+      @Stateful
+      @Stateless
+      def "b feature"() {
+        expect: true
+      }
+    }
+    
+    ''')
+
+    then:
+    stateful.get() == 1
+    stateless.get() == 1
+  }
+}
+
+
+@Target([ElementType.TYPE, ElementType.METHOD, ElementType.FIELD])
+@Retention(RetentionPolicy.RUNTIME)
+@ExtensionAnnotation(StatefulExtension)
+@interface Stateful {
+}
+
+class StatefulExtension implements IAnnotationDrivenExtension<Stateful> {
+
+  StatefulExtension(ExtensionCounter extensionCounter) {
+    extensionCounter.statefulCounter.incrementAndGet()
+  }
+
+  @Override
+  void visitSpecAnnotation(Stateful annotation, SpecInfo spec) {
+  }
+
+  @Override
+  void visitFieldAnnotation(Stateful annotation, FieldInfo field) {
+  }
+
+  @Override
+  void visitFeatureAnnotation(Stateful annotation, FeatureInfo feature) {
+  }
+
+  @Override
+  void visitFixtureAnnotation(Stateful annotation, MethodInfo fixtureMethod) {
+  }
+}
+
+@Target([ElementType.TYPE, ElementType.METHOD, ElementType.FIELD])
+@Retention(RetentionPolicy.RUNTIME)
+@ExtensionAnnotation(StatelessExtension)
+@interface Stateless {
+}
+
+class StatelessExtension implements IStatelessAnnotationDrivenExtension<Stateless> {
+
+  StatelessExtension(ExtensionCounter extensionCounter) {
+    extensionCounter.statelessCounter.incrementAndGet()
+  }
+
+  @Override
+  void visitSpecAnnotation(Stateless annotation, SpecInfo spec) {
+  }
+
+  @Override
+  void visitFieldAnnotation(Stateless annotation, FieldInfo field) {
+  }
+
+  @Override
+  void visitFeatureAnnotation(Stateless annotation, FeatureInfo feature) {
+  }
+
+  @Override
+  void visitFixtureAnnotation(Stateless annotation, MethodInfo fixtureMethod) {
+  }
+}
+
+@ConfigurationObject("extensionCounter")
+class ExtensionCounter {
+  AtomicInteger statefulCounter
+  AtomicInteger statelessCounter
+}

--- a/spock-spring/src/main/java/org/spockframework/spring/UnwrapAopProxyExtension.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/UnwrapAopProxyExtension.java
@@ -23,7 +23,7 @@ import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.util.Assert;
 
-public class UnwrapAopProxyExtension implements IAnnotationDrivenExtension<UnwrapAopProxy> {
+public class UnwrapAopProxyExtension implements IStatelessAnnotationDrivenExtension<UnwrapAopProxy> {
 
   @Override
   public void visitFieldAnnotation(UnwrapAopProxy annotation, final FieldInfo field) {

--- a/spock-unitils/src/main/java/org/spockframework/unitils/UnitilsExtension.java
+++ b/spock-unitils/src/main/java/org/spockframework/unitils/UnitilsExtension.java
@@ -14,14 +14,14 @@
 
 package org.spockframework.unitils;
 
-import org.spockframework.runtime.extension.IAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.IStatelessAnnotationDrivenExtension;
 import org.spockframework.runtime.model.*;
 import org.spockframework.util.NotThreadSafe;
 
 import spock.unitils.UnitilsSupport;
 
 @NotThreadSafe
-public class UnitilsExtension implements IAnnotationDrivenExtension<UnitilsSupport> {
+public class UnitilsExtension implements IStatelessAnnotationDrivenExtension<UnitilsSupport> {
   @Override
   public void visitSpecAnnotation(UnitilsSupport unitilsSupport, SpecInfo spec) {
     UnitilsInterceptor interceptor = new UnitilsInterceptor();


### PR DESCRIPTION
which allows Spock to re-use the same instance for all Specifications,
instead of creating a new instance for each.