### PR TITLE
Move workflows Kotlin dependencies for Gradle to version catalog

### DIFF
--- a/build-logic/preprocess-workflows/preprocess-workflows.gradle
+++ b/build-logic/preprocess-workflows/preprocess-workflows.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation('org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.0')
+  implementation(libs.workflows.kotlin.compiler.embeddable)
 }
 
 gradlePlugin {

--- a/build-logic/preprocess-workflows/preprocess-workflows.gradle
+++ b/build-logic/preprocess-workflows/preprocess-workflows.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation(libs.workflows.kotlin.compiler.embeddable)
+  implementation(libs.workflows.kotlin.compilerEmbeddable)
 }
 
 gradlePlugin {

--- a/build-logic/preprocess-workflows/src/main/groovy/org/spockframework/gradle/PreprocessWorkflowsPlugin.groovy
+++ b/build-logic/preprocess-workflows/src/main/groovy/org/spockframework/gradle/PreprocessWorkflowsPlugin.groovy
@@ -43,10 +43,10 @@ class PreprocessWorkflowsPlugin implements Plugin<Project> {
     def libs = project.extensions.getByType(VersionCatalogsExtension).find('libs').orElseThrow(AssertionError::new)
     def kotlinCompilerClasspath = project.configurations.detachedConfiguration(
       libs.findLibrary('workflows-kotlin-compiler').orElseThrow(AssertionError::new).get(),
-      libs.findLibrary('workflows-kotlin-scripting-compiler').orElseThrow(AssertionError::new).get()
+      libs.findLibrary('workflows-kotlin-scriptingCompiler').orElseThrow(AssertionError::new).get()
     )
     def kotlinScriptClasspath = project.configurations.detachedConfiguration(
-      libs.findLibrary('workflows-kotlin-main-kts').orElseThrow(AssertionError::new).get()
+      libs.findLibrary('workflows-kotlin-mainKts').orElseThrow(AssertionError::new).get()
     ).tap {
       it.transitive = false
     }

--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,7 @@ tasks.register("codeCoverageReport", JacocoReport) {
 }
 
 if (gradle.startParameter.taskNames == ["ghActionsBuild"]) {
-  gradle.startParameter.taskNames = ["build", "codeCoverageReport"]
+  gradle.startParameter.taskNames = ["build", "preprocessWorkflows", "codeCoverageReport"]
 }
 
 if (gradle.startParameter.taskNames == ["ghActionsPublish"] || gradle.startParameter.taskNames == ["ghActionsDocs"]) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ jacoco = '0.8.12'
 junit = '5.11.4'
 asm = '9.7.1'
 mockito4 = '4.11.0'
-mockito5 = '5.15s.2'
+mockito5 = '5.15.2'
 workflows-kotlin = "2.0.20"
 
 [libraries]
@@ -35,9 +35,9 @@ junit-jupiter.module = "org.junit.jupiter:junit-jupiter"
 junit-platform-testkit.module = "org.junit.platform:junit-platform-testkit"
 junit-platform-console.module = "org.junit.platform:junit-platform-console"
 workflows-kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "workflows-kotlin" }
-workflows-kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "workflows-kotlin" }
-workflows-kotlin-main-kts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "workflows-kotlin" }
-workflows-kotlin-scripting-compiler = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler", version.ref = "workflows-kotlin" }
+workflows-kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "workflows-kotlin" }
+workflows-kotlin-mainKts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "workflows-kotlin" }
+workflows-kotlin-scriptingCompiler = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler", version.ref = "workflows-kotlin" }
 
 # just here so that renovate can figure out the dependencies
 groovy-v2 = { module = "org.codehaus.groovy:groovy", version.ref="groovy2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,8 @@ jacoco = '0.8.12'
 junit = '5.11.4'
 asm = '9.7.1'
 mockito4 = '4.11.0'
-mockito5 = '5.15.2'
+mockito5 = '5.15s.2'
+workflows-kotlin = "2.0.20"
 
 [libraries]
 jetbrains-annotations = "org.jetbrains:annotations:26.0.1"
@@ -33,6 +34,10 @@ junit-bom =  { module = "org.junit:junit-bom",  version.ref = "junit" }
 junit-jupiter.module = "org.junit.jupiter:junit-jupiter"
 junit-platform-testkit.module = "org.junit.platform:junit-platform-testkit"
 junit-platform-console.module = "org.junit.platform:junit-platform-console"
+workflows-kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "workflows-kotlin" }
+workflows-kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "workflows-kotlin" }
+workflows-kotlin-main-kts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "workflows-kotlin" }
+workflows-kotlin-scripting-compiler = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler", version.ref = "workflows-kotlin" }
 
 # just here so that renovate can figure out the dependencies
 groovy-v2 = { module = "org.codehaus.groovy:groovy", version.ref="groovy2" }


### PR DESCRIPTION
This contains old Kotlin version to test that Renovate now properly updates it.
