### PR TITLE
Fix the `IStoreProvider` impl. in SpecContext...

### DIFF
--- a/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/PlatformSpecRunner.java
@@ -87,7 +87,9 @@ public class PlatformSpecRunner {
 
     context = context.withChildStoreProvider().withCurrentInstance(instance);
     getSpecificationContext(context).setCurrentSpec(context.getSpec());
-    getSpecificationContext(context).pushStoreProvider(context.getStoreProvider());
+
+    // this is either for the shared spec instance or the current iteration
+    getSpecificationContext(context).setStoreProvider(context.getStoreProvider());
     if (shared) {
       context = context.withSharedInstance(instance);
     }
@@ -193,14 +195,11 @@ public class PlatformSpecRunner {
     // so the current feature cannot be set as features can run in parallel
     // so getting the current feature from the specification context would not properly work
 
-    getSpecificationContext(context).pushStoreProvider(context.getStoreProvider());
-
     supervisor.beforeFeature(currentFeature);
     invoke(context, this, createMethodInfoForDoRunFeature(context, feature));
     supervisor.afterFeature(currentFeature);
 
     runCloseContextStoreProvider(context, MethodKind.CLEANUP);
-    getSpecificationContext(context).popStoreProvider();
   }
 
   private MethodInfo createMethodInfoForDoRunFeature(SpockExecutionContext context, Runnable feature) {
@@ -222,15 +221,11 @@ public class PlatformSpecRunner {
 
     context = context.withCurrentIteration(iterationInfo);
     getSpecificationContext(context).setCurrentIteration(iterationInfo);
-    getSpecificationContext(context).pushStoreProvider(context.getStoreProvider());
 
     supervisor.beforeIteration(iterationInfo);
     invoke(context, this, createMethodInfoForDoRunIteration(context, runnable));
     supervisor.afterIteration(iterationInfo);
     runCloseContextStoreProvider(context, MethodKind.CLEANUP);
-
-    getSpecificationContext(context).setCurrentIteration(null); // TODO check if we really need to null here
-    getSpecificationContext(context).popStoreProvider();
   }
 
   IterationInfo createIterationInfo(SpockExecutionContext context, int iterationIndex, Object[] args, int estimatedNumIterations) {

--- a/spock-core/src/main/java/org/spockframework/runtime/SpecificationContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpecificationContext.java
@@ -22,7 +22,7 @@ public class SpecificationContext implements ISpecificationContext {
   private volatile Specification sharedInstance;
 
   private volatile Throwable thrownException;
-  private final Deque<IStoreProvider> storeProvider = new ArrayDeque<>(3); // spec, feature, iteration
+  private volatile IStoreProvider storeProvider; // shared spec or iteration
 
   private final MockController mockController = new MockController();
 
@@ -113,14 +113,10 @@ public class SpecificationContext implements ISpecificationContext {
 
   @Override
   public IStore getStore(IStore.Namespace namespace) {
-    return storeProvider.getLast().getStore(namespace);
+    return storeProvider.getStore(namespace);
   }
 
-  public void pushStoreProvider(IStoreProvider storeProvider) {
-    this.storeProvider.push(storeProvider);
-  }
-
-  public void popStoreProvider() {
-    this.storeProvider.pop();
+  public void setStoreProvider(IStoreProvider storeProvider) {
+    this.storeProvider = storeProvider;
   }
 }


### PR DESCRIPTION
The `SpecificationContext` always belongs to a single spec instance,
so it is either the shared `Specification` instance or it belongs to
the iteration. There is no `Feature`-level instance, so we don't need
to use a stack.
