### PR TITLE
Prevent major Groovy version upgrade for Spock dependency in tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,6 +24,16 @@
       matchPackagePrefixes: ["org.mockito:"],
       matchCurrentValue: "/^4\\./",
       allowedVersions: "(,5.0)"
+    },
+    {
+      matchPackagePrefixes: ["org.spockframework:spock-"],
+      matchCurrentVersion: "/-groovy-3\\.0$/",
+      allowedVersions: "/-groovy-3\\.0$/"
+    },
+    {
+      matchPackagePrefixes: ["org.spockframework:spock-"],
+      matchCurrentVersion: "/-groovy-4\\.0$/",
+      allowedVersions: "/-groovy-4\\.0$/"
     }
   ]
 }


### PR DESCRIPTION
It should prevent 2.3-groovy-3.0 -> 2.3-groovy-4.0 upgrade by Renovate, such as: https://github.com/spockframework/spock/pull/2098