### PR TITLE
Clarified strict mocks doc

### DIFF
--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -75,10 +75,10 @@ code that expects this type.
 
 .Lenient vs. Strict Mocking Frameworks
 ****
-Like Mockito, we firmly believe that a mocking framework should be lenient by default. This means that unexpected
+We firmly believe that a mocking framework should be lenient by default. This means that unexpected
 method calls on mock objects (or, in other words, interactions that aren't relevant for the test at hand) are allowed
-and answered with a default response. Conversely, mocking frameworks like EasyMock and JMock are strict by default,
-and throw an exception for every unexpected method call. While strictness enforces rigor, it can also lead
+and answered with a default response. Conversely, other mocking frameworks like EasyMock, JMock and Mockito (starting with Mockito v4)
+are strict by default, and throw an exception for every unexpected method call. While strictness enforces rigor, it can also lead
 to over-specification, resulting in brittle tests that fail with every other internal code change. Spock's mocking
 framework makes it easy to describe only what's relevant about an interaction, avoiding the over-specification trap.
 ****


### PR DESCRIPTION
In reality, [Mockito is really using stricts mocks by default since 4 major release](https://github.com/mockito/mockito/blob/main/mockito-core/src/main/java/org/mockito/quality/Strictness.java#L24). So I think it is worth updating this doc :)