### PR TITLE
Remove the optimization which data provider is remembered in a multiplication

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/DataSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/DataSpec.groovy
@@ -200,8 +200,10 @@ class DataSpec extends EmbeddedSpecification {
       tag::single-data-providers-combined-result1[]
       - `feature [a: 1, b: 5, c: 7, #0]`
       - `feature [a: 2, b: 5, c: 8, #1]`
-      - `feature [a: 3, b: 6, c: 7, #2]`
-      - `feature [a: 4, b: 6, c: 8, #3]`
+      - `feature [a: 3, b: 5, c: 9, #2]`
+      - `feature [a: 4, b: 6, c: 7, #3]`
+      - `feature [a: 5, b: 6, c: 8, #4]`
+      - `feature [a: 6, b: 6, c: 9, #5]`
       end::single-data-providers-combined-result1[]
     '''
       .stripIndent(*(GroovyRuntimeUtil.groovy3orNewer ? [true] : []))
@@ -218,10 +220,10 @@ class DataSpec extends EmbeddedSpecification {
 
         // tag::single-data-providers-combined1[]
         where:
-        a << [1, 2, 3, 4]
+        a << [1, 2, 3, 4, 5, 6]
         b << [5, 6]
         combined:
-        c << [7, 8]
+        c << [7, 8, 9]
         // end::single-data-providers-combined1[]
       }
     '''

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/DataTables.groovy
@@ -316,10 +316,10 @@ class DataTables extends EmbeddedSpecification {
     results.testEvents().started().list().testDescriptor.displayName == [
       'a feature (#a #b #c)',
       'a feature (1 3 4)',
-      'a feature (2 3 4)',
       'a feature (1 3 5)',
-      'a feature (2 3 5)',
       'a feature (1 3 6)',
+      'a feature (2 3 4)',
+      'a feature (2 3 5)',
       'a feature (2 3 6)'
     ]
 

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataTables/filtered_iterations_are_logged.txt
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataTables/filtered_iterations_are_logged.txt
@@ -1,4 +1,4 @@
-Filtered iteration [i: 2, a: 2, b: 2, c: 1]:
+Filtered iteration [i: 2, a: 1, b: 1, c: 2]:
 Condition not satisfied:
 
 i == 1
@@ -7,7 +7,7 @@ i == 1
 
 	at apackage.ASpec.a feature(script.groovy:15)
 
-Filtered iteration [i: 3, a: 1, b: 1, c: 2]:
+Filtered iteration [i: 3, a: 1, b: 1, c: 3]:
 Condition not satisfied:
 
 i == 1
@@ -16,7 +16,7 @@ i == 1
 
 	at apackage.ASpec.a feature(script.groovy:15)
 
-Filtered iteration [i: 4, a: 2, b: 2, c: 2]:
+Filtered iteration [i: 4, a: 2, b: 2, c: 1]:
 Condition not satisfied:
 
 i == 1
@@ -25,7 +25,7 @@ i == 1
 
 	at apackage.ASpec.a feature(script.groovy:15)
 
-Filtered iteration [i: 5, a: 1, b: 1, c: 3]:
+Filtered iteration [i: 5, a: 2, b: 2, c: 2]:
 Condition not satisfied:
 
 i == 1


### PR DESCRIPTION
This could cause unintuitive behavior and change of test sets which are executed.