### PR TITLE
Retry extension does not mesh with TestAbortedException and PendingFeature

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -63,6 +63,7 @@ will now require that the spec is annotated with <<parallel_execution.adoc#isola
 * Fix incompatibility with JUnit 6 in OSGi environment spockIssue:2231[]
 * OSGi: Pin the `Require-Capability:osgi.ee=JavaSE` to Java `8` spockPull:2233[]
 * Fix: Prevent NPE in SpecRunHistory.sortFeatures when duration is missing spockIssue:2234[]
+* `Retry` extension does not mesh with `TestAbortedException` and `PendingFeature` spockIssue:1863[]
 
 == 2.4-M6 (2025-04-15)
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryBaseInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/RetryBaseInterceptor.java
@@ -16,6 +16,7 @@
 
 package org.spockframework.runtime.extension.builtin;
 
+import org.opentest4j.TestAbortedException;
 import org.spockframework.runtime.GroovyRuntimeUtil;
 import org.spockframework.runtime.extension.*;
 import spock.lang.Retry;
@@ -58,6 +59,12 @@ public class RetryBaseInterceptor {
   }
 
   private boolean hasExpectedClass(Throwable failure) {
+    for (Class<? extends Throwable> exception : retry.skipRetryExceptions()) {
+      if (exception.isInstance(failure)) {
+        return false;
+      }
+    }
+
     for (Class<? extends Throwable> exception : retry.exceptions()) {
       if (exception.isInstance(failure)) {
         return true;

--- a/spock-core/src/main/java/spock/lang/Retry.java
+++ b/spock-core/src/main/java/spock/lang/Retry.java
@@ -16,7 +16,9 @@
 
 package spock.lang;
 
+import org.opentest4j.TestAbortedException;
 import org.spockframework.runtime.extension.ExtensionAnnotation;
+import org.spockframework.runtime.extension.builtin.PendingFeatureSuccessfulError;
 import org.spockframework.runtime.extension.builtin.RetryExtension;
 import org.spockframework.util.Beta;
 
@@ -53,6 +55,23 @@ public @interface Retry {
    * @return array of Exception classes to retry.
    */
   Class<? extends Throwable>[] exceptions() default {Exception.class, AssertionError.class};
+
+  /**
+   * Configures which types of Exceptions should skip any remaining retry.
+   * If the retry is skipped, the exception will be thrown.
+   *
+   * <p>Subclasses are included if their parent class is listed.
+   *
+   * <p>These Exceptions are evaluated before {@link #exceptions()} are evaluated.
+   *
+   * @return array of Exception classes which cause the retry to skip.
+   * @since 2.4
+   */
+  @Beta
+  Class<? extends Throwable>[] skipRetryExceptions() default {
+    TestAbortedException.class, //TestAbortedException shall skip to allow interop with annotations like @IgnoreIf, see https://github.com/spockframework/spock/issues/1863
+    PendingFeatureSuccessfulError.class //Iterop with @PendingFeature to skip the Retry
+  };
 
   /**
    * Condition that is evaluated to decide whether the feature should be
@@ -99,7 +118,7 @@ public @interface Retry {
     ITERATION,
 
     /**
-     * Retry the the feature together with the setup and cleanup methods.
+     * Retry the feature together with the setup and cleanup methods.
      */
     SETUP_FEATURE_CLEANUP
   }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryPendingFeatureInteropSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryPendingFeatureInteropSpec.groovy
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.extension
+
+import org.opentest4j.TestAbortedException
+import org.spockframework.EmbeddedSpecification
+import spock.lang.Issue
+import spock.lang.PendingFeature
+import spock.lang.PendingFeatureIf
+import spock.lang.Retry
+import spock.lang.Specification
+
+/**
+ * This specification shall test the interoperation between {@link PendingFeature} and the {@link Retry} extension.
+ */
+@Issue("https://github.com/spockframework/spock/issues/1863")
+class RetryPendingFeatureInteropSpec extends EmbeddedSpecification {
+
+  def setup() {
+    runner.addClassImport(Specification)
+    runner.addClassImport(PendingFeature)
+    runner.addClassImport(PendingFeatureIf)
+    runner.addClassImport(Retry)
+    runner.addClassImport(TestAbortedException)
+  }
+
+  /**
+   * This test and the next test checks for the different interceptor combinations, because PendingFeature and Retry
+   * influence each other with the exception handling.
+   */
+  def "Retry feature shall be skipped when using PendingFeature"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @PendingFeature
+  @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
+  def "feature"() {
+    expect:
+    false
+  }
+""")) {
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  /**
+   * See test above, where the order of the annotations is switch, where the retry is the outer interceptor.
+   */
+  def "Retry feature inverse annotation order shall be skipped when using PendingFeature"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
+  @PendingFeature
+  def "feature"() {
+    expect:
+    false
+  }
+""")) {
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry feature shall be skipped when using PendingFeatureIf"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @PendingFeatureIf({ true })
+  @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
+  def "Retry feature shall be skipped when using PendingFeatureIf"() {
+    expect:
+    false
+  }
+""")) {
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry feature inverse annotation order shall be skipped when using PendingFeatureIf"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
+  @PendingFeatureIf({ true })
+  def "feature"() {
+    expect:
+    false
+  }
+""")) {
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry iteration shall be skipped when using PendingFeature"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @PendingFeature
+  @Retry(mode = Retry.Mode.ITERATION)
+  def "feature"() {
+    expect:
+    false
+  }
+""")) {
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry feature parameterized shall be skipped when using PendingFeature"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @PendingFeature
+  @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
+  def "feature"() {
+    expect:
+    if (i)
+      throw new Exception()
+
+    where:
+    i << [1, 2]
+  }
+""")) {
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 2
+      testsSucceededCount == 1
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry iteration parameterized shall be skipped when using PendingFeature"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @PendingFeature
+  @Retry(mode = Retry.Mode.ITERATION)
+  def "feature"() {
+    expect:
+    if (i)
+      throw new Exception()
+
+    where:
+    i << [1, 2]
+  }
+""")) {
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 2
+      testsSucceededCount == 1
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry iteration parameterized shall be skipped when using PendingFeatureIf"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @PendingFeatureIf({ true })
+  @Retry(mode = Retry.Mode.ITERATION)
+  def "feature"() {
+    expect:
+    if (i)
+      throw new Exception()
+
+    where:
+    i << [1, 2]
+  }
+""")) {
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 2
+      testsSucceededCount == 1
+      testsFailedCount == 0
+    }
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryTestAbortedExceptionInteropSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/RetryTestAbortedExceptionInteropSpec.groovy
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.extension
+
+import org.opentest4j.TestAbortedException
+import org.spockframework.EmbeddedSpecification
+import spock.lang.IgnoreIf
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Retry
+import spock.lang.Specification
+
+/**
+ * This specification shall test the interoperation of API using the {@link TestAbortedException} and the {@link Retry} extension.
+ */
+@Issue("https://github.com/spockframework/spock/issues/1863")
+class RetryTestAbortedExceptionInteropSpec extends EmbeddedSpecification {
+
+  def setup() {
+    runner.addClassImport(Specification)
+    runner.addClassImport(Requires)
+    runner.addClassImport(IgnoreIf)
+    runner.addClassImport(Retry)
+    runner.addClassImport(TestAbortedException)
+  }
+
+  def "Retry iteration shall be skipped if a TestAbortedException is thrown"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Retry(mode = Retry.Mode.ITERATION)
+  def "feature"() {
+    expect:
+    throw new TestAbortedException()
+  }
+""")) {
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry feature shall be skipped if a TestAbortedException is thrown"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
+  def "feature"() {
+    expect:
+    throw new TestAbortedException()
+  }
+  """)) {
+      testsStartedCount == 1
+      testsSkippedCount == 0
+      testsAbortedCount == 1
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry iteration parameterized shall be skipped if a TestAbortedException is thrown"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Retry(mode = Retry.Mode.ITERATION)
+  def "feature"() {
+    expect:
+    if (i > 0)
+      throw new TestAbortedException(i.toString())
+
+    where:
+    i << [1, 2]
+  }
+  """)) {
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 2
+      testsSucceededCount == 1
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry feature parameterized shall be skipped if a TestAbortedException is thrown"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
+  def "feature"() {
+    expect:
+    if (i > 0)
+      throw new TestAbortedException(i.toString())
+
+    where:
+    i << [1, 2]
+  }
+  """)) {
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 2
+      testsSucceededCount == 1
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry shall be skipped when feature is ignored"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @IgnoreIf({ true })
+  @Retry
+  def "feature"() {
+    expect:
+    false
+  }
+""")) {
+      testsStartedCount == 0
+      testsSkippedCount == 1
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry inverse shall be skipped when feature is ignored"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Retry
+  @IgnoreIf({ true })
+  def "feature"() {
+    expect:
+    false
+  }
+""")) {
+      testsStartedCount == 0
+      testsSkippedCount == 1
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry parameterized shall be skipped when feature is ignored"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @IgnoreIf({ true })
+  @Retry
+  def "feature"() {
+    expect:
+    false
+
+    where:
+    i << [1, 2]
+  }
+""")) {
+      testsStartedCount == 0
+      testsSkippedCount == 1
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+
+  def "Retry inverse parameterized shall be skipped when feature is ignored"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Retry
+  @IgnoreIf({ true })
+  def "feature"() {
+    expect:
+    false
+
+    where:
+    i << [1, 2]
+  }
+""")) {
+      testsStartedCount == 0
+      testsSkippedCount == 1
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry shall be skipped  when using Requires"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Requires({ false })
+  @Retry
+  def "feature"() {
+    expect:
+    false
+  }
+""")) {
+      testsStartedCount == 0
+      testsSkippedCount == 1
+      testsAbortedCount == 0
+      testsSucceededCount == 0
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry iteration parameterized shall be skipped when using Requires"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Requires({ data.get("i") && false })
+  @Retry(mode = Retry.Mode.ITERATION)
+  def "feature"() {
+    expect:
+    false
+
+    where:
+    i << [1, 2]
+  }
+""")) {
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 2
+      testsSucceededCount == 1
+      testsFailedCount == 0
+    }
+  }
+
+  def "Retry feature parameterized shall be skipped when using Requires"() {
+    expect:
+    verifyAll(runner.runSpecBody("""
+  @Requires({ data.get("i") && false })
+  @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
+  def "feature"() {
+    expect:
+    false
+
+    where:
+    i << [1, 2]
+  }
+""")) {
+      testsStartedCount == 3
+      testsSkippedCount == 0
+      testsAbortedCount == 2
+      testsSucceededCount == 1
+      testsFailedCount == 0
+    }
+  }
+}


### PR DESCRIPTION
The Retry annotation now skips when a TestAbortedException is thrown. 
And it also interoperates now with the PendingFeature correctly.

Fixes #1863