### PR TITLE
Enable implicit non-top-level conditions (#1160)

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -25,6 +25,17 @@ include::include.adoc[]
 === Breaking Changes
 
 * Mock/Stub checks on `Comparable<T>` with `T` being something other than `Object` now compare using the java identity hash code instead of always being equal spockIssue:2352[]
+* It is no longer true that only top-level expression statements are treated as implicit conditions.
+Just like within `with { ... }`, `verifyAll { ... }`, `@ConditionBlock` methods, and other places, each expression statement is now considered an implicit condition, except for statements in unknown closures.
++
+This enables the usage of `if` and similar while also being able to still safely use `.every { ... }`, but without the regular confusion why a test is not failing if the condition is inside an `if`.
+You can even have interactions in those nested places now.
++
+As now expression statements are considered implicit conditions that previously were not, this can lead to compilation errors in existing code-bases, because such nested statements were previously simply ignored by the Spock compiler and now also must be valid conditions.
++
+If those compile errors are not accidentally written assignments that should have been conditions or similar, you can for example use the <<spock_primer.adoc#opt-out-of-condition-handling,`!!` prefix operator>> to declare an expression statement explicitly as not being an implicit condition.
++
+spockPull:2250[]
 
 == 2.4 (2025-12-11)
 

--- a/docs/spock_primer.adoc
+++ b/docs/spock_primer.adoc
@@ -230,8 +230,9 @@ digestible form. Nice, isn't it?
 ===== Implicit and explicit conditions
 
 Conditions are an essential ingredient of `then` blocks and `expect` blocks. Except for calls to `void` methods and
-expressions classified as interactions, all top-level expressions in these blocks are implicitly treated as conditions.
-To use conditions in other places, you need to designate them with Groovy's assert keyword:
+expressions classified as interactions, all expression statements in these blocks are implicitly treated as conditions
+except if they happen inside some unknown closure.
+To use conditions in other places, you need to designate them with Groovy's `assert` keyword:
 
 [source,groovy]
 ----

--- a/spock-core/src/main/java/org/spockframework/compiler/AbstractDeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AbstractDeepBlockRewriter.java
@@ -151,7 +151,7 @@ public class AbstractDeepBlockRewriter extends StatementReplacingVisitorSupport 
     groupConditionFound = false;
     ISpecialMethodCall oldSpecialMethodCall = currSpecialMethodCall;
     if (!currSpecialMethodCall.isMatch(expr)) {
-      currSpecialMethodCall = NoSpecialMethodCall.INSTANCE; // unrelated closure terminates currSpecialMethodCall scope
+      currSpecialMethodCall = NoSpecialMethodCall.CLOSURE_INSTANCE; // unrelated closure terminates currSpecialMethodCall scope
     }
     try {
       Statement code = expr.getCode();

--- a/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
@@ -200,7 +200,7 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
   }
 
   private boolean handleImplicitCondition(ExpressionStatement stat) {
-    if (!(stat == currTopLevelStat && isThenOrExpectOrFilterBlock()
+    if (!(((currSpecialMethodCall == NoSpecialMethodCall.INSTANCE) && isThenOrExpectOrFilterBlock())
         || currSpecialMethodCall.isConditionMethodCall()
         || currSpecialMethodCall.isConditionBlock()
         || currSpecialMethodCall.isGroupConditionBlock()

--- a/spock-core/src/main/java/org/spockframework/compiler/NoSpecialMethodCall.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/NoSpecialMethodCall.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 
 public class NoSpecialMethodCall implements ISpecialMethodCall {
   public static final ISpecialMethodCall INSTANCE = new NoSpecialMethodCall();
+  public static final ISpecialMethodCall CLOSURE_INSTANCE = new NoSpecialMethodCall();
 
   @Override
   public boolean isMethodName(String name) {

--- a/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitFixtureMethods.groovy
+++ b/spock-junit4/src/test/groovy/org/spockframework/junit4/junit/JUnitFixtureMethods.groovy
@@ -151,7 +151,7 @@ class JUnitFixtureMethods extends JUnitBaseSpec {
     then:
     def e = result.failures[exceptionPos].exception
     if (suppressed) {
-      e = e.suppressed[0]
+      !!(e = e.suppressed[0])
     }
     e instanceof RuntimeException
     e.message == name

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionEvaluation.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionEvaluation.groovy
@@ -59,6 +59,19 @@ class ConditionEvaluation extends EmbeddedSpecification {
         7
   }
 
+  @FailsWith(ConditionNotSatisfiedError)
+  def "failing non-top-level condition"() {
+    expect:
+    if (true) {
+      2 * 3 == 7
+    }
+  }
+
+  def "failing non-top-level non-condition"() {
+    expect:
+    [1, 2, 3].any { it == 2 }
+  }
+
   def "MethodCallExpression"() {
     expect:
     [1, 2, 3].size() == 3

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/extension/TempDirExtensionSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/extension/TempDirExtensionSpec.groovy
@@ -88,12 +88,12 @@ class TempDirExtensionSpec extends EmbeddedSpecification {
       def tempFile = aaabbb.resolve("tmp.txt")
       Files.createDirectories(aaabbb)
       Files.write(tempFile, "ewfwf".bytes)
-      aaabbb.toFile().writable = false
-      aaa.toFile().writable = false
-      tempFile.toFile().writable = false
-      previousIteration = iterationDir
+      !!(aaabbb.toFile().writable = false)
+      !!(aaa.toFile().writable = false)
+      !!(tempFile.toFile().writable = false)
+      !!(previousIteration = iterationDir)
     } else if (i == 1) {
-      assert !previousIteration.exists()
+      !previousIteration.exists()
     }
 
     where:

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_private_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_private_methods.groovy
@@ -70,9 +70,13 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 3, 5, null, $spock_condition_throwable)}
     if (true) {
-        [true, false].any({
-            it
-        })
+        try {
+            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 5, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
+                it
+            })}, $spock_valueRecorder.realizeNas(7, false), false, 6)
+        }
+        catch (java.lang.Throwable $spock_condition_throwable) {
+            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 5, 9, null, $spock_condition_throwable)}
     }
     this.with({
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_private_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_private_methods.groovy
@@ -66,9 +66,13 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 3, 5, null, $spock_condition_throwable)}
     if (true) {
-        [true, false].any({
-            it
-        })
+        try {
+            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 5, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
+                it
+            })}, $spock_valueRecorder.realizeNas(7, false), false, 6)
+        }
+        catch (java.lang.Throwable $spock_condition_throwable) {
+            org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 5, 9, null, $spock_condition_throwable)}
     }
     this.with({
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()


### PR DESCRIPTION
Fixes #1160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Expression statements in then/expect/filter blocks — including many nested contexts and certain interaction closures — are now treated as implicit conditions by default; this may cause compilation failures. Use the prefix operator `!!` to opt out of implicit-condition handling.

* **Tests**
  * Added and updated tests and snapshots to cover non-top-level condition evaluation and related edge cases.

* **Documentation**
  * Updated release notes and primer to clarify implicit-condition rules and the unknown-closure exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->