### PR TITLE
Use fixed version to fix CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.main.kts
+++ b/.github/workflows/codeql-analysis.main.kts
@@ -24,19 +24,15 @@
 
 @file:Repository("https://bindings.krzeminski.it/")
 @file:DependsOn("actions:checkout___major:[v5,v6-alpha)")
-@file:DependsOn("github:codeql-action__analyze___major:[v4,v5-alpha)")
-@file:DependsOn("github:codeql-action__init___major:[v4,v5-alpha)")
+@file:DependsOn("github:codeql-action__analyze___major:v4")
+@file:DependsOn("github:codeql-action__init___major:v4")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.github.CodeqlActionAnalyze
 import io.github.typesafegithub.workflows.actions.github.CodeqlActionInit
 import io.github.typesafegithub.workflows.domain.Concurrency
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
-import io.github.typesafegithub.workflows.domain.triggers.Cron
-import io.github.typesafegithub.workflows.domain.triggers.MergeGroup
-import io.github.typesafegithub.workflows.domain.triggers.PullRequest
-import io.github.typesafegithub.workflows.domain.triggers.Push
-import io.github.typesafegithub.workflows.domain.triggers.Schedule
+import io.github.typesafegithub.workflows.domain.triggers.*
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts.github
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow


### PR DESCRIPTION
Fixes these issues.

```
> Task :preprocessCodeqlAnalysisWorkflow
.github/workflows/codeql-analysis.main.kts:31:58: error: unresolved reference 'CodeqlActionAnalyze'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionAnalyze
                                                         ^
.github/workflows/codeql-analysis.main.kts:32:58: error: unresolved reference 'CodeqlActionInit'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionInit
                                                         ^
.github/workflows/codeql-analysis.main.kts:90:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:92:22: error: unresolved reference 'CodeqlActionInit'.
            action = CodeqlActionInit(
                     ^
.github/workflows/codeql-analysis.main.kts:132:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:134:22: error: unresolved reference 'CodeqlActionAnalyze'.
            action = CodeqlActionAnalyze()
                     ^
.github/workflows/codeql-analysis.main.kts:31:58: error: unresolved reference 'CodeqlActionAnalyze'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionAnalyze
                                                         ^
.github/workflows/codeql-analysis.main.kts:32:58: error: unresolved reference 'CodeqlActionInit'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionInit
                                                         ^
.github/workflows/codeql-analysis.main.kts:90:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:92:22: error: unresolved reference 'CodeqlActionInit'.
            action = CodeqlActionInit(
                     ^
.github/workflows/codeql-analysis.main.kts:132:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:134:22: error: unresolved reference 'CodeqlActionAnalyze'.
            action = CodeqlActionAnalyze()
                     ^
.github/workflows/codeql-analysis.main.kts:31:58: error: unresolved reference 'CodeqlActionAnalyze'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionAnalyze
                                                         ^
.github/workflows/codeql-analysis.main.kts:32:58: error: unresolved reference 'CodeqlActionInit'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionInit
                                                         ^
.github/workflows/codeql-analysis.main.kts:90:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:92:22: error: unresolved reference 'CodeqlActionInit'.
            action = CodeqlActionInit(
                     ^
.github/workflows/codeql-analysis.main.kts:132:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:134:22: error: unresolved reference 'CodeqlActionAnalyze'.
            action = CodeqlActionAnalyze()
                     ^
.github/workflows/codeql-analysis.main.kts:31:58: error: unresolved reference 'CodeqlActionAnalyze'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionAnalyze
                                                         ^
.github/workflows/codeql-analysis.main.kts:32:58: error: unresolved reference 'CodeqlActionInit'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionInit
                                                         ^
.github/workflows/codeql-analysis.main.kts:90:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:92:22: error: unresolved reference 'CodeqlActionInit'.
            action = CodeqlActionInit(
                     ^
.github/workflows/codeql-analysis.main.kts:132:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:134:22: error: unresolved reference 'CodeqlActionAnalyze'.
            action = CodeqlActionAnalyze()
                     ^
.github/workflows/codeql-analysis.main.kts:31:58: error: unresolved reference 'CodeqlActionAnalyze'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionAnalyze
                                                         ^
.github/workflows/codeql-analysis.main.kts:32:58: error: unresolved reference 'CodeqlActionInit'.
import io.github.typesafegithub.workflows.actions.github.CodeqlActionInit
                                                         ^
.github/workflows/codeql-analysis.main.kts:90:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:92:22: error: unresolved reference 'CodeqlActionInit'.
            action = CodeqlActionInit(
                     ^
.github/workflows/codeql-analysis.main.kts:132:9: error: cannot infer type for type parameter 'T'. Specify it explicitly.
        uses(
        ^
.github/workflows/codeql-analysis.main.kts:134:22: error: unresolved reference 'CodeqlActionAnalyze'.
            action = CodeqlActionAnalyze()
                     ^
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL workflow dependencies to use stable versions and simplified workflow configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->