### PR TITLE
Fix typesafe workflow

### DIFF
--- a/.github/workflows/branches-and-prs.main.kts
+++ b/.github/workflows/branches-and-prs.main.kts
@@ -28,7 +28,7 @@
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.actions.Checkout.FetchDepth
-import io.github.typesafegithub.workflows.actions.codecov.CodecovAction
+import io.github.typesafegithub.workflows.actions.codecov.CodecovAction_Untyped
 import io.github.typesafegithub.workflows.domain.Concurrency
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
@@ -127,8 +127,8 @@ workflow(
         )
         uses(
             name = "Upload to Codecov.io",
-            action = CodecovAction(
-                failCiIfError = true
+            action = CodecovAction_Untyped(
+                failCiIfError_Untyped = "true"
             )
         )
     }

--- a/.github/workflows/branches-and-prs.main.kts
+++ b/.github/workflows/branches-and-prs.main.kts
@@ -23,7 +23,7 @@
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 @file:Repository("https://bindings.krzeminski.it/")
-@file:DependsOn("actions:checkout___major:[v5,v6-alpha)")
+@file:DependsOn("actions:checkout___major:[v6,v7-alpha)")
 @file:DependsOn("codecov:codecov-action___major:[v5,v6-alpha)")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout

--- a/.github/workflows/branches-and-prs.main.kts
+++ b/.github/workflows/branches-and-prs.main.kts
@@ -20,7 +20,7 @@
 
 @file:Repository("https://repo.maven.apache.org/maven2/")
 // work-around for https://youtrack.jetbrains.com/issue/KT-69145
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.6.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 @file:Repository("https://bindings.krzeminski.it/")
 @file:DependsOn("actions:checkout___major:[v5,v6-alpha)")

--- a/.github/workflows/branches-and-prs.yaml
+++ b/.github/workflows/branches-and-prs.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Checkout Repository'
-      uses: 'actions/checkout@v5'
+      uses: 'actions/checkout@v6'
     - id: 'step-1'
       name: 'Regenerate all Workflow YAMLs'
       run: 'find .github/workflows -mindepth 1 -maxdepth 1 -name ''*.main.kts'' -exec {} \;'
@@ -106,7 +106,7 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Checkout Repository'
-      uses: 'actions/checkout@v5'
+      uses: 'actions/checkout@v6'
       with:
         fetch-depth: '2'
     - id: 'step-1'

--- a/.github/workflows/codeql-analysis.main.kts
+++ b/.github/workflows/codeql-analysis.main.kts
@@ -23,13 +23,13 @@
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 @file:Repository("https://bindings.krzeminski.it/")
-@file:DependsOn("actions:checkout___major:[v5,v6-alpha)")
-@file:DependsOn("github:codeql-action__analyze___major:v4")
-@file:DependsOn("github:codeql-action__init___major:v4")
+@file:DependsOn("actions:checkout___major:[v6,v7-alpha)")
+@file:DependsOn("github:codeql-action__analyze___major:[v4.32.4,v5-alpha)")
+@file:DependsOn("github:codeql-action__init___major:[v4.32.4,v5-alpha)")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
-import io.github.typesafegithub.workflows.actions.github.CodeqlActionAnalyze
-import io.github.typesafegithub.workflows.actions.github.CodeqlActionInit
+import io.github.typesafegithub.workflows.actions.github.CodeqlActionAnalyze_Untyped
+import io.github.typesafegithub.workflows.actions.github.CodeqlActionInit_Untyped
 import io.github.typesafegithub.workflows.domain.Concurrency
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.triggers.*
@@ -85,7 +85,7 @@ workflow(
         // Initializes the CodeQL tools for scanning
         uses(
             name = "Initialize CodeQL",
-            action = CodeqlActionInit(
+            action = CodeqlActionInit_Untyped(
                 // Override language selection by uncommenting this and choosing your languages
                 // languages = listOf("go", "javascript", "csharp", "python", "cpp", "java"),
             )
@@ -127,7 +127,7 @@ workflow(
         )
         uses(
             name = "Perform CodeQL Analysis",
-            action = CodeqlActionAnalyze()
+            action = CodeqlActionAnalyze_Untyped()
         )
     }
 }

--- a/.github/workflows/codeql-analysis.main.kts
+++ b/.github/workflows/codeql-analysis.main.kts
@@ -20,7 +20,7 @@
 
 @file:Repository("https://repo.maven.apache.org/maven2/")
 // work-around for https://youtrack.jetbrains.com/issue/KT-69145
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.6.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 @file:Repository("https://bindings.krzeminski.it/")
 @file:DependsOn("actions:checkout___major:[v5,v6-alpha)")

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Checkout Repository'
-      uses: 'actions/checkout@v5'
+      uses: 'actions/checkout@v6'
     - id: 'step-1'
       name: 'Set up JDKs'
       uses: './.github/actions/setup-build-env'

--- a/.github/workflows/common.main.kts
+++ b/.github/workflows/common.main.kts
@@ -17,7 +17,7 @@
  */
 
 @file:Repository("https://repo.maven.apache.org/maven2/")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.6.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 import io.github.typesafegithub.workflows.domain.Job
 import io.github.typesafegithub.workflows.domain.JobOutputs.EMPTY

--- a/.github/workflows/docs-pr.main.kts
+++ b/.github/workflows/docs-pr.main.kts
@@ -24,7 +24,7 @@
 
 @file:Repository("https://bindings.krzeminski.it/")
 @file:DependsOn("actions:checkout___major:[v5,v6-alpha)")
-@file:DependsOn("actions:upload-artifact___major:[v5,v6-alpha)")
+@file:DependsOn("actions:upload-artifact___major:[v5,7.0)")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.actions.Checkout.FetchDepth

--- a/.github/workflows/docs-pr.main.kts
+++ b/.github/workflows/docs-pr.main.kts
@@ -20,7 +20,7 @@
 
 @file:Repository("https://repo.maven.apache.org/maven2/")
 // work-around for https://youtrack.jetbrains.com/issue/KT-69145
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.6.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 @file:Repository("https://bindings.krzeminski.it/")
 @file:DependsOn("actions:checkout___major:[v5,v6-alpha)")

--- a/.github/workflows/docs-pr.main.kts
+++ b/.github/workflows/docs-pr.main.kts
@@ -23,7 +23,7 @@
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 @file:Repository("https://bindings.krzeminski.it/")
-@file:DependsOn("actions:checkout___major:[v5,v6-alpha)")
+@file:DependsOn("actions:checkout___major:[v6,v7-alpha)")
 @file:DependsOn("actions:upload-artifact___major:[v5,7.0)")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Checkout Repository'
-      uses: 'actions/checkout@v5'
+      uses: 'actions/checkout@v6'
       with:
         fetch-depth: '1'
     - id: 'step-1'

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -51,7 +51,7 @@ jobs:
       run: './gradlew --stacktrace asciidoctor javadoc "-Dvariant=5.0" "-DjavaVersion=25"'
     - id: 'step-4'
       name: 'Archive and upload docs'
-      uses: 'actions/upload-artifact@v5'
+      uses: 'actions/upload-artifact@v6'
       with:
         name: 'docs'
         path: |-

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -23,7 +23,7 @@
 @file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 @file:Repository("https://bindings.krzeminski.it/")
-@file:DependsOn("actions:checkout___major:[v5,v6-alpha)")
+@file:DependsOn("actions:checkout___major:[v6,v7-alpha)")
 @file:DependsOn("codecov:codecov-action___major:[v5,v6-alpha)")
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -28,7 +28,7 @@
 
 import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.actions.Checkout.FetchDepth
-import io.github.typesafegithub.workflows.actions.codecov.CodecovAction
+import io.github.typesafegithub.workflows.actions.codecov.CodecovAction_Untyped
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts.github
@@ -103,8 +103,8 @@ workflow(
         )
         uses(
             name = "Upload to Codecov.io",
-            action = CodecovAction(
-                failCiIfError = true
+            action = CodecovAction_Untyped(
+                failCiIfError_Untyped = "true"
             )
         )
     }

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -20,7 +20,7 @@
 
 @file:Repository("https://repo.maven.apache.org/maven2/")
 // work-around for https://youtrack.jetbrains.com/issue/KT-69145
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.6.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
 
 @file:Repository("https://bindings.krzeminski.it/")
 @file:DependsOn("actions:checkout___major:[v5,v6-alpha)")

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,7 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Checkout Repository'
-      uses: 'actions/checkout@v5'
+      uses: 'actions/checkout@v6'
       with:
         fetch-depth: '2'
     - id: 'step-1'
@@ -131,7 +131,7 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Checkout Repository'
-      uses: 'actions/checkout@v5'
+      uses: 'actions/checkout@v6'
     - id: 'step-1'
       name: 'Set up JDKs'
       uses: './.github/actions/setup-build-env'
@@ -163,7 +163,7 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Checkout Repository'
-      uses: 'actions/checkout@v5'
+      uses: 'actions/checkout@v6'
     - id: 'step-1'
       name: 'Set up JDKs'
       uses: './.github/actions/setup-build-env'


### PR DESCRIPTION
- **Update github-workflows-kt to 3.7.0 to fix failure**
- **Update dependency actions:upload-artifact___major to v6**
- **Update generated workflow**
- **Update Checkout to v6**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions and action versions (including checkout) across workflows for compatibility.
  * Upgraded the workflow automation framework to a newer release for stability.
  * Migrated action interfaces to their newer variants to align with upstream changes and improve CI reliability.
  * Adjusted documentation, scanning, and artifact-publishing workflows for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->