### PR TITLE
Use Locale.ROOT with String.format which does or could render numbers

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/ErrorReporter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ErrorReporter.java
@@ -20,6 +20,8 @@ import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.messages.*;
 
+import java.util.Locale;
+
 /**
  * Reporting facility for problems found during compilation.
  * In general, error(ASTNode) is the preferred method to use.
@@ -40,12 +42,12 @@ public class ErrorReporter {
 
   public void error(String msg, Object... args) {
     sourceUnit.getErrorCollector().addErrorAndContinue(
-        new SimpleMessage(String.format(msg, args), sourceUnit));
+        new SimpleMessage(String.format(Locale.ROOT, msg, args), sourceUnit));
   }
 
   public void error(String msg, Throwable cause, Object... args) {
     sourceUnit.getErrorCollector().addErrorAndContinue(
-        new SimpleMessage(String.format(msg, args) + "\n\n" + TextUtil.printStackTrace(cause), sourceUnit));
+        new SimpleMessage(String.format(Locale.ROOT, msg, args) + "\n\n" + TextUtil.printStackTrace(cause), sourceUnit));
   }
 
   public void error(ASTNode node, String msg, Object... args) {

--- a/spock-core/src/main/java/org/spockframework/compiler/InvalidSpecCompileException.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/InvalidSpecCompileException.java
@@ -19,6 +19,8 @@ package org.spockframework.compiler;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.syntax.SyntaxException;
 
+import java.util.Locale;
+
 /**
  * Indicates that a spec was found to contain a (syntactic or semantic)
  * error during compilation. As such, this is the compile-time equivalent
@@ -33,7 +35,7 @@ import org.codehaus.groovy.syntax.SyntaxException;
  */
 public class InvalidSpecCompileException extends SyntaxException {
   public InvalidSpecCompileException(int line, int column, String msg, Object... args) {
-    super(String.format(msg, args), line, column);
+    super(String.format(Locale.ROOT, msg, args), line, column);
   }
 
   public InvalidSpecCompileException(ASTNode node, String msg, Object... args) {

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -340,7 +340,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
   }
 
   private String createInternalName(FeatureMethod feature) {
-    return String.format("$spock_feature_%d_%d", specDepth, feature.getOrdinal());
+    return String.format(Locale.ROOT, "$spock_feature_%d_%d", specDepth, feature.getOrdinal());
   }
 
   private MethodNode copyMethod(MethodNode method, String newName) {

--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -576,7 +576,7 @@ public class WhereBlockRewriter {
       // and the row to be added does not have the same size as previous rows
       // => compile error
       if (rows.size() > 0 && rows.getLast().size() != row.size())
-        throw new InvalidSpecCompileException(row.get(0), String.format("Row in data table has wrong number of elements (%s instead of %s)", row.size(), rows.getLast().size()));
+        throw new InvalidSpecCompileException(row.get(0), String.format(Locale.ROOT, "Row in data table has wrong number of elements (%d instead of %d)", row.size(), rows.getLast().size()));
 
       // add the new row
       rows.add(row);

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
@@ -45,6 +45,7 @@ import org.spockframework.util.ReflectionUtil;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -125,7 +126,7 @@ class ByteBuddyMockFactory {
           targetClass = CODEGEN_TARGET_CLASS;
         }
         int randomNumber = Math.abs(ThreadLocalRandom.current().nextInt());
-        String name = String.format("%s$%s$%d", typeName, "SpockMock", randomNumber);
+        String name = String.format(Locale.ROOT, "%s$%s$%d", typeName, "SpockMock", randomNumber);
         ClassLoadingStrategy<ClassLoader> strategy = determineBestClassLoadingStrategy(targetClass, settings);
         //noinspection resource
         return new ByteBuddy()

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockInteraction.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockInteraction.java
@@ -179,6 +179,6 @@ public class MockInteraction implements IMockInteraction {
   }
 
   public String toString() {
-    return String.format("%s   (%d %s)", text, acceptedInvocations.size(), acceptedInvocations.size() == 1 ? "invocation" : "invocations");
+    return String.format(Locale.ROOT, "%s   (%d %s)", text, acceptedInvocations.size(), acceptedInvocations.size() == 1 ? "invocation" : "invocations");
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/DataVariablesIterationNameProvider.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataVariablesIterationNameProvider.java
@@ -59,7 +59,7 @@ public class DataVariablesIterationNameProvider implements NameProvider<Iteratio
       });
     }
     if (includeIterationIndex) {
-      nameJoiner.add(format("#%d", iteration.getIterationIndex()));
+      nameJoiner.add(format(Locale.ROOT, "#%d", iteration.getIterationIndex()));
     }
     return includeFeatureNameForIterations ? format("%s [%s]", feature.getName(), nameJoiner) : nameJoiner.toString();
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/FailedSetEqualityComparisonRenderer.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/FailedSetEqualityComparisonRenderer.java
@@ -31,14 +31,14 @@ public class FailedSetEqualityComparisonRenderer implements ExpressionComparison
     int differences = missingSize + extraSize;
 
     if (editDistance < 11)
-      return String.format("false%n%d difference%s (%d%% similarity, %d missing, %d extra)%nmissing: %s%nextra: %s",
+      return String.format(Locale.ROOT, "false%n%d difference%s (%d%% similarity, %d missing, %d extra)%nmissing: %s%nextra: %s",
         differences,
         differences == 1 ? "" : "s",
         similarityInPercent,
         missingSize, extraSize,
         missing, extra);
 
-    return String.format("false%n%d differences (%d%% similarity, %d missing, %d extra)%nmissing/extra: too many to render",
+    return String.format(Locale.ROOT, "false%n%d differences (%d%% similarity, %d missing, %d extra)%nmissing/extra: too many to render",
       differences,
       similarityInPercent,
       missingSize, extraSize);

--- a/spock-core/src/main/java/org/spockframework/runtime/FailedStringComparisonRenderer.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/FailedStringComparisonRenderer.java
@@ -5,6 +5,8 @@ import org.spockframework.runtime.model.ExpressionInfo;
 
 import groovy.lang.GString;
 
+import java.util.Locale;
+
 public class FailedStringComparisonRenderer implements ExpressionComparisonRenderer {
   public static final long MAX_EDIT_DISTANCE_MEMORY = 50 * 1024;
   @Override
@@ -56,7 +58,7 @@ public class FailedStringComparisonRenderer implements ExpressionComparisonRende
 
   private String createAndRenderEditDistance(String str1, String str2) {
     EditDistance dist = new EditDistance(str1, str2);
-    return String.format("false\n%d difference%s (%d%% similarity)\n%s",
+    return String.format(Locale.ROOT, "false\n%d difference%s (%d%% similarity)\n%s",
       dist.getDistance(), dist.getDistance() == 1 ? "" : "s", dist.getSimilarityInPercent(),
       new EditPathRenderer().render(str1, str2, dist.calculatePath()));
   }
@@ -65,7 +67,7 @@ public class FailedStringComparisonRenderer implements ExpressionComparisonRende
     String sub1 = str1.substring(commonStart, end1);
     String sub2 = str2.substring(commonStart, end2);
     EditDistance dist = new EditDistance(sub1, sub2);
-    return String.format("false\n%d difference%s (%d%% similarity) (comparing subset start: %d, end1: %d, end2: %d)\n%s",
+    return String.format(Locale.ROOT, "false\n%d difference%s (%d%% similarity) (comparing subset start: %d, end1: %d, end2: %d)\n%s",
       dist.getDistance(), dist.getDistance() == 1 ? "" : "s", dist.getSimilarityInPercent(),
       commonStart, end1, end2,
       new EditPathRenderer().render(sub1, sub2, dist.calculatePath()));

--- a/spock-core/src/main/java/org/spockframework/runtime/InvalidSpecException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/InvalidSpecException.java
@@ -16,6 +16,8 @@
 
 package org.spockframework.runtime;
 
+import java.util.Locale;
+
 /**
  * Indicates that a Spec has done something it is not supposed to do. It is up
  * to the Spec author to correct the problem.
@@ -35,7 +37,7 @@ public class InvalidSpecException extends SpockException {
   }
 
   public InvalidSpecException withArgs(Object... args) {
-    msg = String.format(msg, args);
+    msg = String.format(Locale.ROOT, msg, args);
     return this;
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/SafeIterationNameProvider.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SafeIterationNameProvider.java
@@ -16,6 +16,8 @@ package org.spockframework.runtime;
 
 import org.spockframework.runtime.model.*;
 
+import java.util.Locale;
+
 import static java.lang.String.format;
 
 public class SafeIterationNameProvider implements NameProvider<IterationInfo> {
@@ -40,7 +42,7 @@ public class SafeIterationNameProvider implements NameProvider<IterationInfo> {
 
   private String getFallbackName(IterationInfo iteration) {
     return iteration.getFeature().isReportIterations()
-      ? format("%s [#%d]", iteration.getFeature().getName(), iteration.getIterationIndex())
+      ? format(Locale.ROOT, "%s [#%d]", iteration.getFeature().getName(), iteration.getIterationIndex())
       : iteration.getFeature().getName();
   }
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockExecutionException.java
@@ -16,6 +16,8 @@
 
 package org.spockframework.runtime;
 
+import java.util.Locale;
+
 /**
  * Indicates that a problem occurred during Spec execution.
  *
@@ -34,7 +36,7 @@ public class SpockExecutionException extends SpockException {
   }
 
   public SpockExecutionException withArgs(Object... args) {
-    msg = String.format(msg, args);
+    msg = String.format(Locale.ROOT, msg, args);
     return this;
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/SpockRuntime.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/SpockRuntime.java
@@ -211,7 +211,7 @@ public abstract class SpockRuntime {
   }
 
   private static <T> SpockAssertionError getAssertionFailedError(Function<? super T, ?> namer, InternalItemFailure<T> failure) {
-    SpockAssertionError error = new SpockAssertionError(String.format("Assertions failed for item[%d] %s:\n%s", failure.index, namer.apply(failure.item), failure.throwable.toString()));
+    SpockAssertionError error = new SpockAssertionError(String.format(Locale.ROOT, "Assertions failed for item[%d] %s:\n%s", failure.index, namer.apply(failure.item), failure.throwable.toString()));
     error.setStackTrace(failure.throwable.getStackTrace());
     return error;
   }

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/ExtensionException.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/ExtensionException.java
@@ -18,6 +18,8 @@ package org.spockframework.runtime.extension;
 
 import org.spockframework.runtime.SpockException;
 
+import java.util.Locale;
+
 public class ExtensionException extends SpockException {
   private String message;
 
@@ -31,7 +33,7 @@ public class ExtensionException extends SpockException {
   }
 
   public ExtensionException withArgs(Object... args) {
-    message = String.format(message, args);
+    message = String.format(Locale.ROOT, message, args);
     return this;
   }
 

--- a/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TimeoutInterceptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/extension/builtin/TimeoutInterceptor.java
@@ -24,6 +24,7 @@ import java.io.PrintStream;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
@@ -122,7 +123,7 @@ public class TimeoutInterceptor implements IMethodInterceptor {
       // act accordingly. We gloss over the fact that some other thread might also have tried to
       // interrupt this thread. This shouldn't be a problem in practice, in particular because
       // throwing an InterruptedException wouldn't abort the whole test run anyway.
-      String msg = String.format("Method timed out after %1.2f seconds", timeoutSeconds);
+      String msg = String.format(Locale.ROOT, "Method timed out after %1.2f seconds", timeoutSeconds);
       SpockTimeoutError error = new SpockTimeoutError(timeoutSeconds, msg);
       error.setStackTrace(stackTrace);
       throw error;
@@ -134,6 +135,7 @@ public class TimeoutInterceptor implements IMethodInterceptor {
 
   private void logUnsuccessfulInterrupt(String methodName, long now, long timeoutAt, long waitMillis, int unsuccessfulAttempts) {
     System.err.printf(
+      Locale.ROOT,
       "[spock.lang.Timeout] Method '%s' has not stopped after timing out %1.2f seconds ago - interrupting. Next try in %1.2f seconds.\n%n",
       methodName,
       TimeUtil.toSeconds(Duration.ofNanos(now - timeoutAt)),
@@ -152,6 +154,7 @@ public class TimeoutInterceptor implements IMethodInterceptor {
 
   private void logMethodTimeout(String methodName, double timeoutSeconds) {
     System.err.printf(
+      Locale.ROOT,
       "[spock.lang.Timeout] Method '%s' timed out after %1.2f seconds.%n",
       methodName,
       timeoutSeconds
@@ -206,7 +209,7 @@ public class TimeoutInterceptor implements IMethodInterceptor {
     String lineFormat = "\"%s\" #%d";
     int threadSectionStart = -1;
     for (int i = 0; i < lines.size(); ++i) {
-      if (lines.get(i).startsWith(String.format(lineFormat, threadName, threadId))) {
+      if (lines.get(i).startsWith(String.format(Locale.ROOT, lineFormat, threadName, threadId))) {
         threadSectionStart = i;
       } else if (threadSectionStart > 0 && lines.get(i).isEmpty()) {
         return Pair.of(threadSectionStart, i);

--- a/spock-core/src/main/java/org/spockframework/runtime/model/TextPosition.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/TextPosition.java
@@ -17,6 +17,7 @@
 package org.spockframework.runtime.model;
 
 import java.io.Serializable;
+import java.util.Locale;
 
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.syntax.Token;
@@ -79,7 +80,7 @@ public class TextPosition implements Comparable<TextPosition>, Serializable {
   }
 
   public String toString() {
-    return String.format("(%d,%d)", line, column);
+    return String.format(Locale.ROOT, "(%d,%d)", line, column);
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/util/Assert.java
+++ b/spock-core/src/main/java/org/spockframework/util/Assert.java
@@ -17,6 +17,7 @@ package org.spockframework.util;
 
 import org.jetbrains.annotations.Contract;
 
+import java.util.Locale;
 import java.util.function.Supplier;
 
 /**
@@ -33,7 +34,7 @@ public abstract class Assert {
 
   @Contract("null, _, _ -> fail")
   public static <T> T notNull(T obj, String msg, Object... values) {
-    if (obj == null) throw new InternalSpockError(String.format(msg, values));
+    if (obj == null) throw new InternalSpockError(String.format(Locale.ROOT, msg, values));
     return obj;
   }
 
@@ -44,7 +45,7 @@ public abstract class Assert {
 
   @Contract("false, _, _ -> fail")
   public static void that(boolean condition, String msg, Object... values) {
-    if (!condition) throw new InternalSpockError(String.format(msg, values));
+    if (!condition) throw new InternalSpockError(String.format(Locale.ROOT, msg, values));
   }
 
   public static void that(boolean condition, Supplier<String> msgSupplier) {

--- a/spock-core/src/main/java/org/spockframework/util/InternalSpockError.java
+++ b/spock-core/src/main/java/org/spockframework/util/InternalSpockError.java
@@ -16,6 +16,8 @@
 
 package org.spockframework.util;
 
+import java.util.Locale;
+
 /**
  *
  * @author Peter Niederwieser
@@ -46,6 +48,6 @@ public class InternalSpockError extends Error {
 
   @Override
   public String getMessage() {
-    return String.format(super.getMessage(), msgArgs);
+    return String.format(Locale.ROOT, super.getMessage(), msgArgs);
   }
 }

--- a/spock-core/src/main/java/org/spockframework/util/IoUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/IoUtil.java
@@ -150,6 +150,7 @@ public class IoUtil {
 
     if (fromSize != toSize)
       throw new IOException(String.format(
+        Locale.ROOT,
         "Error copying file %s to %s; source file size is %d, but target file size is %d",
         source, target, fromSize, toSize));
   }

--- a/spock-core/src/main/java/org/spockframework/util/VersionNumber.java
+++ b/spock-core/src/main/java/org/spockframework/util/VersionNumber.java
@@ -14,6 +14,7 @@
 
 package org.spockframework.util;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -96,7 +97,7 @@ public final class VersionNumber implements Comparable<VersionNumber> {
   }
 
   public String toString() {
-    return String.format(versionTemplate, major, minor, micro, (qualifier == null ? "" : "-" + getQualifier()) + (isSnapshot ? "-SNAPSHOT" : ""));
+    return String.format(Locale.ROOT, versionTemplate, major, minor, micro, (qualifier == null ? "" : "-" + getQualifier()) + (isSnapshot ? "-SNAPSHOT" : ""));
   }
 
   public String toOriginalString() {

--- a/spock-core/src/main/java/spock/config/ConfigurationException.java
+++ b/spock-core/src/main/java/spock/config/ConfigurationException.java
@@ -14,6 +14,8 @@
 
 package spock.config;
 
+import java.util.Locale;
+
 /**
  * Thrown to indicate that there is a problem with Spock's configuration (file).
  *
@@ -21,9 +23,9 @@ package spock.config;
  */
 public class ConfigurationException extends RuntimeException {
   public ConfigurationException(String msg, Object... args) {
-    super(String.format(msg, args));
+    super(String.format(Locale.ROOT, msg, args));
   }
   public ConfigurationException(String msg, Throwable t, Object... args) {
-    super(String.format(msg, args), t);
+    super(String.format(Locale.ROOT, msg, args), t);
   }
 }

--- a/spock-core/src/main/java/spock/lang/Snapshotter.java
+++ b/spock-core/src/main/java/spock/lang/Snapshotter.java
@@ -285,7 +285,7 @@ public class Snapshotter {
 
     private static String calculateSafeUniqueName(String extension, IterationInfo iterationInfo, String snapshotId) {
       Checks.checkArgument(snapshotId.length() <= 100,
-        () -> String.format("'snapshotId' is too long, only 100 characters are allowed, but was %d: %s", snapshotId.length(), snapshotId));
+        () -> String.format(Locale.ROOT, "'snapshotId' is too long, only 100 characters are allowed, but was %d: %s", snapshotId.length(), snapshotId));
 
       FeatureInfo feature = iterationInfo.getFeature();
       String safeName = sanitize(feature.getName());
@@ -296,9 +296,9 @@ public class Snapshotter {
       int uniqueSuffixLength = 1 + featureId.length() + 1 + extension.length() + iterationIndex.length() + snapshotIdSuffix.length();
       if (safeName.length() + uniqueSuffixLength > 250) {
         safeName = safeName.substring(0, 250 - uniqueSuffixLength);
-        return String.format(Locale.ROOT, "%s%s-%s%s.%s", safeName, snapshotIdSuffix, featureId, iterationIndex, extension);
+        return String.format("%s%s-%s%s.%s", safeName, snapshotIdSuffix, featureId, iterationIndex, extension);
       }
-      return String.format(Locale.ROOT, "%s%s%s.%s", safeName, snapshotIdSuffix, iterationIndex, extension);
+      return String.format("%s%s%s.%s", safeName, snapshotIdSuffix, iterationIndex, extension);
     }
 
     private static String sanitize(String snapshotId) {

--- a/spock-core/src/main/java/spock/mock/AutoAttachExtension.java
+++ b/spock-core/src/main/java/spock/mock/AutoAttachExtension.java
@@ -19,6 +19,8 @@ import org.spockframework.runtime.extension.*;
 import org.spockframework.runtime.model.*;
 import spock.lang.Specification;
 
+import java.util.Locale;
+
 public class AutoAttachExtension implements IStatelessAnnotationDrivenExtension<AutoAttach> {
   private static final MockUtil MOCK_UTIL = new MockUtil();
 
@@ -44,11 +46,11 @@ public class AutoAttachExtension implements IStatelessAnnotationDrivenExtension<
     public void intercept(IMethodInvocation invocation) throws Throwable {
       Object mock = field.readValue(invocation.getInstance());
       if (mock == null) {
-        throw new SpockException(String.format("Cannot AutoAttach 'null' for field %s:%s",
+        throw new SpockException(String.format(Locale.ROOT, "Cannot AutoAttach 'null' for field %s:%d",
           field.getName(), field.getLine()));
       }
       if (!MOCK_UTIL.isMock(mock)) {
-        throw new SpockException(String.format("AutoAttach failed '%s' is not a mock for field %s:%s",
+        throw new SpockException(String.format(Locale.ROOT, "AutoAttach failed '%s' is not a mock for field %s:%d",
           mock, field.getName(), field.getLine()));
       }
       MOCK_UTIL.attachMock(mock, (Specification) invocation.getInstance());

--- a/spock-core/src/main/java/spock/util/concurrent/AsyncConditions.java
+++ b/spock-core/src/main/java/spock/util/concurrent/AsyncConditions.java
@@ -18,6 +18,7 @@ import org.spockframework.lang.ConditionBlock;
 import org.spockframework.runtime.SpockTimeoutError;
 import org.spockframework.util.*;
 
+import java.util.Locale;
 import java.util.concurrent.*;
 
 /**
@@ -137,7 +138,7 @@ public class AsyncConditions {
 
     long pendingEvalBlocks = latch.getCount();
     if (pendingEvalBlocks > 0) {
-      String msg = String.format("Async conditions timed out " +
+      String msg = String.format(Locale.ROOT, "Async conditions timed out " +
           "after %1.2f seconds; %d out of %d evaluate blocks did not complete in time",
           seconds, pendingEvalBlocks, numEvalBlocks);
       throw new SpockTimeoutError(seconds, msg);

--- a/spock-core/src/main/java/spock/util/concurrent/BlockingVariable.java
+++ b/spock-core/src/main/java/spock/util/concurrent/BlockingVariable.java
@@ -14,6 +14,7 @@
 
 package spock.util.concurrent;
 
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -109,7 +110,7 @@ public class BlockingVariable<T> {
    */
   public T get() throws InterruptedException {
     if (!valueReady.await((long) (timeout * 1000), TimeUnit.MILLISECONDS)) {
-      String msg = String.format("BlockingVariable.get() timed out after %1.2f seconds", timeout);
+      String msg = String.format(Locale.ROOT, "BlockingVariable.get() timed out after %1.2f seconds", timeout);
       throw new SpockTimeoutError(timeout, msg);
     }
     return value;

--- a/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
+++ b/spock-core/src/main/java/spock/util/concurrent/PollingConditions.java
@@ -198,9 +198,9 @@ public class PollingConditions {
       }
     }
 
-    String msg = String.format(Locale.ENGLISH, "Condition not satisfied after %1.2f seconds and %d attempts", elapsedTime / 1000d, attempts);
+    String msg = String.format(Locale.ROOT, "Condition not satisfied after %1.2f seconds and %d attempts", elapsedTime / 1000d, attempts);
     if (timeoutMessage != null) {
-      msg = String.format(Locale.ENGLISH, "%s: %s", msg, GroovyRuntimeUtil.invokeClosure(timeoutMessage, testException));
+      msg = String.format("%s: %s", msg, GroovyRuntimeUtil.invokeClosure(timeoutMessage, testException));
     }
     throw new SpockTimeoutError(seconds, msg, testException);
   }

--- a/spock-spring/src/main/java/org/spockframework/spring/mock/DelegatingInterceptor.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/mock/DelegatingInterceptor.java
@@ -24,6 +24,7 @@ import org.spockframework.util.*;
 import spock.lang.Specification;
 
 import java.lang.reflect.*;
+import java.util.Locale;
 
 public class DelegatingInterceptor implements IProxyBasedMockInterceptor {
   private final FieldInfo fieldInfo;
@@ -41,7 +42,7 @@ public class DelegatingInterceptor implements IProxyBasedMockInterceptor {
 
     if (delegate == null) {
       if ("toString".equals(method.getName())) {
-        return String.format("Mock for '%s.%s:%d'", fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine());
+        return String.format(Locale.ROOT, "Mock for '%s.%s:%d'", fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine());
       } else if ("equals".equals(method.getName())){
         return fieldInfo.equals(arguments[0]);
       } else if ("hashCode".equals(method.getName())) {

--- a/spock-spring/src/main/java/org/spockframework/spring/mock/SpockDefinition.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/mock/SpockDefinition.java
@@ -44,11 +44,11 @@ class SpockDefinition extends FieldDefinition implements MockDefinition {
       "SpringBean annotation is required for this field: '%s.%s:%d' ",
       fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine());
     if (!fieldInfo.hasInitializer()) {
-      throw new SpringExtensionException(String.format("Field '%s.%s:%d' needs to have an initializer, e.g. List l = Mock()",
+      throw new SpringExtensionException(String.format(Locale.ROOT, "Field '%s.%s:%d' needs to have an initializer, e.g. List l = Mock()",
         fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine()));
     }
     if (Object.class.equals(fieldInfo.getType())) {
-      throw new SpringExtensionException(String.format("Field '%s.%s:%d' must use a concrete type, not def or Object.",
+      throw new SpringExtensionException(String.format(Locale.ROOT, "Field '%s.%s:%d' must use a concrete type, not def or Object.",
         fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine()));
     }
   }

--- a/spock-spring/src/main/java/org/spockframework/spring/mock/SpockMockPostprocessor.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/mock/SpockMockPostprocessor.java
@@ -186,7 +186,7 @@ public class SpockMockPostprocessor extends BackwardsCompatibleInstantiationAwar
     Set<String> existingBeans = getExistingBeans(beanFactory, definition.getTypeToSpy());
     if (ObjectUtils.isEmpty(existingBeans)) {
       FieldInfo fieldInfo = definition.getFieldInfo();
-      throw new SpringExtensionException(String.format("No matching bean found! " +
+      throw new SpringExtensionException(String.format(Locale.ROOT, "No matching bean found! " +
         "@SpringSpy requires an existing spring bean to wrap, to create a standalone spy use @SpringBean.%n" +
         "Offending Field: '%s.%s:%d'", fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine()));
     } else {

--- a/spock-spring/src/main/java/org/spockframework/spring/mock/SpyDefinition.java
+++ b/spock-spring/src/main/java/org/spockframework/spring/mock/SpyDefinition.java
@@ -24,6 +24,8 @@ import spock.mock.DetachedMockFactory;
 import org.springframework.core.ResolvableType;
 import org.springframework.util.ObjectUtils;
 
+import java.util.Locale;
+
 class SpyDefinition extends FieldDefinition {
 
   private final SpringSpy annotation;
@@ -40,11 +42,11 @@ class SpyDefinition extends FieldDefinition {
       "SpringBean annotation is required for this field: '%s.%s:%d' ",
       fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine());
     if (fieldInfo.hasInitializer()) {
-      throw new SpringExtensionException(String.format("Field '%s.%s:%d' may not have an initializer.",
+      throw new SpringExtensionException(String.format(Locale.ROOT, "Field '%s.%s:%d' may not have an initializer.",
         fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine()));
     }
     if (Object.class.equals(fieldInfo.getType())) {
-      throw new SpringExtensionException(String.format("Field '%s.%s:%d' must use a concrete type, not def or Object.",
+      throw new SpringExtensionException(String.format(Locale.ROOT, "Field '%s.%s:%d' must use a concrete type, not def or Object.",
         fieldInfo.getParent().getName(), fieldInfo.getName(), fieldInfo.getLine()));
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized string formatting to be locale-independent across the framework, ensuring consistent user-facing messages (errors, timeouts, iteration and mock names, snapshots, diagnostics, and logs) regardless of the system locale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->