### PR TITLE
Fix MockitoMockMaker throws NPE on null object

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -14,6 +14,7 @@ include::include.adoc[]
 
 * Fix argument mismatch descriptions for varargs methods by expanding varargs instead of reporting `<too few arguments>` spockPull:2315[]
 * Fix Pattern flags being dropped when `java.util.regex.Pattern` instances are used in Spock regex conditions spockIssue:2298[]
+* Fix `MockitoMockMaker` throws NPE on null object spockIssue:2337[]
 
 == 2.4 (2025-12-11)
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/IMockMaker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/IMockMaker.java
@@ -125,6 +125,7 @@ public interface IMockMaker {
    * @param object a potential mock object
    * @return information about the mock object or {@code null}
    */
+  @Nullable
   default IMockObject asMockOrNull(Object object) {
     return null;
   }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockMakerRegistry.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockMakerRegistry.java
@@ -22,7 +22,6 @@ import org.spockframework.mock.IMockObject;
 import org.spockframework.mock.ISpockMockObject;
 import org.spockframework.mock.runtime.IMockMaker.IStaticMock;
 import org.spockframework.mock.runtime.IMockMaker.MockMakerCapability;
-import org.spockframework.runtime.GroovyRuntimeUtil;
 import org.spockframework.util.InternalSpockError;
 import org.spockframework.util.Nullable;
 import org.spockframework.util.ThreadSafe;
@@ -182,7 +181,11 @@ public final class MockMakerRegistry {
    * @param object a mock object
    * @return information about the mock object
    */
-  public IMockObject asMockOrNull(Object object) {
+  @Nullable
+  public IMockObject asMockOrNull(@Nullable Object object) {
+    if (object == null) {
+      return null;
+    }
     if (object instanceof ISpockMockObject) {
       return ((ISpockMockObject) object).$spock_get();
     }

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/mockito/MockitoMockMaker.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/mockito/MockitoMockMaker.java
@@ -19,6 +19,7 @@ package org.spockframework.mock.runtime.mockito;
 import org.spockframework.mock.CannotCreateMockException;
 import org.spockframework.mock.IMockObject;
 import org.spockframework.mock.runtime.IMockMaker;
+import org.spockframework.util.Nullable;
 import org.spockframework.util.ReflectionUtil;
 import org.spockframework.util.ThreadSafe;
 import spock.mock.MockMakerId;
@@ -69,8 +70,9 @@ public class MockitoMockMaker implements IMockMaker {
   }
 
   @Override
-  public IMockObject asMockOrNull(Object object) {
-    if (impl == null) {
+  @Nullable
+  public IMockObject asMockOrNull(@Nullable Object object) {
+    if (impl == null || object == null) {
       return null;
     }
     return impl.asMockOrNull(object);

--- a/spock-specs/src/test/groovy/org/spockframework/mock/runtime/mockito/MockitoMockMakerSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/runtime/mockito/MockitoMockMakerSpec.groovy
@@ -45,6 +45,14 @@ class MockitoMockMakerSpec extends Specification {
     mockito.toString() == "$ID default mock maker settings"
   }
 
+  def "MockitoMockMaker.asMockOrNull() on null returns null"() {
+    given:
+    def maker = new MockitoMockMaker()
+
+    expect:
+    maker.asMockOrNull(null) == null
+  }
+
   def "Verify ID and IMockMakerSettings with Mockito settings"() {
     when:
     def set = mockito {}
@@ -506,6 +514,19 @@ Can not mock final classes with the following settings :
     m instanceof Runnable
     additionalInterfaceClass.isInstance(m)
     mockUtil.isMock(m)
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/2337")
+  def "NPE when stubbing method on null object"() {
+    given:
+    Object nullObj = null
+
+    when:
+    //Issue #2337: MockitoMockMaker passes null to Mockito's getHandler() throws NPE
+    nullObj.toString() >> ""
+
+    then:
+    noExceptionThrown()
   }
 }
 


### PR DESCRIPTION
MockMakerRegistry.asMockOrNull() shall return null on null object and not call the mock makers.

Fixes #2337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a NullPointerException when processing null objects in Mockito-backed mock handling, improving robustness and null-safety.

* **Tests**
  * Added regression and null-input tests to ensure stubbing or mock queries against null do not throw.

* **Documentation**
  * Noted the fix in the upcoming release notes under “Misc.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->