### PR TITLE
Fix for #2352 - Generic Comparable Stubs/Mocks ==

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -18,7 +18,7 @@ include::include.adoc[]
 
 === Breaking Changes
 
-* == checks on Comparable<T> with T being something other than Object now compare using the java identity hash code instead of always being equal spockPull:2353[]
+* Mock/Stub checks on `Comparable<T>` with `T` being something other than `Object` now compare using the java identity hash code instead of always being equal spockIssue:2352[]
 
 == 2.4 (2025-12-11)
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -16,6 +16,10 @@ include::include.adoc[]
 * Fix Pattern flags being dropped when `java.util.regex.Pattern` instances are used in Spock regex conditions spockIssue:2298[]
 * Fix `MockitoMockMaker` throws NPE on null object spockIssue:2337[]
 
+=== Breaking Changes
+
+* == checks on Comparable<T> with T being something other than Object now compare using the java identity hash code instead of always being equal spockPull:2353[]
+
 == 2.4 (2025-12-11)
 
 _This is a summary of the highlights of the milestone releases_

--- a/spock-core/src/main/java/org/spockframework/mock/DefaultCompareToInteraction.java
+++ b/spock-core/src/main/java/org/spockframework/mock/DefaultCompareToInteraction.java
@@ -31,5 +31,4 @@ public class DefaultCompareToInteraction extends DefaultInteraction {
   public Supplier<Object> accept(IMockInvocation invocation) {
     return () -> Integer.compare(System.identityHashCode(invocation.getMockObject().getInstance()), System.identityHashCode(invocation.getArguments().get(0)));
   }
-
 }

--- a/spock-core/src/main/java/org/spockframework/mock/DefaultCompareToInteraction.java
+++ b/spock-core/src/main/java/org/spockframework/mock/DefaultCompareToInteraction.java
@@ -1,5 +1,7 @@
 package org.spockframework.mock;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public class DefaultCompareToInteraction extends DefaultInteraction {
@@ -18,12 +20,30 @@ public class DefaultCompareToInteraction extends DefaultInteraction {
 
     return "compareTo".equals(method.getName())
       && method.getParameterTypes().size() == 1
-      && method.getParameterTypes().get(0) == Object.class
-      && invocation.getMockObject().getInstance() instanceof Comparable;
+      && (
+        // either this is the base compareTo(object) method or it is a genericized Comparable
+        method.getParameterTypes().get(0) == Object.class
+        || getInterfacesFromClass(method.getParameterTypes().get(0)).contains(Comparable.class)
+      ) && invocation.getMockObject().getInstance() instanceof Comparable;
   }
 
   @Override
   public Supplier<Object> accept(IMockInvocation invocation) {
     return () -> Integer.compare(System.identityHashCode(invocation.getMockObject().getInstance()), System.identityHashCode(invocation.getArguments().get(0)));
   }
+
+  private Set<Class<?>> getInterfacesFromClass(Class<?> clazz) {
+    Set<Class<?>> interfaces = new HashSet<>();
+    if (clazz.isInterface()) {
+      interfaces.add(clazz);
+    }
+    for (Class<?> iface : clazz.getInterfaces()) {
+      interfaces.addAll(getInterfacesFromClass(iface));
+    }
+    if (clazz.getSuperclass() != null) {
+      interfaces.addAll(getInterfacesFromClass(clazz.getSuperclass()));
+    }
+    return interfaces;
+  }
+
 }

--- a/spock-core/src/main/java/org/spockframework/mock/DefaultCompareToInteraction.java
+++ b/spock-core/src/main/java/org/spockframework/mock/DefaultCompareToInteraction.java
@@ -1,7 +1,7 @@
 package org.spockframework.mock;
 
-import java.util.HashSet;
-import java.util.Set;
+import org.spockframework.util.ReflectionUtil;
+
 import java.util.function.Supplier;
 
 public class DefaultCompareToInteraction extends DefaultInteraction {
@@ -23,27 +23,13 @@ public class DefaultCompareToInteraction extends DefaultInteraction {
       && (
         // either this is the base compareTo(object) method or it is a genericized Comparable
         method.getParameterTypes().get(0) == Object.class
-        || getInterfacesFromClass(method.getParameterTypes().get(0)).contains(Comparable.class)
+        || ReflectionUtil.getInterfacesFromClass(method.getParameterTypes().get(0)).contains(Comparable.class)
       ) && invocation.getMockObject().getInstance() instanceof Comparable;
   }
 
   @Override
   public Supplier<Object> accept(IMockInvocation invocation) {
     return () -> Integer.compare(System.identityHashCode(invocation.getMockObject().getInstance()), System.identityHashCode(invocation.getArguments().get(0)));
-  }
-
-  private Set<Class<?>> getInterfacesFromClass(Class<?> clazz) {
-    Set<Class<?>> interfaces = new HashSet<>();
-    if (clazz.isInterface()) {
-      interfaces.add(clazz);
-    }
-    for (Class<?> iface : clazz.getInterfaces()) {
-      interfaces.addAll(getInterfacesFromClass(iface));
-    }
-    if (clazz.getSuperclass() != null) {
-      interfaces.addAll(getInterfacesFromClass(clazz.getSuperclass()));
-    }
-    return interfaces;
   }
 
 }

--- a/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/ReflectionUtil.java
@@ -413,4 +413,24 @@ public abstract class ReflectionUtil {
     }
     return false;
   }
+
+  /**
+   * Gets all interfaces implemented by the given class, including parents
+   *
+   * @param clazz the class to retrieve interfaces for
+   * @return a set of interfaces implemented by the class
+   */
+  public static Set<Class<?>> getInterfacesFromClass(Class<?> clazz) {
+    Set<Class<?>> interfaces = new HashSet<>();
+    if (clazz.isInterface()) {
+      interfaces.add(clazz);
+    }
+    for (Class<?> iface : clazz.getInterfaces()) {
+      interfaces.addAll(getInterfacesFromClass(iface));
+    }
+    if (clazz.getSuperclass() != null) {
+      interfaces.addAll(getInterfacesFromClass(clazz.getSuperclass()));
+    }
+    return interfaces;
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/ArgumentMatching.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/ArgumentMatching.groovy
@@ -326,6 +326,19 @@ class ArgumentMatching extends Specification {
     1 * bar.foo(qux)
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/2352")
+  def "expect non-matching generic Comparables to be unequal"() {
+    given: "two stubs of the same comparable class"
+    // Mocks have the same issue but one had to be picked here
+    GenericComparable baz = Stub()
+    GenericComparable qux = Stub()
+
+    when: "they are checked for equality"
+    def result = baz != qux
+    then: "they are not equal"
+    result
+  }
+
   interface Overloads {
     void m()
     void m(String one)

--- a/spock-specs/src/test/groovy/org/spockframework/util/ReflectionUtilSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/ReflectionUtilSpec.groovy
@@ -415,4 +415,22 @@ class ReflectionUtilSpec extends Specification {
     this.class | new URLClassLoader([] as URL[], null as ClassLoader)    | false
     this.class | ByteBuddyTestClassLoader.withInterface(this.class.name) | false
   }
+
+  def "getInterfacesForClass finds interfaces from extending other interfaces"() {
+    when:
+    Set<Class<?>> results = ReflectionUtil.getInterfacesFromClass(List)
+
+    then:
+    results.size() == 3
+    results.containsAll([List, Collection, Iterable])
+  }
+
+  def "getInterfacesForClass finds interfaces from a class"() {
+    when:
+    Set<Class<?>> results = ReflectionUtil.getInterfacesFromClass(ArrayList)
+
+    then:
+    results.size() == 6
+    results.containsAll([List, RandomAccess, Cloneable, Serializable, Collection, Iterable])
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/util/ReflectionUtilSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/ReflectionUtilSpec.groovy
@@ -421,7 +421,6 @@ class ReflectionUtilSpec extends Specification {
     Set<Class<?>> results = ReflectionUtil.getInterfacesFromClass(List)
 
     then:
-    results.size() == 3
     results.containsAll([List, Collection, Iterable])
   }
 
@@ -430,7 +429,6 @@ class ReflectionUtilSpec extends Specification {
     Set<Class<?>> results = ReflectionUtil.getInterfacesFromClass(ArrayList)
 
     then:
-    results.size() == 6
     results.containsAll([List, RandomAccess, Cloneable, Serializable, Collection, Iterable])
   }
 }

--- a/spock-specs/src/test/java/org/spockframework/smoke/mock/GenericComparable.java
+++ b/spock-specs/src/test/java/org/spockframework/smoke/mock/GenericComparable.java
@@ -1,7 +1,5 @@
 package org.spockframework.smoke.mock;
 
-import org.jetbrains.annotations.NotNull;
-
 public class GenericComparable implements Comparable<GenericComparable>{
   private final int value;
 
@@ -10,7 +8,7 @@ public class GenericComparable implements Comparable<GenericComparable>{
   }
 
   @Override
-  public int compareTo(@NotNull GenericComparable o) {
+  public int compareTo(GenericComparable o) {
     return Integer.compare(value, o.value);
   }
 }

--- a/spock-specs/src/test/java/org/spockframework/smoke/mock/GenericComparable.java
+++ b/spock-specs/src/test/java/org/spockframework/smoke/mock/GenericComparable.java
@@ -1,0 +1,16 @@
+package org.spockframework.smoke.mock;
+
+import org.jetbrains.annotations.NotNull;
+
+public class GenericComparable implements Comparable<GenericComparable>{
+  private final int value;
+
+  public GenericComparable(int value) {
+    this.value = value;
+  }
+
+  @Override
+  public int compareTo(@NotNull GenericComparable o) {
+    return Integer.compare(value, o.value);
+  }
+}


### PR DESCRIPTION
They should come out as unequal like different Stubs/Mocks for a non Comparable class would. Extends the work for #1322 to handle Generics. Does this by considering any method named compareTo with a single argument that is a Comprable to be a Comparable.compareTo method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mock argument matching now recognizes and correctly compares generic Comparable values in compareTo interactions.

* **Tests**
  * Added tests ensuring non-matching generic Comparable stubs are treated as unequal and verifying interface-discovery behavior.

* **Documentation**
  * Documented change to Comparable comparison behavior in mock comparisons (may affect equality outcomes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spockframework/spock/pull/2353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->