### PR TITLE
Default to javaVersion 11 for Groovy 5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,10 @@ ext {
     minGroovyVersion = "5.0.0"
     maxGroovyVersion = "5.9.99"
     if (javaVersion < 11) {
-      throw new InvalidUserDataException("Groovy $variant is not compatible with Java $javaVersion")
+      if (System.getProperty("javaVersion") != null) {
+        throw new InvalidUserDataException("Groovy $variant is not compatible with Java $javaVersion")
+      }
+      javaVersion = 11
     }
   } else {
     throw new InvalidUserDataException("Unknown variant: $variant. Choose one of: $variants")


### PR DESCRIPTION
Previously, the build would just fail if you didn't specify Java version 11 or higher for a Groovy 5.0 build.
Now, it will default to Java version 11 to make it more forgiving.