### PR TITLE
Generate llms.txt index and harden docs publishing

### DIFF
--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -188,10 +188,6 @@ workflow(
             )
         )
         run(
-            name = "Create Temporary Branch",
-            command = "git checkout -b \"docs-\$GITHUB_SHA\""
-        )
-        run(
             name = "Install GraphViz",
             command = "sudo apt update && sudo apt install --yes graphviz"
         )

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,12 +170,9 @@ jobs:
       with:
         additional-java-version: '${{ matrix.java }}'
     - id: 'step-2'
-      name: 'Create Temporary Branch'
-      run: 'git checkout -b "docs-$GITHUB_SHA"'
-    - id: 'step-3'
       name: 'Install GraphViz'
       run: 'sudo apt update && sudo apt install --yes graphviz'
-    - id: 'step-4'
+    - id: 'step-3'
       name: 'Publish Docs'
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/build-logic/base/base.gradle
+++ b/build-logic/base/base.gradle
@@ -19,7 +19,7 @@ dependencies {
 testing {
   suites {
     test {
-      useSpock('2.4-groovy-3.0')
+      useSpock('2.4-groovy-4.0')
     }
   }
 }

--- a/build-logic/base/src/main/groovy/org/spockframework/gradle/DocVersions.groovy
+++ b/build-logic/base/src/main/groovy/org/spockframework/gradle/DocVersions.groovy
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import groovy.transform.CompileStatic
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Scans a published {@code docs/} directory for documentation version sub-directories.
+ *
+ * <p>A "stable" version is a plain {@code X.Y} or {@code X.Y.Z} directory; milestones,
+ * release candidates, snapshots and the {@code current}/{@code latest} aliases are ignored.
+ * Versions are sorted descending by numeric component (so {@code 2.10} sorts above {@code 2.9}).
+ */
+@CompileStatic
+class DocVersions {
+  private static final String STABLE_REGEX = /\d+\.\d+(\.\d+)?/
+  private static final String SNAPSHOT_REGEX = /\d+\.\d+(\.\d+)?-SNAPSHOT/
+
+  static List<String> stable(Path docsDir) {
+    versionDirs(docsDir)
+      .findAll { it ==~ STABLE_REGEX }
+      .sort(false) { String a, String b -> compare(b, a) }
+  }
+
+  static List<String> snapshots(Path docsDir) {
+    versionDirs(docsDir)
+      .findAll { it ==~ SNAPSHOT_REGEX }
+      .sort(false) { String a, String b -> compare(stripSnapshot(b), stripSnapshot(a)) }
+  }
+
+  static String latestStable(Path docsDir) {
+    stable(docsDir)[0]
+  }
+
+  static String latestSnapshot(Path docsDir) {
+    snapshots(docsDir)[0]
+  }
+
+  private static List<String> versionDirs(Path docsDir) {
+    if (!Files.isDirectory(docsDir)) {
+      return []
+    }
+    List<String> names = []
+    docsDir.eachDir { Path dir -> names << dir.fileName.toString() }
+    names
+  }
+
+  private static String stripSnapshot(String version) {
+    version - '-SNAPSHOT'
+  }
+
+  private static int compare(String a, String b) {
+    List<Integer> pa = a.split(/\./).collect { it.toInteger() }
+    List<Integer> pb = b.split(/\./).collect { it.toInteger() }
+    int n = Math.max(pa.size(), pb.size())
+    for (int i = 0; i < n; i++) {
+      int x = i < pa.size() ? pa[i] : 0
+      int y = i < pb.size() ? pb[i] : 0
+      if (x != y) {
+        return x <=> y
+      }
+    }
+    0
+  }
+}

--- a/build-logic/base/src/main/groovy/org/spockframework/gradle/DocsRedirects.groovy
+++ b/build-logic/base/src/main/groovy/org/spockframework/gradle/DocsRedirects.groovy
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import groovy.transform.CompileStatic
+
+import java.nio.file.Path
+
+/**
+ * Computes the redirect pages of a published {@code docs/} directory:
+ *
+ * <ul>
+ *   <li>{@code docs/index.html} → the latest stable release directly (no extra hop);</li>
+ *   <li>{@code docs/current} → latest stable (stable alias);</li>
+ *   <li>{@code docs/latest} → latest development snapshot.</li>
+ * </ul>
+ */
+@CompileStatic
+class DocsRedirects {
+  /**
+   * Maps redirect file paths (relative to {@code docsDir}) to their HTML content. A redirect is
+   * only included when a corresponding version exists.
+   */
+  static Map<String, String> redirects(Path docsDir) {
+    Map<String, String> redirects = [:]
+    def latestStable = DocVersions.latestStable(docsDir)
+    if (latestStable) {
+      // docs/index.html sits at the docs root, so it points straight at the version directory
+      redirects['index.html'] = redirectHtml("$latestStable/index.html")
+      redirects['current/index.html'] = redirectHtml("../$latestStable/index.html")
+    }
+    def latestSnapshot = DocVersions.latestSnapshot(docsDir)
+    if (latestSnapshot) {
+      redirects['latest/index.html'] = redirectHtml("../$latestSnapshot/index.html")
+    }
+    redirects
+  }
+
+  static String redirectHtml(String url) {
+    """\
+      <html>
+        <head>
+          <meta HTTP-EQUIV="REFRESH" content="0; url=${url}">
+        </head>
+      </html>
+    """.stripIndent(true)
+  }
+}

--- a/build-logic/base/src/main/groovy/org/spockframework/gradle/GenerateDocsRedirects.groovy
+++ b/build-logic/base/src/main/groovy/org/spockframework/gradle/GenerateDocsRedirects.groovy
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Generates the {@code docs/current} and {@code docs/latest} redirect pages from a published
+ * {@code docs/} directory: {@code current} → latest stable, {@code latest} → latest snapshot.
+ *
+ * <p>{@code docsDir} is {@link Internal} because the redirect pages are written inside it and the
+ * task runs against a freshly checked-out worktree; callers wire it with
+ * {@code outputs.upToDateWhen { false }}.
+ */
+@CompileStatic
+abstract class GenerateDocsRedirects extends DefaultTask {
+  @Internal
+  abstract DirectoryProperty getDocsDir()
+
+  @TaskAction
+  void generate() {
+    Path docs = docsDir.get().asFile.toPath()
+    DocsRedirects.redirects(docs).each { String relativePath, String html ->
+      Path target = docs.resolve(relativePath)
+      Files.createDirectories(target.parent)
+      target.text = html
+    }
+  }
+}

--- a/build-logic/base/src/main/groovy/org/spockframework/gradle/GenerateLlmsTxt.groovy
+++ b/build-logic/base/src/main/groovy/org/spockframework/gradle/GenerateLlmsTxt.groovy
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Generates the {@code llms.txt} documentation index from a published {@code docs/} directory.
+ *
+ * <p>{@code docsDir} is {@link Internal} because the output {@code llms.txt} lives inside it and
+ * the task runs against a freshly checked-out worktree; callers wire it with
+ * {@code outputs.upToDateWhen { false }}.
+ */
+@CompileStatic
+abstract class GenerateLlmsTxt extends DefaultTask {
+  @Internal
+  abstract DirectoryProperty getDocsDir()
+
+  @Input
+  abstract Property<String> getBaseUrl()
+
+  @OutputFile
+  abstract RegularFileProperty getOutputFile()
+
+  @TaskAction
+  void generate() {
+    def docs = docsDir.get().asFile.toPath()
+    outputFile.get().asFile.toPath().text = LlmsTxtRenderer.render(docs, baseUrl.get())
+  }
+}

--- a/build-logic/base/src/main/groovy/org/spockframework/gradle/LlmsTxtRenderer.groovy
+++ b/build-logic/base/src/main/groovy/org/spockframework/gradle/LlmsTxtRenderer.groovy
@@ -1,0 +1,111 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import groovy.transform.CompileStatic
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.regex.Matcher
+
+/**
+ * Renders a token-efficient {@code llms.txt} index for the published Spock documentation.
+ *
+ * <p>The file gives a URL template plus one example, the page list (slug + optional
+ * one-sentence description, derived from the latest stable version's {@code index.md} with
+ * link markup stripped), and a compact list of versions. It deliberately avoids spelling
+ * out an absolute URL for every page and version.
+ */
+@CompileStatic
+class LlmsTxtRenderer {
+  // [Title](slug.md) optionally followed by ": description"
+  private static final String PAGE_LINK_REGEX = /\[[^\]]+]\(([^)]+)\.md\)(?::\s*(.+))?/
+
+  static String render(Path docsDir, String baseUrl) {
+    def latestStable = DocVersions.latestStable(docsDir)
+    // fall back to the snapshot (or a literal placeholder) so the example never reads ".../null/"
+    def exampleVersion = latestStable ?: DocVersions.latestSnapshot(docsDir) ?: '{version}'
+
+    // Template is written flush-left on purpose: stripIndent() runs after interpolation, so
+    // indenting it would mangle the multi-line ${renderPages}/${renderVersions} blocks.
+    """\
+# Spock Framework Documentation
+
+> Spock is a testing and specification framework for Java and Groovy applications.
+> Compose a documentation page URL from the template below using any version and page slug.
+
+Template: ${baseUrl}{version}/{page}.md
+Example:  ${baseUrl}${exampleVersion}/all_in_one.md
+
+## Pages
+
+${renderPages(docsDir, latestStable)}
+
+## Versions
+
+${renderVersions(docsDir)}
+"""
+  }
+
+  private static String renderPages(Path docsDir, String latestStable) {
+    pages(docsDir, latestStable)
+      .collect { Page page -> page.description ? "- `${page.slug}` — ${page.description}" : "- `${page.slug}`" }
+      .join('\n')
+  }
+
+  private static String renderVersions(Path docsDir) {
+    def stable = DocVersions.stable(docsDir)
+    def lines = []
+    if (stable) {
+      lines << "- Latest stable: ${stable[0]}"
+      lines << "- Stable: ${stable.join(', ')}"
+    }
+    def latestSnapshot = DocVersions.latestSnapshot(docsDir)
+    if (latestSnapshot) {
+      lines << "- Development: ${latestSnapshot}"
+    }
+    lines.join('\n')
+  }
+
+  private static List<Page> pages(Path docsDir, String latestStable) {
+    if (!latestStable) {
+      return []
+    }
+    def index = docsDir.resolve(latestStable).resolve('index.md')
+    if (!Files.isRegularFile(index)) {
+      return []
+    }
+    List<Page> pages = []
+    index.eachLine { String line ->
+      Matcher matcher = line =~ PAGE_LINK_REGEX
+      if (matcher.find()) {
+        def description = matcher.group(2)?.trim()
+        pages << new Page(matcher.group(1), description ?: null)
+      }
+    }
+    pages
+  }
+
+  @CompileStatic
+  private static class Page {
+    final String slug
+    final String description
+
+    Page(String slug, String description) {
+      this.slug = slug
+      this.description = description
+    }
+  }
+}

--- a/build-logic/base/src/test/groovy/org/spockframework/gradle/DocVersionsSpec.groovy
+++ b/build-logic/base/src/test/groovy/org/spockframework/gradle/DocVersionsSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.util.io.FileSystemFixture
+
+class DocVersionsSpec extends Specification {
+  @TempDir
+  FileSystemFixture docs
+
+  def "stable versions are filtered and sorted descending, numerically"() {
+    given:
+    docs.create {
+      ['1.0', '2.0', '2.4', '2.9', '2.10', '2.4-M1', '2.4-RC1', '2.5-SNAPSHOT', 'current', 'latest'].each {
+        dir(it) {}
+      }
+    }
+
+    expect:
+    DocVersions.stable(docs.currentPath) == ['2.10', '2.9', '2.4', '2.0', '1.0']
+  }
+
+  def "snapshot versions are filtered and the latest is detected"() {
+    given:
+    docs.create {
+      ['1.0', '2.4', '2.4-SNAPSHOT', '2.5-SNAPSHOT'].each { dir(it) {} }
+    }
+
+    expect:
+    DocVersions.snapshots(docs.currentPath) == ['2.5-SNAPSHOT', '2.4-SNAPSHOT']
+    DocVersions.latestSnapshot(docs.currentPath) == '2.5-SNAPSHOT'
+    DocVersions.latestStable(docs.currentPath) == '2.4'
+  }
+}

--- a/build-logic/base/src/test/groovy/org/spockframework/gradle/DocsRedirectsSpec.groovy
+++ b/build-logic/base/src/test/groovy/org/spockframework/gradle/DocsRedirectsSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.util.io.FileSystemFixture
+
+class DocsRedirectsSpec extends Specification {
+  @TempDir
+  FileSystemFixture docs
+
+  def "index points straight to latest stable, current and latest are aliases"() {
+    given:
+    docs.create {
+      ['1.0', '2.3', '2.4', '2.4-M1', '2.4-SNAPSHOT', '2.5-SNAPSHOT', 'current', 'latest'].each { dir(it) {} }
+    }
+
+    when:
+    def redirects = DocsRedirects.redirects(docs.currentPath)
+
+    then: "the main index redirects directly to the version (no current/ hop)"
+    redirects['index.html'].contains('url=2.4/index.html')
+
+    and:
+    redirects['current/index.html'].contains('url=../2.4/index.html')
+    redirects['latest/index.html'].contains('url=../2.5-SNAPSHOT/index.html')
+  }
+
+  def "redirect html uses a meta refresh to the given url"() {
+    expect:
+    DocsRedirects.redirectHtml('../2.4/index.html') == '''\
+      <html>
+        <head>
+          <meta HTTP-EQUIV="REFRESH" content="0; url=../2.4/index.html">
+        </head>
+      </html>
+    '''.stripIndent(true)
+  }
+}

--- a/build-logic/base/src/test/groovy/org/spockframework/gradle/GenerateDocsIndexTasksSpec.groovy
+++ b/build-logic/base/src/test/groovy/org/spockframework/gradle/GenerateDocsIndexTasksSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.util.io.FileSystemFixture
+
+class GenerateDocsIndexTasksSpec extends Specification {
+  @TempDir
+  FileSystemFixture docs
+
+  def setup() {
+    docs.create {
+      dir('2.4') {
+        file('index.md') << '[Introduction](introduction.md): A brief overview.\n'
+      }
+      ['2.3', '2.5-SNAPSHOT'].each { dir(it) {} }
+    }
+  }
+
+  def "GenerateLlmsTxt writes the rendered index to the output file"() {
+    given:
+    def project = ProjectBuilder.builder().build()
+    def task = project.tasks.register('generateLlmsTxt', GenerateLlmsTxt).get()
+    def output = docs.currentPath.resolve('llms.txt')
+
+    and:
+    task.docsDir.set(docs.currentPath.toFile())
+    task.baseUrl.set('https://docs.spockframework.org/')
+    task.outputFile.set(output.toFile())
+
+    when:
+    task.generate()
+
+    then:
+    output.text.contains('- `introduction` — A brief overview.')
+    output.text.contains('Latest stable: 2.4')
+  }
+
+  def "GenerateDocsRedirects writes the index, current and latest redirect pages"() {
+    given:
+    def project = ProjectBuilder.builder().build()
+    def task = project.tasks.register('generateDocsRedirects', GenerateDocsRedirects).get()
+
+    and:
+    task.docsDir.set(docs.currentPath.toFile())
+
+    when:
+    task.generate()
+
+    then:
+    docs.currentPath.resolve('index.html').text.contains('url=2.4/index.html')
+    docs.currentPath.resolve('current/index.html').text.contains('url=../2.4/index.html')
+    docs.currentPath.resolve('latest/index.html').text.contains('url=../2.5-SNAPSHOT/index.html')
+  }
+}

--- a/build-logic/base/src/test/groovy/org/spockframework/gradle/LlmsTxtRendererSpec.groovy
+++ b/build-logic/base/src/test/groovy/org/spockframework/gradle/LlmsTxtRendererSpec.groovy
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.gradle
+
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.util.io.FileSystemFixture
+
+class LlmsTxtRendererSpec extends Specification {
+  static final String BASE_URL = 'https://spockframework.org/spock/docs/'
+
+  @TempDir
+  FileSystemFixture docs
+
+  def setup() {
+    docs.create {
+      dir('2.4') {
+        file('index.md') << '''\
+          # Spock Framework Reference Documentation
+
+          1. [Introduction](introduction.md): A brief overview of Spock.
+          2. [Getting Started](getting_started.md): Quick start.
+          3. [Known Issues](known_issues.md)
+
+          [Single Page Documentation](all_in_one.md)
+        '''.stripIndent(true)
+      }
+      ['2.3', '1.0', '2.4-M1', '2.5-SNAPSHOT', 'current', 'latest'].each { dir(it) {} }
+    }
+  }
+
+  def "renders template, example and notes"() {
+    when:
+    def result = LlmsTxtRenderer.render(docs.currentPath, BASE_URL)
+
+    then:
+    with(result) {
+      startsWith('# Spock Framework Documentation')
+      contains("Template: ${BASE_URL}{version}/{page}.md")
+      contains("${BASE_URL}2.4/all_in_one.md")
+    }
+  }
+
+  def "renders pages from the latest stable index.md, slug + optional description, link stripped"() {
+    when:
+    def result = LlmsTxtRenderer.render(docs.currentPath, BASE_URL)
+
+    then:
+    result.contains('- `introduction` — A brief overview of Spock.')
+    result.contains('- `getting_started` — Quick start.')
+
+    and: "entry without description renders as a bare slug"
+    result.contains('- `known_issues`\n')
+    !result.contains('- `known_issues` —')
+
+    and: "all_in_one is included"
+    result.contains('- `all_in_one`')
+  }
+
+  def "renders the versions section with stable list and development snapshot"() {
+    when:
+    def result = LlmsTxtRenderer.render(docs.currentPath, BASE_URL)
+
+    then:
+    with(result) {
+      contains('Latest stable: 2.4')
+      contains('Stable: 2.4, 2.3, 1.0')
+      contains('Development: 2.5-SNAPSHOT')
+    }
+  }
+
+  def "omits stable lines and never emits 'null' when there are no stable versions"() {
+    given: "a docs dir with only a development snapshot"
+    def snapshotOnly = docs.currentPath.resolve('snap-only')
+    java.nio.file.Files.createDirectories(snapshotOnly.resolve('2.5-SNAPSHOT'))
+
+    when:
+    def result = LlmsTxtRenderer.render(snapshotOnly, BASE_URL)
+
+    then:
+    !result.contains('null')
+    !result.contains('Latest stable:')
+    result.contains('Development: 2.5-SNAPSHOT')
+    and: "the example falls back to the snapshot"
+    result.contains("Example:  ${BASE_URL}2.5-SNAPSHOT/all_in_one.md")
+  }
+
+  def "emits no per-page absolute URLs (token efficiency)"() {
+    when:
+    def result = LlmsTxtRenderer.render(docs.currentPath, BASE_URL)
+
+    then:
+    !result.contains('2.4/introduction')
+    !result.contains('2.4/getting_started')
+  }
+}

--- a/build-logic/base/src/test/groovy/org/spockframework/gradle/SpockBasePluginSpec.groovy
+++ b/build-logic/base/src/test/groovy/org/spockframework/gradle/SpockBasePluginSpec.groovy
@@ -84,7 +84,7 @@ class SpockBasePluginSpec extends Specification {
     testTask.reports.html.outputLocation.get().asFile == project.file("build/reports/tests/test/Test-4.0")
 
     and:
-    testTask.testFramework.getClass() == JUnitPlatformTestFramework
+    testTask.testFramework instanceof JUnitPlatformTestFramework
   }
 
   private Project createProject() {

--- a/build.gradle
+++ b/build.gradle
@@ -265,41 +265,96 @@ if (gradle.startParameter.taskNames == ["ghActionsPublish"] || gradle.startParam
   }
 }
 
-tasks.register("publishJavadoc", Exec) {
+// Publishing to gh-pages uses a detached worktree under build/ (gitignored) instead of
+// switching the main checkout. This keeps the main checkout on the release commit, needs no
+// throwaway branch to switch back to, and writes nothing to the local .git/config (the bot
+// commit identity is passed per command via `git -c`).
+
+tasks.register("prepareJavadocWorktree", Exec) {
   dependsOn "javadoc"
   commandLine "sh", "-c",
     """
-  git config user.email "dev@forum.spockframework.org"
-  git config user.name "Spock Framework Robot"
+  set -e
+  git worktree remove --force build/gh-pages-javadoc 2>/dev/null || true
+  git worktree prune
   git fetch origin +gh-pages:gh-pages
-  git switch gh-pages
-  rm -rf javadoc/$variantLessVersion
-  mkdir -p javadoc/$variantLessVersion
-  cp -r build/javadoc/$variantLessVersion javadoc/
-  git add javadoc
-  git commit -qm "Publish javadoc/$variantLessVersion"
-  git push "https://\$GITHUB_TOKEN@github.com/spockframework/spock.git" gh-pages 2>&1 | sed "s/\$GITHUB_TOKEN/xxx/g"
-  git switch -
+  git worktree add --force build/gh-pages-javadoc gh-pages
+  rm -rf build/gh-pages-javadoc/javadoc/$variantLessVersion
+  mkdir -p build/gh-pages-javadoc/javadoc/$variantLessVersion
+  cp -r build/javadoc/$variantLessVersion build/gh-pages-javadoc/javadoc/
 """
 }
-tasks.register("publishDocs", Exec) {
+
+tasks.register("commitJavadoc", Exec) {
+  dependsOn "prepareJavadocWorktree"
+  // bash + pipefail so a failed push (piped through sed for token redaction) fails the task;
+  // with sh's default the pipeline would report sed's exit code (always 0) and mask the failure.
+  commandLine "bash", "-c",
+    """
+  set -eo pipefail
+  git -C build/gh-pages-javadoc add javadoc
+  git -C build/gh-pages-javadoc -c user.name="Spock Framework Robot" -c user.email="dev@forum.spockframework.org" commit -qm "Publish javadoc/$variantLessVersion"
+  git -C build/gh-pages-javadoc push "https://\$GITHUB_TOKEN@github.com/spockframework/spock.git" gh-pages 2>&1 | sed "s/\$GITHUB_TOKEN/xxx/g"
+  git worktree remove --force build/gh-pages-javadoc
+"""
+}
+
+tasks.register("publishJavadoc") {
+  dependsOn "commitJavadoc"
+}
+
+tasks.register("prepareDocsWorktree", Exec) {
   dependsOn "asciidoctor", "asciidoctorMarkdown"
+  // when a release publishes both (ghActionsDocs), fetch gh-pages only after the javadoc push
+  // has landed, so the docs push fast-forwards instead of being rejected as non-fast-forward
+  mustRunAfter "commitJavadoc"
   commandLine "sh", "-c",
     """
-  git config user.email "dev@forum.spockframework.org"
-  git config user.name "Spock Framework Robot"
+  set -e
+  git worktree remove --force build/gh-pages 2>/dev/null || true
+  git worktree prune
   git fetch origin +gh-pages:gh-pages
-  git switch gh-pages
-  rm -rf docs/$variantLessVersion
-  mkdir -p docs/$variantLessVersion
-  cp -r build/docs/asciidoc/* docs/$variantLessVersion
-  cp -r build/docs/asciidocMarkdown/* docs/$variantLessVersion
-  git add docs
-  git commit -qm "Publish docs/$variantLessVersion"
-  git push "https://\$GITHUB_TOKEN@github.com/spockframework/spock.git" gh-pages 2>&1 | sed "s/\$GITHUB_TOKEN/xxx/g"
-  git switch -
+  git worktree add --force build/gh-pages gh-pages
+  rm -rf build/gh-pages/docs/$variantLessVersion
+  mkdir -p build/gh-pages/docs/$variantLessVersion
+  cp -r build/docs/asciidoc/* build/gh-pages/docs/$variantLessVersion
+  cp -r build/docs/asciidocMarkdown/* build/gh-pages/docs/$variantLessVersion
 """
 }
+
+tasks.register("generateLlmsTxt", org.spockframework.gradle.GenerateLlmsTxt) {
+  dependsOn "prepareDocsWorktree"
+  docsDir = file("build/gh-pages/docs")
+  baseUrl = "https://spockframework.org/spock/docs/"
+  outputFile = file("build/gh-pages/docs/llms.txt")
+  // reads a tree materialised by prepareDocsWorktree in the same build
+  outputs.upToDateWhen { false }
+}
+
+tasks.register("generateDocsRedirects", org.spockframework.gradle.GenerateDocsRedirects) {
+  dependsOn "prepareDocsWorktree"
+  docsDir = file("build/gh-pages/docs")
+  outputs.upToDateWhen { false }
+}
+
+tasks.register("commitDocs", Exec) {
+  dependsOn "generateLlmsTxt", "generateDocsRedirects"
+  // bash + pipefail so a failed push (piped through sed for token redaction) fails the task;
+  // with sh's default the pipeline would report sed's exit code (always 0) and mask the failure.
+  commandLine "bash", "-c",
+    """
+  set -eo pipefail
+  git -C build/gh-pages add .
+  git -C build/gh-pages -c user.name="Spock Framework Robot" -c user.email="dev@forum.spockframework.org" commit -qm "Publish docs/$variantLessVersion"
+  git -C build/gh-pages push "https://\$GITHUB_TOKEN@github.com/spockframework/spock.git" gh-pages 2>&1 | sed "s/\$GITHUB_TOKEN/xxx/g"
+  git worktree remove --force build/gh-pages
+"""
+}
+
+tasks.register("publishDocs") {
+  dependsOn "commitDocs"
+}
+
 tasks.register("tagRelease", Exec) {
   commandLine "sh", "-c",
     """


### PR DESCRIPTION
## What

Adds an `llms.txt` documentation index to the published docs and makes the gh-pages publishing step robust and self-maintaining.

### `llms.txt`
A token-efficient index served at `https://docs.spockframework.org/llms.txt`, regenerated on every docs publish. It gives a URL **template** + example, a `## Pages` list (slug + the one-sentence description parsed from the latest stable's `index.md`, description optional so it works for 2.4 today and improves automatically from 2.5), and a compact `## Versions` block listing stable releases + the development snapshot. No per-page/per-version URLs are spelled out.

### Self-maintaining redirects
`docs/index.html`, `docs/current`, and `docs/latest` are now generated from the same directory scan instead of being hand-edited (a recurring source of staleness). `docs/index.html` redirects **directly** to the latest stable version, removing the previous `current/` hop.

### Hardened publishing
`publishDocs`/`publishJavadoc` now publish via a detached `build/gh-pages` **worktree** instead of `git switch`-ing the main checkout:
- main checkout never changes branches; no throwaway `docs-$GITHUB_SHA` branch needed (dropped from the release workflow);
- the bot commit identity is passed **per command** (`git -c user.name=… -c user.email=…`) instead of mutating local `.git/config` — no side effects when run locally;
- the worktree is pruned/removed each run.

## How it's built
Generation logic lives in the `build-logic/base` convention-plugin module as `@CompileStatic`, `Path`-based, unit-tested helpers (`DocVersions`, `LlmsTxtRenderer`, `DocsRedirects`) behind thin Gradle tasks (`GenerateLlmsTxt`, `GenerateDocsRedirects`). `groovy-nio` is provided by `localGroovy()`, so no dependency change was needed.

## Incidental
The `base` test suite was frozen by the build cache and broke once these new test sources forced a recompile under Gradle 9. Two pre-existing issues fixed here:
- `useSpock('2.4-groovy-3.0')` → `2.4-groovy-4.0` (the groovy-3.0 Spock AST transform can't run on Gradle 9's bundled Groovy 4);
- `SpockBasePluginSpec` asserted `testFramework.class == JUnitPlatformTestFramework`, but Gradle 9 returns a `_Decorated` subclass → switched to `instanceof`.

## Notes
- The `current` redirect / `## Pages` descriptions become richer automatically once 2.5 is the latest stable (2.4 predates per-page descriptions).
- The commit/push path can only be exercised in a real release run; the worktree + generators were verified locally against the actual `spockframework/gh-pages` content.
