### PR TITLE
Extend the top interaction scope to cleanup methods

### DIFF
--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -444,7 +444,7 @@ This makes sure that `subscriber` receives `"message1"` during execution of the 
 and `"message2"` during execution of the second `when:` block.
 
 Interactions declared outside a `then:` block are active from their declaration until the end of the
-containing feature method.
+containing feature method plus an eventually existing `cleanup` method.
 
 Interactions are always scoped to a particular feature method. Hence they cannot be declared in a static method,
 `setupSpec` method, or `cleanupSpec` method. Likewise, mock objects should not be stored in static or `@Shared`

--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -444,7 +444,7 @@ This makes sure that `subscriber` receives `"message1"` during execution of the 
 and `"message2"` during execution of the second `when:` block.
 
 Interactions declared outside a `then:` block are active from their declaration until the end of the
-containing feature method plus an eventually existing `cleanup` method.
+containing feature method, plus any `cleanup` methods.
 
 Interactions are always scoped to a particular feature method. Hence they cannot be declared in a static method,
 `setupSpec` method, or `cleanupSpec` method. Likewise, mock objects should not be stored in static or `@Shared`

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -25,6 +25,12 @@ include::include.adoc[]
 === Breaking Changes
 
 * Mock/Stub checks on `Comparable<T>` with `T` being something other than `Object` now compare using the java identity hash code instead of always being equal spockIssue:2352[]
+* Interactions outside a `then:` block are now still active in an eventually existing `cleanup` method.
+  If the interaction contains a lower cardinality, this is still checked at the end of the feature method.
+  Upper cardinality is still relevant in the `cleanup` method, so could cause test failures where previously simply the default response of the mock object was used without cardinality check and could now cause previously working tests to fail.
+  This enables `cleanup` methods to get stubbed responses from mock objects which previously was only possible by using a custom default response.
+  If an interaction with stubbed response is present, the default response is also no longer used in the `cleanup` method because the interaction's stubbed response is used now, which could also cause existing tests to fail.
+  spockIssue:616[]
 
 == 2.4 (2025-12-11)
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -25,7 +25,7 @@ include::include.adoc[]
 === Breaking Changes
 
 * Mock/Stub checks on `Comparable<T>` with `T` being something other than `Object` now compare using the java identity hash code instead of always being equal spockIssue:2352[]
-* Interactions outside a `then:` block are now still active in an eventually existing `cleanup` method.
+* Interactions outside a `then:` block are now still active in any eventually existing `cleanup` methods.
   If the interaction contains a lower cardinality, this is still checked at the end of the feature method.
   Upper cardinality is still relevant in the `cleanup` method, so could cause test failures where previously simply the default response of the mock object was used without cardinality check and could now cause previously working tests to fail.
   This enables `cleanup` methods to get stubbed responses from mock objects which previously was only possible by using a custom default response.

--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -110,6 +110,9 @@ public class AstNodeCache {
   public final MethodNode MockController_LeaveScope =
       MockController.getDeclaredMethods(org.spockframework.mock.runtime.MockController.LEAVE_SCOPE).get(0);
 
+  public final MethodNode MockController_VerifyLastScope =
+      MockController.getDeclaredMethods(org.spockframework.mock.runtime.MockController.VERIFY_LAST_SCOPE).get(0);
+
   public final MethodNode SpecificationContext_GetMockController =
       SpecificationContext.getDeclaredMethods(org.spockframework.runtime.SpecificationContext.GET_MOCK_CONTROLLER).get(0);
 

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -410,7 +410,7 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
 
     // for global required interactions
     if (method instanceof FeatureMethod) {
-      method.getStatements().add(createMockControllerCall(nodeCache.MockController_LeaveScope));
+      method.getStatements().add(createMockControllerCall(nodeCache.MockController_VerifyLastScope));
     }
 
     if (method instanceof VerifyAllMethod) {

--- a/spock-core/src/main/java/org/spockframework/mock/TooFewInvocationsError.java
+++ b/spock-core/src/main/java/org/spockframework/mock/TooFewInvocationsError.java
@@ -37,7 +37,7 @@ public class TooFewInvocationsError extends InteractionNotSatisfiedError {
     Assert.notNull(interactions);
     Assert.that(interactions.size() > 0);
     this.interactions = interactions;
-    this.unmatchedInvocations = unmatchedInvocations;
+    this.unmatchedInvocations = new ArrayList<>(unmatchedInvocations);
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/MockController.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/MockController.java
@@ -17,7 +17,7 @@
 package org.spockframework.mock.runtime;
 
 import org.spockframework.mock.*;
-import org.spockframework.util.Checks;
+import org.spockframework.util.Assert;
 import org.spockframework.util.ExceptionUtil;
 
 import java.util.*;
@@ -108,6 +108,14 @@ public class MockController implements IMockController, IThreadAwareMockControll
     throwAnyPreviousError();
     IInteractionScope scope = scopes.removeFirst();
     scope.verifyInteractions();
+  }
+
+  public static final String VERIFY_LAST_SCOPE = "verifyLastScope";
+
+  public synchronized void verifyLastScope() {
+    throwAnyPreviousError();
+    Assert.that(scopes.size() == 1, () -> "There should be exactly one scope left, but there were " + scopes.size());
+    scopes.getFirst().verifyInteractions();
   }
 
   private void throwAnyPreviousError() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GlobalInteractionsInCleanup.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GlobalInteractionsInCleanup.groovy
@@ -23,8 +23,18 @@ import spock.lang.Specification
 
 import java.util.function.Function
 
+abstract class GlobalInteractionsInCleanupSuperSpec extends Specification {
+  def cleanup() {
+    verifyAll {
+      mock.apply("a") == "b"
+      mock2.apply("a") == "c"
+      mock3.apply("a") == "d"
+    }
+  }
+}
+
 @Issue("https://github.com/spockframework/spock/issues/616")
-class GlobalInteractionsInCleanup extends Specification {
+class GlobalInteractionsInCleanup extends GlobalInteractionsInCleanupSuperSpec {
   def mock = Mock(Function)
   def mock2 = Mock(Function) {
     apply("a") >> { "c" }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GlobalInteractionsInCleanup.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/GlobalInteractionsInCleanup.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.mock
+
+import org.spockframework.runtime.ConditionNotSatisfiedError
+import spock.lang.FailsWith
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.util.function.Function
+
+@Issue("https://github.com/spockframework/spock/issues/616")
+class GlobalInteractionsInCleanup extends Specification {
+  def mock = Mock(Function)
+  def mock2 = Mock(Function) {
+    apply("a") >> { "c" }
+  }
+  def mock3 = Mock(Function)
+
+  def setup() {
+    mock.apply("a") >> { "b" }
+  }
+
+  def cleanup() {
+    verifyAll {
+      mock.apply("a") == "b"
+      mock2.apply("a") == "c"
+      mock3.apply("a") == "d"
+    }
+  }
+
+  def "run a successful test"() {
+    given:
+    mock3.apply("a") >> { "d" }
+
+    expect:
+    true
+  }
+
+  @FailsWith(ConditionNotSatisfiedError)
+  def "run a failing test"() {
+    given:
+    mock3.apply("a") >> { "d" }
+
+    expect:
+    false
+  }
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/Primitive_types_are_used_in_AST_transformation-groovy4.txt
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/Primitive_types_are_used_in_AST_transformation-groovy4.txt
@@ -208,7 +208,7 @@ public class apackage/TestSpec extends spock/lang/Specification implements groov
       "()", 
       0
     ]
-    INVOKEVIRTUAL org/spockframework/mock/runtime/MockController.leaveScope ()V
+    INVOKEVIRTUAL org/spockframework/mock/runtime/MockController.verifyLastScope ()V
     ACONST_NULL
     POP
    L18

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/Primitive_types_are_used_in_AST_transformation-groovy5.txt
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/Primitive_types_are_used_in_AST_transformation-groovy5.txt
@@ -184,7 +184,7 @@ public class apackage/TestSpec extends spock/lang/Specification implements groov
       "()", 
       0
     ]
-    INVOKEVIRTUAL org/spockframework/mock/runtime/MockController.leaveScope ()V
+    INVOKEVIRTUAL org/spockframework/mock/runtime/MockController.verifyLastScope ()V
    L18
     LINENUMBER 9 L18
     RETURN

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/Primitive_types_are_used_in_AST_transformation.txt
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/Primitive_types_are_used_in_AST_transformation.txt
@@ -181,7 +181,7 @@ public class apackage/TestSpec extends spock/lang/Specification implements groov
     LDC Lorg/spockframework/mock/runtime/MockController;.class
     INVOKESTATIC org/codehaus/groovy/runtime/ScriptBytecodeAdapter.castToType (Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object;
     CHECKCAST org/spockframework/mock/runtime/MockController
-    INVOKEVIRTUAL org/spockframework/mock/runtime/MockController.leaveScope ()V
+    INVOKEVIRTUAL org/spockframework/mock/runtime/MockController.verifyLastScope ()V
     ACONST_NULL
     POP
    L18

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/astToSourceFeatureBody_can_render_everything.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/astToSourceFeatureBody_can_render_everything.groovy
@@ -10,7 +10,7 @@ public class apackage.ASpec extends spock.lang.Specification {
         org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
         java.lang.Object nothing = null
         org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-        this.getSpecificationContext().getMockController().leaveScope()
+        this.getSpecificationContext().getMockController().verifyLastScope()
     }
 
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/astToSourceFeatureBody_can_render_everything__Groovy_4_0_2__.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/astToSourceFeatureBody_can_render_everything__Groovy_4_0_2__.groovy
@@ -10,7 +10,7 @@ public class apackage.ASpec extends spock.lang.Specification implements groovy.l
         org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
         java.lang.Object nothing = null
         org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-        this.getSpecificationContext().getMockController().leaveScope()
+        this.getSpecificationContext().getMockController().verifyLastScope()
     }
 
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/astToSourceFeatureBody_renders_only_methods_and_its_annotation_by_default.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/astToSourceFeatureBody_renders_only_methods_and_its_annotation_by_default.groovy
@@ -9,7 +9,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
     java.lang.Object nothing = null
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/astToSourceSpecBody_renders_only_methods__fields__properties__object_initializers_and_their_annotation_by_default.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/astToSourceSpecBody_renders_only_methods__fields__properties__object_initializers_and_their_annotation_by_default.groovy
@@ -15,7 +15,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
     java.lang.Object nothing = null
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_GString_labels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_GString_labels.groovy
@@ -29,7 +29,7 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '\"then \${idx++}\"', 5, 11, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 3)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_empty_labels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_empty_labels.groovy
@@ -43,7 +43,7 @@ public void $spock_feature_0_0() {
             }
         }
     }
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_labels_and_blocks.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_labels_and_blocks.groovy
@@ -45,7 +45,7 @@ public void $spock_feature_0_0() {
             }
         }
     }
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference.groovy
@@ -51,7 +51,7 @@ public void $spock_feature_0_0() {
             }
         }
     }
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
@@ -51,7 +51,7 @@ public void $spock_feature_0_0() {
             }
         }
     }
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments.groovy
@@ -51,7 +51,7 @@ public void $spock_feature_0_0() {
             }
         }
     }
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/multi_parameterization.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/multi_parameterization.groovy
@@ -15,7 +15,7 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b) {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a == b', 1, 83, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 @org.spockframework.runtime.model.DataProviderMetadata(line = 3, dataVariables = ['a', 'b'])

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/nested_multi_parameterization.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/nested_multi_parameterization.groovy
@@ -15,7 +15,7 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b) {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a == b', 1, 83, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 @org.spockframework.runtime.model.DataProviderMetadata(line = 3, dataVariables = ['a', 'b'])

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables.groovy
@@ -15,7 +15,7 @@ public void $spock_feature_0_0(java.lang.Object name, java.lang.Object greeting)
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'greeting == \"Hello, world\"', 1, 83, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 @org.spockframework.runtime.model.DataProviderMetadata(line = 4, dataVariables = ['name'])

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_combined_with_data_table__data_pipe__derived_variables__cross_multiplication_and_filter.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_combined_with_data_table__data_pipe__derived_variables__cross_multiplication_and_filter.groovy
@@ -14,7 +14,7 @@ public void $spock_feature_0_0(java.lang.Object x, java.lang.Object y, java.lang
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 5, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 public java.lang.Object $spock_feature_0_0prov0(java.lang.Object base, java.lang.Object sep) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy3_4.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy3_4.groovy
@@ -15,7 +15,7 @@ public void $spock_feature_0_0(java.lang.Object name, java.lang.Object greeting)
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'greeting == \"Hello, world!\"', 1, 83, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 @org.spockframework.runtime.model.DataProviderMetadata(line = 4, dataVariables = ['name'])

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy5.groovy
@@ -15,7 +15,7 @@ public void $spock_feature_0_0(java.lang.Object name, java.lang.Object greeting)
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'greeting == \"Hello, world!\"', 1, 83, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 @org.spockframework.runtime.model.DataProviderMetadata(line = 4, dataVariables = ['name'])

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[0].groovy
@@ -14,7 +14,7 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b, java.lang
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 7, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 public java.lang.Object $spock_feature_0_0prov0() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[1].groovy
@@ -14,7 +14,7 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b, java.lang
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 7, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 public java.lang.Object $spock_feature_0_0prov0() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[2].groovy
@@ -14,7 +14,7 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b, java.lang
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 7, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 public java.lang.Object $spock_feature_0_0prov0() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/filter_block_becomes_its_own_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/filter_block_becomes_its_own_method.groovy
@@ -14,7 +14,7 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b) {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 7, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 public java.lang.Object $spock_feature_0_0prov0() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/using_a_variable_in_a_cell_multiple_times_compiles.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/using_a_variable_in_a_cell_multiple_times_compiles.groovy
@@ -14,7 +14,7 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b, java.lang
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a + b == result', 2, 9, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 public java.lang.Object $spock_feature_0_0prov0() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/collection_condition_matchCollectionsAsSet_is_transformed_correctly.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/collection_condition_matchCollectionsAsSet_is_transformed_correctly.groovy
@@ -18,7 +18,7 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'x =~ [1]', 4, 9, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/collection_condition_matchCollectionsInAnyOrder_is_transformed_correctly.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/collection_condition_matchCollectionsInAnyOrder_is_transformed_correctly.groovy
@@ -18,7 +18,7 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'x ==~ [1]', 4, 9, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/regex_find_conditions_are_transformed_correctly.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/regex_find_conditions_are_transformed_correctly.groovy
@@ -18,7 +18,7 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'x =~ /\\d/', 4, 9, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/regex_match_conditions_are_transformed_correctly.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/regex_match_conditions_are_transformed_correctly.groovy
@@ -18,7 +18,7 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'x ==~ /a\\db/', 4, 9, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_explicit_condition.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_explicit_condition.groovy
@@ -11,5 +11,5 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'null.with {\n  false\n}', 2, 8, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_implicit_condition.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_implicit_condition.groovy
@@ -11,5 +11,5 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'null.with {\n  false\n}', 2, 1, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[0].groovy
@@ -11,5 +11,5 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'false', 3, 3, null, $spock_condition_throwable)}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[1].groovy
@@ -15,5 +15,5 @@ public void $spock_feature_0_0() {
             $spock_errorCollector1.validateCollectedErrors()}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[2].groovy
@@ -11,5 +11,5 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'false', 3, 3, null, $spock_condition_throwable)}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[0].groovy
@@ -12,5 +12,5 @@ public void $spock_feature_0_0() {
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[1].groovy
@@ -16,5 +16,5 @@ public void $spock_feature_0_0() {
             $spock_errorCollector1.validateCollectedErrors()}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[2].groovy
@@ -12,5 +12,5 @@ public void $spock_feature_0_0() {
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[0].groovy
@@ -5,5 +5,5 @@ public void $spock_feature_0_0() {
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[1].groovy
@@ -5,5 +5,5 @@ public void $spock_feature_0_0() {
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[2].groovy
@@ -5,5 +5,5 @@ public void $spock_feature_0_0() {
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[0].groovy
@@ -18,5 +18,5 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[1].groovy
@@ -27,5 +27,5 @@ public void $spock_feature_0_0() {
             $spock_errorCollector1.validateCollectedErrors()}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[2].groovy
@@ -18,5 +18,5 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[0].groovy
@@ -19,5 +19,5 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[1].groovy
@@ -28,5 +28,5 @@ public void $spock_feature_0_0() {
             $spock_errorCollector1.validateCollectedErrors()}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[2].groovy
@@ -19,5 +19,5 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[0].groovy
@@ -13,5 +13,5 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[1].groovy
@@ -17,5 +17,5 @@ public void $spock_feature_0_0() {
             $spock_errorCollector1.validateCollectedErrors()}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[2].groovy
@@ -13,5 +13,5 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec/thrown_rewrite_keeps_correct_method_reference.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec/thrown_rewrite_keeps_correct_method_reference.groovy
@@ -23,7 +23,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
     org.spockframework.runtime.SpecInternals.thrownImpl(this, null, null, java.lang.IllegalStateException)
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec/thrown_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec/thrown_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
@@ -23,7 +23,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
     org.spockframework.runtime.SpecInternals.thrownImpl(this, null, null, java.lang.IllegalStateException)
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec/thrown_rewrite_keeps_correct_method_reference_for_multi_assignments.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec/thrown_rewrite_keeps_correct_method_reference_for_multi_assignments.groovy
@@ -23,7 +23,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
     org.spockframework.runtime.SpecInternals.thrownImpl(this, null, null, java.lang.IllegalStateException)
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/methods_without_condition_declarations_stay_unchanged_in_specs.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/methods_without_condition_declarations_stay_unchanged_in_specs.groovy
@@ -19,7 +19,7 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 3, 5, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_private_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_private_methods.groovy
@@ -94,7 +94,7 @@ public void $spock_feature_0_0() {
         }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/methods_without_condition_declarations_stay_unchanged_in_specs.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/methods_without_condition_declarations_stay_unchanged_in_specs.groovy
@@ -19,7 +19,7 @@ public void $spock_feature_0_0() {
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 3, 5, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_private_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_private_methods.groovy
@@ -90,7 +90,7 @@ public void $spock_feature_0_0() {
         }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/MocksAstSpec/simple_interaction.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/MocksAstSpec/simple_interaction.groovy
@@ -17,7 +17,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
     this.getSpecificationContext().getMockController().leaveScope()
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_provider_with_asserting_closure_produces_error_rethrower_variable_in_data_provider_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_provider_with_asserting_closure_produces_error_rethrower_variable_in_data_provider_method.groovy
@@ -4,7 +4,7 @@ import spock.lang.*
 class ASpec extends Specification {
 /*--------- tag::snapshot[] ---------*/
 public void $spock_feature_0_0(java.lang.Object dataPipe, java.lang.Object dataVariable) {
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 public java.lang.Object $spock_feature_0_0prov0() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_variable_with_asserting_closure_produces_error_rethrower_variable_in_data_processor_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_variable_with_asserting_closure_produces_error_rethrower_variable_in_data_processor_method.groovy
@@ -4,7 +4,7 @@ import spock.lang.*
 class ASpec extends Specification {
 /*--------- tag::snapshot[] ---------*/
 public void $spock_feature_0_0(java.lang.Object dataPipe, java.lang.Object dataVariable) {
-    this.getSpecificationContext().getMockController().leaveScope()
+    this.getSpecificationContext().getMockController().verifyLastScope()
 }
 
 public java.lang.Object $spock_feature_0_0prov0() {


### PR DESCRIPTION
Fixes #616
