### PR TITLE
Pin Kotlin for workflow script execution on CI

### DIFF
--- a/.github/actions/install-pinned-kotlin/action.yml
+++ b/.github/actions/install-pinned-kotlin/action.yml
@@ -1,0 +1,19 @@
+name: Install pinned Kotlin
+description: >
+  Installs a pinned Kotlin version and prepends it to the PATH.
+  Kotlin 2.3.20 and newer cannot execute the workflow scripts with the `kotlin` CLI,
+  because resolving extension functions from imported scripts is broken there,
+  see https://youtrack.jetbrains.com/issue/KT-86352.
+  As the GitHub runner images ship an affected version, this action puts an
+  unaffected version on the PATH before any workflow script is executed on a runner.
+
+runs:
+  using: "composite"
+  steps:
+    - name: 'Install Kotlin 2.3.10 (work-around for KT-86352)'
+      run: |
+        curl --fail --silent --show-error --location --output "$RUNNER_TEMP/kotlin-compiler.zip" "https://github.com/JetBrains/kotlin/releases/download/v2.3.10/kotlin-compiler-2.3.10.zip"
+        echo "c8d546f9ff433b529fb0ad43feceb39831040cae2ca8d17e7df46364368c9a9e  $RUNNER_TEMP/kotlin-compiler.zip" | sha256sum --check
+        unzip -q "$RUNNER_TEMP/kotlin-compiler.zip" -d "$RUNNER_TEMP/pinned-kotlin"
+        echo "$RUNNER_TEMP/pinned-kotlin/kotlinc/bin" >> "$GITHUB_PATH"
+      shell: bash

--- a/.github/workflows/branches-and-prs.main.kts
+++ b/.github/workflows/branches-and-prs.main.kts
@@ -40,8 +40,6 @@ import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts.github
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
-import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource.InferFromClasspath
-import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 
 workflow(
     name = "Verify Branches and PRs",
@@ -61,9 +59,7 @@ workflow(
         group = "${expr { github.workflow }}-${expr("${github.eventPullRequest.pull_request.number} || ${github.ref}")}",
         cancelInProgress = true
     ),
-    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
-        checkoutActionVersion = InferFromClasspath()
-    )
+    consistencyCheckJobConfig = commonConsistencyCheckJobConfig
 ) {
     job(
         id = "check_all_workflow_yaml_consistency",
@@ -74,6 +70,7 @@ workflow(
             name = "Checkout Repository",
             action = Checkout()
         )
+        installPinnedKotlin()
         run(
             name = "Regenerate all Workflow YAMLs",
             command = """find .github/workflows -mindepth 1 -maxdepth 1 -name '*.main.kts' -exec {} \;"""

--- a/.github/workflows/branches-and-prs.yaml
+++ b/.github/workflows/branches-and-prs.yaml
@@ -22,9 +22,12 @@ jobs:
       name: 'Check out'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
+      name: 'Install pinned Kotlin (work-around for KT-86352)'
+      uses: './.github/actions/install-pinned-kotlin'
+    - id: 'step-2'
       name: 'Execute script'
       run: 'rm ''.github/workflows/branches-and-prs.yaml'' && ''.github/workflows/branches-and-prs.main.kts'''
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Consistency check'
       run: 'git diff --exit-code ''.github/workflows/branches-and-prs.yaml'''
   check_all_workflow_yaml_consistency:
@@ -37,9 +40,12 @@ jobs:
       name: 'Checkout Repository'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
+      name: 'Install pinned Kotlin (work-around for KT-86352)'
+      uses: './.github/actions/install-pinned-kotlin'
+    - id: 'step-2'
       name: 'Regenerate all Workflow YAMLs'
       run: 'find .github/workflows -mindepth 1 -maxdepth 1 -name ''*.main.kts'' -exec {} \;'
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Check for Modifications'
       run: |-
         git add --intent-to-add .

--- a/.github/workflows/codeql-analysis.main.kts
+++ b/.github/workflows/codeql-analysis.main.kts
@@ -36,8 +36,6 @@ import io.github.typesafegithub.workflows.domain.triggers.*
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts.github
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
-import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource.InferFromClasspath
-import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 
 workflow(
     name = "Code scanning - action",
@@ -63,9 +61,7 @@ workflow(
         group = "${expr { github.workflow }}-${expr("${github.eventPullRequest.pull_request.number} || ${github.ref}")}",
         cancelInProgress = true
     ),
-    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
-        checkoutActionVersion = InferFromClasspath()
-    )
+    consistencyCheckJobConfig = commonConsistencyCheckJobConfig
 ) {
     job(
         id = "codeql-build",

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -23,9 +23,12 @@ jobs:
       name: 'Check out'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
+      name: 'Install pinned Kotlin (work-around for KT-86352)'
+      uses: './.github/actions/install-pinned-kotlin'
+    - id: 'step-2'
       name: 'Execute script'
       run: 'rm ''.github/workflows/codeql-analysis.yaml'' && ''.github/workflows/codeql-analysis.main.kts'''
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Consistency check'
       run: 'git diff --exit-code ''.github/workflows/codeql-analysis.yaml'''
   codeql-build:

--- a/.github/workflows/common.main.kts
+++ b/.github/workflows/common.main.kts
@@ -28,12 +28,34 @@ import io.github.typesafegithub.workflows.dsl.JobBuilder
 import io.github.typesafegithub.workflows.dsl.WorkflowBuilder
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts.secrets
 import io.github.typesafegithub.workflows.dsl.expressions.expr
+import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource.InferFromClasspath
+import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 import java.util.Properties
 
 val GRADLE_ENTERPRISE_ACCESS_KEY by secrets
 
 val commonCredentials = mapOf(
     "DEVELOCITY_ACCESS_KEY" to expr(GRADLE_ENTERPRISE_ACCESS_KEY)
+)
+
+// Work-around for https://youtrack.jetbrains.com/issue/KT-86352,
+// see the action definition for details.
+object InstallPinnedKotlin : LocalAction<Outputs>("./.github/actions/install-pinned-kotlin") {
+    override fun toYamlArguments() = linkedMapOf<String, String>()
+
+    override fun buildOutputObject(stepId: String): Outputs = Outputs(stepId)
+}
+
+fun JobBuilder<*>.installPinnedKotlin() {
+    uses(
+        name = "Install pinned Kotlin (work-around for KT-86352)",
+        action = InstallPinnedKotlin
+    )
+}
+
+val commonConsistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
+    checkoutActionVersion = InferFromClasspath(),
+    additionalSteps = { installPinnedKotlin() }
 )
 
 data class Strategy(

--- a/.github/workflows/docs-pr.main.kts
+++ b/.github/workflows/docs-pr.main.kts
@@ -37,8 +37,6 @@ import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts.github
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
-import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource.InferFromClasspath
-import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 
 workflow(
     name = "Verify Docs",
@@ -58,9 +56,7 @@ workflow(
         group = "${expr { github.workflow }}-${expr("${github.eventPullRequest.pull_request.number} || ${github.ref}")}",
         cancelInProgress = true
     ),
-    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
-        checkoutActionVersion = InferFromClasspath()
-    )
+    consistencyCheckJobConfig = commonConsistencyCheckJobConfig
 ) {
     job(
         id = "docs-and-javadoc",

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -22,9 +22,12 @@ jobs:
       name: 'Check out'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
+      name: 'Install pinned Kotlin (work-around for KT-86352)'
+      uses: './.github/actions/install-pinned-kotlin'
+    - id: 'step-2'
       name: 'Execute script'
       run: 'rm ''.github/workflows/docs-pr.yaml'' && ''.github/workflows/docs-pr.main.kts'''
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Consistency check'
       run: 'git diff --exit-code ''.github/workflows/docs-pr.yaml'''
   docs-and-javadoc:

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -35,8 +35,6 @@ import io.github.typesafegithub.workflows.dsl.expressions.Contexts.github
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts.secrets
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
-import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource.InferFromClasspath
-import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 
 workflow(
     name = "Build and Release Spock",
@@ -47,9 +45,7 @@ workflow(
         )
     ),
     sourceFile = __FILE__,
-    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
-        checkoutActionVersion = InferFromClasspath()
-    )
+    consistencyCheckJobConfig = commonConsistencyCheckJobConfig
 ) {
     val GITHUB_TOKEN by secrets
     val SONATYPE_OSS_USER by secrets

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,12 @@ jobs:
       name: 'Check out'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
+      name: 'Install pinned Kotlin (work-around for KT-86352)'
+      uses: './.github/actions/install-pinned-kotlin'
+    - id: 'step-2'
       name: 'Execute script'
       run: 'rm ''.github/workflows/release.yaml'' && ''.github/workflows/release.main.kts'''
-    - id: 'step-2'
+    - id: 'step-3'
       name: 'Consistency check'
       run: 'git diff --exit-code ''.github/workflows/release.yaml'''
   build-and-verify:


### PR DESCRIPTION
### Problem

The Kotlin versions preinstalled on the GitHub runner images (2.3.20 and newer) cannot execute our workflow scripts with the `kotlin` CLI: resolving extension functions from `@file:Import`ed scripts is broken, see [KT-86352](https://youtrack.jetbrains.com/issue/KT-86352). This breaks the `check_yaml_consistency` jobs and the regenerate-all-workflows job, which execute the `*.main.kts` scripts on the runner. Generation via Gradle is unaffected, as it uses the legacy scripting host.

### Work-around

* Add a local composite action `.github/actions/install-pinned-kotlin` that downloads Kotlin 2.3.10 (last unaffected version), validates its sha256 against the official release checksum, and prepends it to the `PATH`.
* Run it before any workflow script execution on a runner: in the generated consistency check jobs via a shared `commonConsistencyCheckJobConfig` (which also centralizes the previously duplicated `DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(...)` blocks), and in the `check_all_workflow_yaml_consistency` job.

Verified locally by executing the scripts with the pinned 2.3.10 CLI: no KT-86352 failure, and the output is byte-identical to the Gradle-generated YAML.

### Revert plan

Revert this commit once KT-86352 is resolved and the runner images ship a fixed Kotlin version.