### PR TITLE
Restrict JaCoCo instrumentation to Spock packages

### DIFF
--- a/build-logic/base/src/main/groovy/org/spockframework/gradle/JacocoJavaagentProvider.groovy
+++ b/build-logic/base/src/main/groovy/org/spockframework/gradle/JacocoJavaagentProvider.groovy
@@ -39,7 +39,7 @@ abstract class JacocoJavaagentProvider implements CommandLineArgumentProvider, N
   @Override
   Iterable<String> asArguments() {
     [
-      "-javaagent:${jacocoAgent.get().asFile}=destfile=${execResultFile.get().asFile},dumponexit=false,append=false,jmx=true,includes=org.spockframework.*".toString(),
+      "-javaagent:${jacocoAgent.get().asFile}=destfile=${execResultFile.get().asFile},dumponexit=false,append=false,jmx=true,includes=org.spockframework.*:spock.*".toString(),
       "-DJacocoAstDumpTrigger=true"
     ]
   }

--- a/build-logic/base/src/main/groovy/org/spockframework/gradle/SpockBasePlugin.groovy
+++ b/build-logic/base/src/main/groovy/org/spockframework/gradle/SpockBasePlugin.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.jetbrains.annotations.VisibleForTesting
 
 import java.time.Duration
@@ -130,6 +131,11 @@ class SpockBasePlugin implements Plugin<Project> {
         .flatMap { it.findVersion("jacoco") }
         .orElseThrow { new IllegalStateException("Jacoco version not found") }
     project.extensions.getByType(JacocoPluginExtension).toolVersion = jacocoVersion.requiredVersion
+
+    // Only instrument Spock's own packages, not the libraries under test.
+    project.tasks.withType(Test).configureEach { task ->
+      task.extensions.getByType(JacocoTaskExtension).includes = ['spock.*', 'org.spockframework.*']
+    }
   }
 
   private static void dependencyInsight(Project project) {


### PR DESCRIPTION
## What

Configure JaCoCo to only instrument Spock's own packages (`spock.*` and `org.spockframework.*`) instead of instrumenting every class loaded under test.

## Why

The JaCoCo agent was instrumenting all loaded classes, including the third-party libraries exercised by the specs. Restricting instrumentation to Spock's packages keeps coverage data focused on the code we actually own and reduces instrumentation overhead.

## Changes

- **`SpockBasePlugin`**: the `jacoco` Gradle plugin's `JacocoTaskExtension` had no include filter, so every `Test` task instrumented everything. Set `includes = ['spock.*', 'org.spockframework.*']` on all `Test` tasks.
- **`JacocoJavaagentProvider`**: the custom agent used for the `compileTestGroovy` AST-dump coverage already filtered to `org.spockframework.*`; added the missing `spock.*` (the agent's `includes` option is colon-separated).