### PR TITLE
Allow declaring mock interactions outside a Specification via MockInteractionSupport

### DIFF
--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -1259,6 +1259,35 @@ is attached to a spec before usage:
 include::{sourcedir}/interaction/DetachedMockFactoryDocSpec.groovy[tags=use-custom-mock-creator-attach]
 ----
 
+[[external-interactions]]
+=== Declaring Interactions Outside Specifications
+
+`DetachedMockFactory` lets you create a mock outside a `Specification`, but the mock's interactions still have to be declared inside the spec.
+`MockInteractionSupport` lets you encapsulate interactions (and mock creation) in a reusable fixture.
+It routes everything through the owning spec's mock controller, so the interactions behave exactly like interactions declared in a `setup:` block: the spec must be live (called from within a feature's lifecycle), and cardinality interactions are verified when the spec's controller scope leaves.
+
+[[MockInteractionSupport]]
+==== MockInteractionSupport
+
+Implement `spock.mock.MockInteractionSupport` to build a reusable fixture object that both creates mocks and declares interactions.
+The fixture supplies the owning spec through `getSpecification()` (typically stored in a constructor field), and the `Mock()`/`Stub()`/`Spy()` factory methods work just as they do inside a spec.
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/interaction/ExternalMockInteractionsDocSpec.groovy[tags=support-fixture]
+----
+
+A spec can then delegate creation and configuration to the fixture:
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/interaction/ExternalMockInteractionsDocSpec.groovy[tags=support-usage]
+----
+
+A class cannot be both a `Specification` and a `MockInteractionSupport`, because a spec already has the full capability.
+
+If you forget to attach the fixture, using it fails fast with a clear error that tells you the spec is missing.
+
 == Further Reading
 
 If you would like to dive deeper into interaction-based testing, we recommend the following resources:

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -10,6 +10,7 @@ include::include.adoc[]
 
 * Add support for `final` local variables in `where:` blocks, declared at their beginning and evaluated once per feature, scoped to the where-block spockIssue:138[]
 * Improve `TooManyInvocationsError` now reports unsatisfied interactions with argument mismatch details, making it easier to diagnose why invocations didn't match expected interactions spockPull:2315[]
+* Allow declaring mock interactions and creating mocks outside a `Specification` via the `MockInteractionSupport` interface, see <<interaction_based_testing.adoc#external-interactions,Declaring Interactions Outside Specifications>>
 
 === Misc
 
@@ -20,6 +21,7 @@ include::include.adoc[]
 === Breaking Changes
 
 * Mock/Stub checks on `Comparable<T>` with `T` being something other than `Object` now compare using the java identity hash code instead of always being equal spockIssue:2352[]
+* `spock.mock.MockingApi` changed from a class to an interface to support `MockInteractionSupport`. This only affects code that violated the documented contract by extending `MockingApi` directly instead of `Specification`. `instanceof` checks, casts, and type references keep working. However, already compiled code (Java, Kotlin, or `@CompileStatic` Groovy) that invokes a mock factory method on a receiver whose static type is `MockingApi` was compiled as a virtual call and now requires interface dispatch; such code fails with an `IncompatibleClassChangeError` until it is recompiled.
 
 == 2.4 (2025-12-11)
 

--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -45,6 +45,8 @@ public class AstNodeCache {
   public final ClassNode SpecInternals = ClassHelper.makeWithoutCaching(SpecInternals.class);
   public final ClassNode MockController = ClassHelper.makeWithoutCaching(MockController.class);
   public final ClassNode SpecificationContext = ClassHelper.makeWithoutCaching(SpecificationContext.class);
+  public final ClassNode MockInteractionSupport = ClassHelper.makeWithoutCaching(spock.mock.MockInteractionSupport.class);
+  public final ClassNode Checks = ClassHelper.makeWithoutCaching(org.spockframework.util.Checks.class);
   public final ClassNode DataVariableMultiplication = ClassHelper.makeWithoutCaching(DataVariableMultiplication.class);
   public final ClassNode DataVariableMultiplicationFactor = ClassHelper.makeWithoutCaching(DataVariableMultiplicationFactor.class);
   public final ClassNode BlockInfo = ClassHelper.makeWithoutCaching(BlockInfo.class);
@@ -52,6 +54,15 @@ public class AstNodeCache {
 
   public final MethodNode Specification_GetSpecificationContext =
     Specification.getDeclaredMethods(Identifiers.GET_SPECIFICATION_CONTEXT).get(0);
+
+  public final MethodNode MockInteractionSupport_GetSpecification =
+    MockInteractionSupport.getDeclaredMethods("getSpecification").get(0);
+
+  public final MethodNode Checks_NotNull =
+    Checks.getDeclaredMethods("notNull").stream()
+      .filter(method -> method.getParameters()[1].getType().equals(ClassHelper.STRING_TYPE))
+      .findFirst()
+      .orElseThrow(IllegalStateException::new);
 
   public final MethodNode SpockRuntime_VerifyCondition =
       SpockRuntime.getDeclaredMethods(org.spockframework.runtime.SpockRuntime.VERIFY_CONDITION).get(0);

--- a/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
@@ -252,7 +252,7 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
       // expand nevertheless so that inner scope (if any) won't trip over this again
     }
 
-    currSpecialMethodCall.expand();
+    currSpecialMethodCall.expand(resources.getSpecificationReference());
     return true;
   }
 
@@ -274,7 +274,7 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
 
     foundExceptionCondition = expr;
     if (currSpecialMethodCall.isThrownCall()) {
-      currSpecialMethodCall.expand();
+      currSpecialMethodCall.expand(resources.getSpecificationReference());
     }
     return true;
   }

--- a/spock-core/src/main/java/org/spockframework/compiler/ExternalInteractionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ExternalInteractionRewriter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler;
+
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.ClassExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+import org.spockframework.compiler.model.ExternalInteractionMethod;
+import org.spockframework.util.ObjectUtil;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.spockframework.compiler.AstUtil.createDirectMethodCall;
+
+/**
+ * Rewrites the top-level interaction statements of an instance method that runs
+ * outside a {@code Specification}. Each top-level {@link ExpressionStatement} is
+ * offered to {@link InteractionRewriter}; matched statements are replaced with
+ * the registration call ({@code mockController.addInteraction(...)}). Built-in
+ * creation calls ({@code Mock()}/{@code Stub()}/{@code Spy()} ...) are either
+ * expanded (interface mechanism) or rejected as a compile error (annotation
+ * mechanism), controlled by {@code allowCreation}.
+ *
+ * <p>Only top-level statements are rewritten; closure-nested interaction forms
+ * ({@code with(mock) { ... }}) are not handled here.
+ */
+public class ExternalInteractionRewriter {
+  private final AstNodeCache nodeCache;
+  private final ErrorReporter errorReporter;
+  private final SourceLookup sourceLookup;
+  private final boolean allowCreation;
+
+  /**
+   * @param allowCreation whether built-in creation calls may be expanded
+   *                      (interface mechanism) or are rejected (annotation
+   *                      mechanism).
+   */
+  public ExternalInteractionRewriter(AstNodeCache nodeCache, ErrorReporter errorReporter,
+      SourceLookup sourceLookup, boolean allowCreation) {
+    this.nodeCache = nodeCache;
+    this.errorReporter = errorReporter;
+    this.sourceLookup = sourceLookup;
+    this.allowCreation = allowCreation;
+  }
+
+  /**
+   * Rewrites {@code method}'s body in place. {@code specificationReferenceFactory}
+   * produces a fresh spec-locator expression on each call, used for both
+   * interaction registration and (when allowed) mock creation.
+   */
+  public void rewriteInPlace(MethodNode method, Supplier<Expression> specificationReferenceFactory) {
+    if (!(method.getCode() instanceof BlockStatement)) return;
+
+    ExternalRewriteResources resources = new ExternalRewriteResources(
+        specificationReferenceFactory, new ExternalInteractionMethod(method), nodeCache, sourceLookup, errorReporter);
+
+    // the spec is located through `this`, which is unavailable in static scope;
+    // interactions in static methods are rejected by InteractionRewriter itself
+    boolean staticScopeViolation = method.isStatic();
+
+    BlockStatement body = (BlockStatement) method.getCode();
+    List<Statement> statements = body.getStatements();
+    boolean rewrote = false;
+    for (int i = 0; i < statements.size(); i++) {
+      Statement stat = statements.get(i);
+      ExpressionStatement exprStat = ObjectUtil.asInstance(stat, ExpressionStatement.class);
+      if (exprStat == null) continue;
+
+      // expand or reject built-in creation calls (Mock/Stub/Spy ...) first
+      rewrote |= handleCreation(exprStat, specificationReferenceFactory, staticScopeViolation);
+
+      ExpressionStatement rewritten = new InteractionRewriter(resources, null).rewrite(exprStat);
+      if (rewritten != null) {
+        statements.set(i, rewritten);
+        rewrote = true;
+      }
+    }
+
+    // guard the located spec: anything we rewrote depends on it being non-null
+    if (rewrote) {
+      statements.add(0, createSpecificationNotNullCheck(specificationReferenceFactory.get()));
+    }
+  }
+
+  private boolean handleCreation(ExpressionStatement exprStat, Supplier<Expression> specificationReferenceFactory,
+      boolean staticScopeViolation) {
+    Expression expr = exprStat.getExpression();
+    BinaryExpression binaryExpr = ObjectUtil.asInstance(expr, BinaryExpression.class);
+    Expression callCandidate = binaryExpr != null ? binaryExpr.getRightExpression() : expr;
+    MethodCallExpression call = ObjectUtil.asInstance(callCandidate, MethodCallExpression.class);
+    if (call == null) return false;
+
+    SpecialMethodCall smc = SpecialMethodCall.parse(call, binaryExpr, nodeCache);
+    if (smc == null || !smc.isTestDouble()) return false;
+
+    if (staticScopeViolation) {
+      errorReporter.error(call, "Mocks cannot be created in static scope");
+      return false;
+    }
+
+    if (!allowCreation) {
+      errorReporter.error(call,
+          "Mock/Stub/Spy creation is not allowed in an @Interactions method; pass the mock in as a parameter, or use MockInteractionSupport.");
+      return false;
+    }
+    smc.expand(specificationReferenceFactory.get());
+    return true;
+  }
+
+  /**
+   * Builds {@code Checks.notNull(<specRef>, "...")}, guarding against a missing
+   * owning spec (e.g. a {@code MockInteractionSupport} whose
+   * {@code getSpecification()} was never attached).
+   */
+  private Statement createSpecificationNotNullCheck(Expression specificationReference) {
+    MethodCallExpression check = createDirectMethodCall(
+        new ClassExpression(nodeCache.Checks),
+        nodeCache.Checks_NotNull,
+        new ArgumentListExpression(specificationReference, new ConstantExpression(SPEC_NULL_MESSAGE)));
+    return new ExpressionStatement(check);
+  }
+
+  private static final String SPEC_NULL_MESSAGE =
+      "Cannot declare mock interactions: the owning Specification is null. Attach the MockInteractionSupport to a "
+          + "running Specification through a constructor field.";
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/ExternalRewriteResources.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ExternalRewriteResources.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+
+import org.spockframework.compiler.condition.IConditionErrorRecorders;
+import org.spockframework.compiler.model.Block;
+import org.spockframework.compiler.model.Method;
+
+import java.util.function.Supplier;
+
+import static org.spockframework.compiler.AstUtil.createDirectMethodCall;
+
+/**
+ * Standalone {@link IRewriteResources} for rewriting interactions in code that
+ * does not run on a {@code Specification} instance. Modeled on
+ * {@code DefaultConditionRewriterResources}: it merely holds its dependencies.
+ *
+ * <p>The spec reference is supplied by the caller and is the only thing that
+ * differs from the in-spec rewrite ({@code this} for a real spec,
+ * {@code this.getSpecification()} for a {@code MockInteractionSupport} class,
+ * or the injected {@code $spec} parameter for a {@code @Interactions}
+ * companion). Everything that registers an interaction layers on top of it.
+ */
+public class ExternalRewriteResources implements IRewriteResources {
+  private final Supplier<Expression> specificationReferenceFactory;
+  private final Method currentMethod;
+  private final AstNodeCache nodeCache;
+  private final SourceLookup sourceLookup;
+  private final ErrorReporter errorReporter;
+
+  /**
+   * @param specificationReferenceFactory produces a fresh spec-reference
+   *        expression on each call; a fresh node is required because the
+   *        reference is embedded into a new AST location for every interaction
+   *        or creation it locates.
+   */
+  public ExternalRewriteResources(Supplier<Expression> specificationReferenceFactory, Method currentMethod,
+      AstNodeCache nodeCache, SourceLookup sourceLookup, ErrorReporter errorReporter) {
+    this.specificationReferenceFactory = specificationReferenceFactory;
+    this.currentMethod = currentMethod;
+    this.nodeCache = nodeCache;
+    this.sourceLookup = sourceLookup;
+    this.errorReporter = errorReporter;
+  }
+
+  @Override
+  public Expression getSpecificationReference() {
+    return specificationReferenceFactory.get();
+  }
+
+  @Override
+  public Method getCurrentMethod() {
+    return currentMethod;
+  }
+
+  @Override
+  public Block getCurrentBlock() {
+    throw new UnsupportedOperationException("External interaction rewriting has no block structure");
+  }
+
+  @Override
+  public VariableExpression captureOldValue(Expression oldValue) {
+    throw new UnsupportedOperationException("old() is not supported outside a then-block");
+  }
+
+  @Override
+  public MethodCallExpression getMockInvocationMatcher() {
+    MethodCallExpression specificationContext = createDirectMethodCall(specificationReferenceFactory.get(),
+        nodeCache.Specification_GetSpecificationContext, ArgumentListExpression.EMPTY_ARGUMENTS);
+    return createDirectMethodCall(specificationContext,
+        nodeCache.SpecificationContext_GetMockController, ArgumentListExpression.EMPTY_ARGUMENTS);
+  }
+
+  @Override
+  public AstNodeCache getAstNodeCache() {
+    return nodeCache;
+  }
+
+  @Override
+  public String getSourceText(ASTNode node) {
+    return sourceLookup.lookup(node);
+  }
+
+  @Override
+  public ErrorReporter getErrorReporter() {
+    return errorReporter;
+  }
+
+  @Override
+  public IConditionErrorRecorders getErrorRecorders() {
+    throw new UnsupportedOperationException("External interaction rewriting does not record conditions");
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/IRewriteResources.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/IRewriteResources.java
@@ -30,6 +30,13 @@ import org.spockframework.compiler.model.Method;
  * @author Peter Niederwieser
  */
 public interface IRewriteResources {
+  /**
+   * The AST expression that yields the {@code Specification} instance at this
+   * rewrite site (the "spec reference"). Real specs return {@code this};
+   * external mechanisms return an expression that locates the owning spec.
+   */
+  Expression getSpecificationReference();
+
   Method getCurrentMethod();
 
   Block getCurrentBlock();

--- a/spock-core/src/main/java/org/spockframework/compiler/ISpecialMethodCall.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ISpecialMethodCall.java
@@ -16,6 +16,7 @@
 package org.spockframework.compiler;
 
 import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.stmt.Statement;
 
@@ -61,5 +62,5 @@ public interface ISpecialMethodCall {
 
   ClosureExpression getClosureExpr();
 
-  void expand();
+  void expand(Expression specificationReference);
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/NoSpecialMethodCall.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/NoSpecialMethodCall.java
@@ -16,6 +16,7 @@
 package org.spockframework.compiler;
 
 import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.stmt.Statement;
 
@@ -125,7 +126,7 @@ public class NoSpecialMethodCall implements ISpecialMethodCall {
   }
 
   @Override
-  public void expand() {
+  public void expand(Expression specificationReference) {
     throw new UnsupportedOperationException();
   }
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecRewriter.java
@@ -692,8 +692,13 @@ public class SpecRewriter extends AbstractSpecVisitor implements IRewriteResourc
     return var;
   }
 
+  @Override
+  public Expression getSpecificationReference() {
+    return VariableExpression.THIS_EXPRESSION;
+  }
+
   public MethodCallExpression getSpecificationContext() {
-    return createDirectMethodCall(VariableExpression.THIS_EXPRESSION,
+    return createDirectMethodCall(getSpecificationReference(),
         nodeCache.Specification_GetSpecificationContext, ArgumentListExpression.EMPTY_ARGUMENTS);
   }
 

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecialMethodCall.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecialMethodCall.java
@@ -172,9 +172,9 @@ public class SpecialMethodCall implements ISpecialMethodCall {
   }
 
   @Override
-  public void expand() {
+  public void expand(Expression specificationReference) {
     List<Expression> args = new ArrayList<>();
-    args.add(VariableExpression.THIS_EXPRESSION);
+    args.add(specificationReference);
     args.add(inferredName);
     args.add(inferredType);
     args.addAll(AstUtil.getArgumentList(methodCallExpr));
@@ -184,6 +184,10 @@ public class SpecialMethodCall implements ISpecialMethodCall {
     methodCallExpr.setArguments(argsExpr);
     methodCallExpr.setObjectExpression(new ClassExpression(nodeCache.SpecInternals));
     methodCallExpr.setMethod(new ConstantExpression(methodName + "Impl"));
+    // the receiver is now an explicit class reference, not the (possibly implicit)
+    // original `this`; clear the flag so Groovy's trait transform does not later
+    // rewrite the SpecInternals receiver to the trait's $self parameter
+    methodCallExpr.setImplicitThis(false);
   }
 
   public static SpecialMethodCall parse(MethodCallExpression methodCallExpr, @Nullable BinaryExpression binaryExpr,

--- a/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
@@ -21,8 +21,10 @@ import org.spockframework.compiler.model.Spec;
 import org.spockframework.util.VersionChecker;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.codehaus.groovy.ast.*;
+import org.codehaus.groovy.ast.expr.*;
 import org.codehaus.groovy.control.*;
 import org.codehaus.groovy.transform.*;
 
@@ -58,13 +60,57 @@ public class SpockTransform implements ASTTransformation {
       try (SourceLookup sourceLookup = new SourceLookup(sourceUnit)) {
         List<ClassNode> classes = sourceUnit.getAST().getClasses();
 
-        for (ClassNode clazz : classes)
-          if (isSpec(clazz)) processSpec(sourceUnit, clazz, errorReporter, sourceLookup);
+        for (ClassNode clazz : classes) {
+          boolean spec = isSpec(clazz);
+          boolean support = isMockInteractionSupport(clazz);
+
+          if (spec && support) {
+            errorReporter.error(
+                "Class '%s' must not be both a Specification and a MockInteractionSupport; a spec already supports interactions directly.",
+                clazz.getName());
+            continue;
+          }
+
+          if (spec) {
+            processSpec(sourceUnit, clazz, errorReporter, sourceLookup);
+          } else if (support) {
+            processMockInteractionSupport(sourceUnit, clazz, errorReporter, sourceLookup);
+          }
+        }
       }
     }
 
     boolean isSpec(ClassNode clazz) {
       return clazz.isDerivedFrom(nodeCache.Specification);
+    }
+
+    boolean isMockInteractionSupport(ClassNode clazz) {
+      return clazz.implementsInterface(nodeCache.MockInteractionSupport);
+    }
+
+    void processMockInteractionSupport(SourceUnit sourceUnit, ClassNode clazz, ErrorReporter errorReporter, SourceLookup sourceLookup) {
+      Supplier<Expression> specRef = () -> AstUtil.createDirectMethodCall(
+          VariableExpression.THIS_EXPRESSION, nodeCache.MockInteractionSupport_GetSpecification,
+          ArgumentListExpression.EMPTY_ARGUMENTS);
+      // allowCreation=true (mocks can be created here). The spec is reached via
+      // this.getSpecification(), so static methods that declare interactions or
+      // create mocks get a clear "static scope" compile error. The located spec is
+      // always guarded with Checks.notNull, since getSpecification() may be null
+      // if the fixture was never attached.
+      ExternalInteractionRewriter rewriter =
+          new ExternalInteractionRewriter(nodeCache, errorReporter, sourceLookup, true);
+      rewriteDeclaredMethods(clazz, rewriter, specRef);
+      if (!sourceUnit.getErrorCollector().hasErrors()) {
+        new VariableScopeVisitor(sourceUnit).visitClass(clazz);
+      }
+    }
+
+    /** Rewrites every concrete method declared directly on {@code clazz} in place. */
+    void rewriteDeclaredMethods(ClassNode clazz, ExternalInteractionRewriter rewriter, Supplier<Expression> specRef) {
+      for (MethodNode method : clazz.getMethods()) {
+        if (method.isAbstract() || method.getDeclaringClass() != clazz) continue;
+        rewriter.rewriteInPlace(method, specRef);
+      }
     }
 
     void processSpec(SourceUnit sourceUnit, ClassNode clazz, ErrorReporter errorReporter, SourceLookup sourceLookup) {

--- a/spock-core/src/main/java/org/spockframework/compiler/condition/DefaultConditionRewriterResources.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/condition/DefaultConditionRewriterResources.java
@@ -49,6 +49,16 @@ class DefaultConditionRewriterResources implements IRewriteResources {
   }
 
   @Override
+  public Expression getSpecificationReference() {
+    // Preserves the historical behavior: SpecialMethodCall.expand() used to
+    // hardcode `this` as the spec argument. A verification helper method that
+    // contains a mock-creation call (e.g. the illegal `1 * Mock(Object)...`)
+    // reaches expand() before the "interactions are not allowed" error aborts,
+    // so this must yield `this` rather than throw.
+    return VariableExpression.THIS_EXPRESSION;
+  }
+
+  @Override
   public Method getCurrentMethod() {
     return method;
   }

--- a/spock-core/src/main/java/org/spockframework/compiler/model/ExternalInteractionMethod.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/model/ExternalInteractionMethod.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler.model;
+
+import org.codehaus.groovy.ast.MethodNode;
+
+/**
+ * Minimal {@link Method} model wrapping a plain {@link MethodNode} for external
+ * interaction rewriting. It exists only so that {@code InteractionRewriter} can
+ * read the underlying {@link MethodNode} (for example its static modifier).
+ */
+public class ExternalInteractionMethod extends Method {
+  public ExternalInteractionMethod(MethodNode code) {
+    super(null, code);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/mock/ClosureParameterTypeFromVariableType.java
+++ b/spock-core/src/main/java/org/spockframework/mock/ClosureParameterTypeFromVariableType.java
@@ -31,6 +31,7 @@ import java.util.*;
 
 public class ClosureParameterTypeFromVariableType extends SingleSignatureClosureHint {
   private final static ClassNode MOCKING_API = new ClassNode(MockingApi.class);
+  private final static String MOCKING_API_NAME = MockingApi.class.getName();
   private final static ClassNode OBJECT = new ClassNode(Object.class);
   private final static Set<String> MOCK_METHODS = new HashSet<>();
 
@@ -50,7 +51,7 @@ public class ClosureParameterTypeFromVariableType extends SingleSignatureClosure
       .getAST()
       .getClasses()
       .stream()
-      .filter(cn -> cn.isDerivedFrom(MOCKING_API))
+      .filter(ClosureParameterTypeFromVariableType::extendsOrImplementsMockingApi)
       .map(ClassNode::getMethods)
       .flatMap(Collection::stream)
       .map(MethodNode::getCode)
@@ -84,5 +85,30 @@ public class ClosureParameterTypeFromVariableType extends SingleSignatureClosure
         }
       }));
     return new ClassNode[]{result[0]};
+  }
+
+  /**
+   * Whether {@code cn} is a {@code MockingApi}, either by extending it (the
+   * historical case, when {@code MockingApi} was a class) or by implementing it
+   * (the current case, since {@code Specification implements MockingApi}). The
+   * check walks the superclass chain and compares interfaces by name so it works
+   * regardless of how the {@link ClassNode}s were created.
+   */
+  static boolean extendsOrImplementsMockingApi(ClassNode cn) {
+    for (ClassNode current = cn; current != null; current = current.getSuperClass()) {
+      if (MOCKING_API_NAME.equals(current.getName())) return true;
+      for (ClassNode iface : current.getInterfaces()) {
+        if (declaresInterfaceByName(iface, MOCKING_API_NAME)) return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean declaresInterfaceByName(ClassNode iface, String name) {
+    if (name.equals(iface.getName())) return true;
+    for (ClassNode superIface : iface.getInterfaces()) {
+      if (declaresInterfaceByName(superIface, name)) return true;
+    }
+    return false;
   }
 }

--- a/spock-core/src/main/java/org/spockframework/util/Checks.java
+++ b/spock-core/src/main/java/org/spockframework/util/Checks.java
@@ -56,6 +56,22 @@ public abstract class Checks {
   }
 
   /**
+   * Assert that the supplied {@link Object} is not {@code null}.
+   *
+   * @param object  the object to check
+   * @param message violation message
+   * @return the supplied object as a convenience
+   * @throws IllegalArgumentException if the supplied object is {@code null}
+   */
+  @Contract("null, _ -> fail")
+  public static <T> T notNull(T object, String message) {
+    if (object == null) {
+      throw new IllegalArgumentException(message);
+    }
+    return object;
+  }
+
+  /**
    * Assert that the supplied array is neither {@code null} nor <em>empty</em>.
    * <p>
    * This method does NOT check if the supplied

--- a/spock-core/src/main/java/spock/lang/Specification.java
+++ b/spock-core/src/main/java/spock/lang/Specification.java
@@ -41,7 +41,7 @@ import org.spockframework.util.ExceptionUtil;
  */
 @Testable
 @SuppressWarnings("UnusedDeclaration")
-public abstract class Specification extends MockingApi {
+public abstract class Specification implements MockingApi {
   /**
    * The wildcard symbol. Used in several places as a <em>don't care</em> value:
    * <ul>

--- a/spock-core/src/main/java/spock/mock/MockInteractionSupport.java
+++ b/spock-core/src/main/java/spock/mock/MockInteractionSupport.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spock.mock;
+
+import org.spockframework.util.Beta;
+import spock.lang.Specification;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Implement to encapsulate mock creation and mock interactions in a reusable
+ * fixture object that lives outside a {@code Specification}. The implementor
+ * supplies the owning spec via {@link #getSpecification()} (for example from a
+ * constructor field); all created mocks and declared interactions are routed
+ * through that spec's mock controller.
+ *
+ * <p>Both creation and interactions work: {@code Mock(Bar)} is a real,
+ * resolvable method inherited from {@link MockingApi}, so it compiles,
+ * autocompletes, and survives {@code @CompileStatic}. The Spock compiler
+ * replaces the call with one that creates and auto-attaches the mock to the
+ * located spec.
+ *
+ * <p>A class that is both a {@code Specification} and implements this interface
+ * is a compile error: the spec already has the full capability.
+ *
+ * @since 2.5
+ */
+@Beta
+public interface MockInteractionSupport extends MockingApi {
+  /**
+   * The owning specification used to create mocks and register interactions.
+   *
+   * @return the owning specification
+   */
+  Specification getSpecification();
+
+  @Override
+  default void runWithThreadAwareMocks(Runnable code) {
+    getSpecification().getSpecificationContext().getThreadAwareMockController().runWithThreadAwareMocks(code);
+  }
+
+  @Override
+  default <R> R withActiveThreadAwareMocks(Callable<R> code) {
+    return getSpecification().getSpecificationContext().getThreadAwareMockController().withActiveThreadAwareMocks(code);
+  }
+}

--- a/spock-core/src/main/java/spock/mock/MockingApi.java
+++ b/spock-core/src/main/java/spock/mock/MockingApi.java
@@ -80,7 +80,7 @@ import org.spockframework.util.ObjectUtil;
  * </pre>
  */
 @SuppressWarnings({"unused", "SameReturnValue"})
-public class MockingApi implements MockFactory {
+public interface MockingApi extends MockFactory {
   /**
    * Encloses one or more interaction definitions in a <tt>then</tt> block.
    * Required when an interaction definition uses a statement that doesn't
@@ -136,7 +136,7 @@ public class MockingApi implements MockFactory {
    *
    * @param block a block of code containing one or more interaction definitions
    */
-  public void interaction(Closure block) {
+  default void interaction(Closure block) {
     GroovyRuntimeUtil.invokeClosure(block);
   }
 
@@ -151,7 +151,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a mock whose type and name are inferred from the left-hand side of the enclosing variable assignment
    */
-  public <T> T Mock() {
+  default <T> T Mock() {
     throw invalidMockCreation();
   }
 
@@ -170,7 +170,7 @@ public class MockingApi implements MockFactory {
    * @return a mock with the specified options whose type and name are inferred from the left-hand side of the
    * enclosing variable assignment
    */
-  public <T> T Mock(
+  default <T> T Mock(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -199,7 +199,7 @@ public class MockingApi implements MockFactory {
    * @return a mock with the specified type
    */
   @Override
-  public <T> T Mock(Class<T> type) {
+  default <T> T Mock(Class<T> type) {
     throw invalidMockCreation();
   }
 
@@ -220,7 +220,7 @@ public class MockingApi implements MockFactory {
    * @return a mock with the specified options and type
    */
   @Override
-  public <T> T Mock(
+  default <T> T Mock(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -252,7 +252,7 @@ public class MockingApi implements MockFactory {
    * @return a mock with the specified interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T Mock(
+  default <T> T Mock(
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
       Closure interactions) {
     throw invalidMockCreation();
@@ -278,7 +278,7 @@ public class MockingApi implements MockFactory {
    * @return a mock with the specified options and interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T Mock(
+  default <T> T Mock(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -313,7 +313,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a mock with the specified type and interactions
    */
-  public <T> T Mock(
+  default <T> T Mock(
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -343,7 +343,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a mock with the specified options, type, and interactions
    */
-  public <T> T Mock(
+  default <T> T Mock(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -372,7 +372,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a stub whose type and name are inferred from the left-hand side of the enclosing variable assignment
    */
-  public <T> T Stub() {
+  default <T> T Stub() {
     throw invalidMockCreation();
   }
 
@@ -391,7 +391,7 @@ public class MockingApi implements MockFactory {
    * @return a stub with the specified options whose type and name are inferred from the left-hand side of the
    * enclosing variable assignment
    */
-  public <T> T Stub(
+  default <T> T Stub(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -420,7 +420,7 @@ public class MockingApi implements MockFactory {
    * @return a stub with the specified type
    */
   @Override
-  public <T> T Stub(Class<T> type) {
+  default <T> T Stub(Class<T> type) {
     throw invalidMockCreation();
   }
 
@@ -441,7 +441,7 @@ public class MockingApi implements MockFactory {
    * @return a stub with the specified options and type
    */
   @Override
-  public <T> T Stub(
+  default <T> T Stub(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -473,7 +473,7 @@ public class MockingApi implements MockFactory {
    * @return a stub with the specified interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T Stub(
+  default <T> T Stub(
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
       Closure interactions) {
     throw invalidMockCreation();
@@ -499,7 +499,7 @@ public class MockingApi implements MockFactory {
    * @return a stub with the specified options and interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T Stub(
+  default <T> T Stub(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -534,7 +534,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a stub with the specified type and interactions
    */
-  public <T> T Stub(
+  default <T> T Stub(
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -564,7 +564,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a stub with the specified options, type, and interactions
    */
-  public <T> T Stub(
+  default <T> T Stub(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -593,7 +593,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a spy whose type and name are inferred from the left-hand side of the enclosing variable assignment
    */
-  public <T> T Spy() {
+  default <T> T Spy() {
     throw invalidMockCreation();
   }
 
@@ -612,7 +612,7 @@ public class MockingApi implements MockFactory {
    * @return a spy with the specified options whose type and name are inferred from the left-hand side of the
    * enclosing variable assignment
    */
-  public <T> T Spy(
+  default <T> T Spy(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -641,7 +641,7 @@ public class MockingApi implements MockFactory {
    * @return a spy with the specified type
    */
   @Override
-  public <T> T Spy(Class<T> type) {
+  default <T> T Spy(Class<T> type) {
     throw invalidMockCreation();
   }
 
@@ -665,7 +665,7 @@ public class MockingApi implements MockFactory {
    * @return a spy wrapping the provided instance
    */
   @Override
-  public <T> T Spy(T obj) {
+  default <T> T Spy(T obj) {
     throw invalidMockCreation();
   }
 
@@ -691,7 +691,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a spy with the specified interactions wrapping the provided instance
    */
-  public <T> T Spy(
+  default <T> T Spy(
     @DelegatesTo.Target
       T obj,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST)
@@ -717,7 +717,7 @@ public class MockingApi implements MockFactory {
    * @return a spy with the specified options and type
    */
   @Override
-  public <T> T Spy(
+  default <T> T Spy(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -748,7 +748,7 @@ public class MockingApi implements MockFactory {
    * @return a spy with the specified interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T Spy(
+  default <T> T Spy(
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
       Closure interactions) {
     throw invalidMockCreation();
@@ -773,7 +773,7 @@ public class MockingApi implements MockFactory {
    * @return a spy with the specified options and interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T Spy(
+  default <T> T Spy(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -808,7 +808,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a spy with the specified type and interactions
    */
-  public <T> T Spy(
+  default <T> T Spy(
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -837,7 +837,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a spy with the specified options, type, and interactions
    */
-  public <T> T Spy(
+  default <T> T Spy(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -866,7 +866,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy mock whose type and name are inferred from the left-hand side of the enclosing variable assignment
    */
-  public <T> T GroovyMock() {
+  default <T> T GroovyMock() {
     throw invalidMockCreation();
   }
 
@@ -885,7 +885,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy mock with the specified options whose type and name are inferred from the left-hand side of the
    * enclosing variable assignment
    */
-  public <T> T GroovyMock(
+  default <T> T GroovyMock(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -914,7 +914,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy mock with the specified type
    */
-  public <T> T GroovyMock(Class<T> type) {
+  default <T> T GroovyMock(Class<T> type) {
     throw invalidMockCreation();
   }
 
@@ -934,7 +934,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy mock with the specified options and type
    */
-  public <T> T GroovyMock(
+  default <T> T GroovyMock(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -967,7 +967,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy mock with the specified interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T GroovyMock(
+  default <T> T GroovyMock(
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
       Closure interactions) {
     throw invalidMockCreation();
@@ -993,7 +993,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy mock with the specified options and interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T GroovyMock(
+  default <T> T GroovyMock(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1029,7 +1029,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy mock with the specified type and interactions
    */
-  public <T> T GroovyMock(
+  default <T> T GroovyMock(
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -1059,7 +1059,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy mock with the specified options, type, and interactions
    */
-  public <T> T GroovyMock(
+  default <T> T GroovyMock(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1089,7 +1089,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy stub whose type and name are inferred from the left-hand side of the enclosing variable assignment
    */
-  public <T> T GroovyStub() {
+  default <T> T GroovyStub() {
     throw invalidMockCreation();
   }
 
@@ -1108,7 +1108,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy stub with the specified options whose type and name are inferred from the left-hand side of the
    * enclosing variable assignment
    */
-  public <T> T GroovyStub(
+  default <T> T GroovyStub(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1137,7 +1137,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy stub with the specified type
    */
-  public <T> T GroovyStub(Class<T> type) {
+  default <T> T GroovyStub(Class<T> type) {
     throw invalidMockCreation();
   }
 
@@ -1157,7 +1157,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy stub with the specified options and type
    */
-  public <T> T GroovyStub(
+  default <T> T GroovyStub(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1190,7 +1190,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy stub with the specified interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T GroovyStub(
+  default <T> T GroovyStub(
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
       Closure interactions) {
     throw invalidMockCreation();
@@ -1216,7 +1216,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy stub with the specified options and interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T GroovyStub(
+  default <T> T GroovyStub(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1252,7 +1252,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy stub with the specified type and interactions
    */
-  public <T> T GroovyStub(
+  default <T> T GroovyStub(
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -1282,7 +1282,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy stub with the specified options, type, and interactions
    */
-  public <T> T GroovyStub(
+  default <T> T GroovyStub(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1312,7 +1312,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy spy whose type and name are inferred from the left-hand side of the enclosing variable assignment
    */
-  public <T> T GroovySpy() {
+  default <T> T GroovySpy() {
     throw invalidMockCreation();
   }
 
@@ -1331,7 +1331,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy spy with the specified options whose type and name are inferred from the left-hand side of the
    * enclosing variable assignment
    */
-  public <T> T GroovySpy(
+  default <T> T GroovySpy(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1361,7 +1361,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy spy with the specified type
    */
   @Beta
-  public <T> T GroovySpy(Class<T> type) {
+  default <T> T GroovySpy(Class<T> type) {
     throw invalidMockCreation();
   }
 
@@ -1385,7 +1385,7 @@ public class MockingApi implements MockFactory {
    * @return a spy wrapping the provided instance
    */
   @Beta
-  public <T> T GroovySpy(T obj) {
+  default <T> T GroovySpy(T obj) {
     invalidMockCreation();
     return null;
   }
@@ -1413,7 +1413,7 @@ public class MockingApi implements MockFactory {
    * @return a spy with the specified interactions wrapping the provided instance
    */
   @Beta
-  public <T> T GroovySpy(
+  default <T> T GroovySpy(
     @DelegatesTo.Target
     T obj,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST)
@@ -1439,7 +1439,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy spy with the specified options and type
    */
-  public <T> T GroovySpy(
+  default <T> T GroovySpy(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1471,7 +1471,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy spy with the specified interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T GroovySpy(
+  default <T> T GroovySpy(
     @ClosureParams(ClosureParameterTypeFromVariableType.class)
       Closure interactions) {
     throw invalidMockCreation();
@@ -1496,7 +1496,7 @@ public class MockingApi implements MockFactory {
    * @return a Groovy spy with the specified options and interactions whose type and name are inferred
    * from the left-hand side of the enclosing assignment
    */
-  public <T> T GroovySpy(
+  default <T> T GroovySpy(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1532,7 +1532,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy spy with the specified type and interactions
    */
-  public <T> T GroovySpy(
+  default <T> T GroovySpy(
     @DelegatesTo.Target
       Class<T> type,
     @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
@@ -1561,7 +1561,7 @@ public class MockingApi implements MockFactory {
    *
    * @return a Groovy spy with the specified options, type, and interactions
    */
-  public <T> T GroovySpy(
+  default <T> T GroovySpy(
     @NamedParams({
       @NamedParam(value = "name", type = String.class),
       @NamedParam(value = "additionalInterfaces", type = List.class),
@@ -1595,7 +1595,7 @@ public class MockingApi implements MockFactory {
    * @param type the type of which the static methods shall be spied
    */
   @Beta
-  public <T> void SpyStatic(Class<T> type) {
+  default <T> void SpyStatic(Class<T> type) {
     throw invalidMockCreation();
   }
 
@@ -1615,7 +1615,7 @@ public class MockingApi implements MockFactory {
    * @param mockMakerSettings the mock maker settings to apply to the static spy
    */
   @Beta
-  public <T> void SpyStatic(Class<T> type, IMockMakerSettings mockMakerSettings) {
+  default <T> void SpyStatic(Class<T> type, IMockMakerSettings mockMakerSettings) {
     throw invalidMockCreation();
   }
 
@@ -1629,7 +1629,7 @@ public class MockingApi implements MockFactory {
    * @param code the code to execute
    */
   @Beta
-  public void runWithThreadAwareMocks(Runnable code) {
+  default void runWithThreadAwareMocks(Runnable code) {
     ObjectUtil.<Specification>uncheckedCast(this).getSpecificationContext().getThreadAwareMockController().runWithThreadAwareMocks(code);
   }
 
@@ -1644,11 +1644,11 @@ public class MockingApi implements MockFactory {
    * @return the return value of the executed code
    */
   @Beta
-  public <R> R withActiveThreadAwareMocks(Callable<R> code) {
+  default <R> R withActiveThreadAwareMocks(Callable<R> code) {
     return ObjectUtil.<Specification>uncheckedCast(this).getSpecificationContext().getThreadAwareMockController().withActiveThreadAwareMocks(code);
   }
 
-  private InvalidSpecException invalidMockCreation() {
+  static InvalidSpecException invalidMockCreation() {
     return new InvalidSpecException("Mock objects can only be created inside a spec, and only during the lifetime of a feature (iteration)");
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/docs/interaction/ExternalMockInteractionsDocSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/interaction/ExternalMockInteractionsDocSpec.groovy
@@ -1,0 +1,44 @@
+package org.spockframework.docs.interaction
+
+import spock.lang.Specification
+import spock.mock.MockInteractionSupport
+
+class ExternalMockInteractionsDocSpec extends Specification {
+
+  // tag::support-fixture[]
+  static class OrderFixtures implements MockInteractionSupport {
+    final Specification specification
+
+    OrderFixtures(Specification specification) {
+      this.specification = specification
+    }
+
+    PaymentGateway happyGateway() {
+      PaymentGateway gateway = Mock()      // created and auto-attached to the spec
+      gateway.charge(42) >> true           // stubbing
+      1 * gateway.audit("processed")       // required interaction
+      return gateway
+    }
+  }
+  // end::support-fixture[]
+
+  // tag::support-usage[]
+  def "a MockInteractionSupport fixture creates and configures mocks"() {
+    given:
+    PaymentGateway gateway = new OrderFixtures(this).happyGateway()
+
+    when:
+    boolean charged = gateway.charge(42)
+    gateway.audit("processed")
+
+    then:
+    charged
+  }
+  // end::support-usage[]
+
+  interface PaymentGateway {
+    boolean charge(int amount)
+
+    void audit(String message)
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/mock/ClosureParameterTypeFromVariableTypeSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/mock/ClosureParameterTypeFromVariableTypeSpec.groovy
@@ -1,0 +1,21 @@
+package org.spockframework.mock
+
+import org.codehaus.groovy.ast.ClassNode
+import spock.lang.Specification
+
+class ClosureParameterTypeFromVariableTypeSpec extends Specification {
+  def "recognizes Specification as a MockingApi (now implemented as an interface)"() {
+    expect:
+    ClosureParameterTypeFromVariableType.extendsOrImplementsMockingApi(new ClassNode(Specification))
+  }
+
+  def "recognizes a subclass of Specification as a MockingApi"() {
+    expect:
+    ClosureParameterTypeFromVariableType.extendsOrImplementsMockingApi(new ClassNode(ClosureParameterTypeFromVariableTypeSpec))
+  }
+
+  def "does not recognize an unrelated class"() {
+    expect:
+    !ClosureParameterTypeFromVariableType.extendsOrImplementsMockingApi(new ClassNode(String))
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.spockframework.smoke.ast.mock
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.GroovyRuntimeUtil
+import org.spockframework.specs.extension.SpockSnapshotter
+import spock.lang.Snapshot
+
+class ExternalMockInteractionsAstSpec extends EmbeddedSpecification {
+
+  @Snapshot(extension = 'groovy')
+  SpockSnapshotter snapshotter
+
+  // AST rendering differs between Groovy versions; keep a separate snapshot for Groovy 5+
+  private static final String SNAPSHOT_ID = (GroovyRuntimeUtil.MAJOR_VERSION >= 5) ? "groovy5" : ""
+
+  def "MockInteractionSupport class rewrites creation and interactions in place against getSpecification()"() {
+    when:
+    def result = compiler.transpile('''
+import spock.lang.Specification
+import spock.mock.MockInteractionSupport
+
+class OrderFixtures implements MockInteractionSupport {
+  final Specification specification
+  OrderFixtures(Specification specification) { this.specification = specification }
+
+  def createAndStub() {
+    def gateway = Mock(List)
+    gateway.add("x") >> true
+    1 * gateway.add("y")
+    return gateway
+  }
+}
+''')
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot(SNAPSHOT_ID)
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MockInteractionSupportSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MockInteractionSupportSpec.groovy
@@ -1,0 +1,161 @@
+package org.spockframework.smoke.mock
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.mock.TooFewInvocationsError
+import spock.lang.Specification
+import spock.mock.MockInteractionSupport
+import spock.mock.MockingApi
+
+class MockInteractionSupportSpec extends EmbeddedSpecification {
+  def "MockInteractionSupport is a MockingApi interface"() {
+    expect:
+    MockingApi.isAssignableFrom(MockInteractionSupport)
+    MockInteractionSupport.interface
+  }
+
+  def "interactions declared in a fixture are enforced on the spec, and stubbed values take effect"() {
+    when: "the fixture requires two add('charge') calls, but the feature makes only one"
+    runner.runWithImports('''
+      import spock.lang.Specification
+      import spock.mock.MockInteractionSupport
+
+      class ChargeFixture implements MockInteractionSupport {
+        final Specification specification
+        ChargeFixture(Specification specification) { this.specification = specification }
+
+        String chargeTwice(List<String> collaborator) {
+          2 * collaborator.add("charge")     // required cardinality (deliberately unsatisfied below)
+          collaborator.get(0) >> "charged"   // stubbing
+          return collaborator.get(0)         // returns the stubbed value so the caller can verify it
+        }
+      }
+
+      class ChargeSpec extends Specification {
+        def "charges"() {
+          given:
+          List<String> collaborator = Mock()
+          def fixture = new ChargeFixture(this)
+
+          when:
+          String report = fixture.chargeTwice(collaborator)
+          collaborator.add("charge")         // only one of the two required calls
+
+          then: "the stub declared in the fixture took effect on the spec's mock"
+          report == "charged"
+        }
+      }
+    ''')
+
+    then: "the unsatisfied 2 * add('charge') is enforced when the spec's scope leaves"
+    thrown(TooFewInvocationsError)
+  }
+
+  def "stubbing interactions declared in a fixture take effect on the spec"() {
+    given:
+    def collaborator = Mock(List)
+    def fixtures = new StubbingFixture(this)
+
+    when:
+    fixtures.stubContains(collaborator)
+
+    then:
+    collaborator.contains("x")
+  }
+
+  def "a created mock auto-attaches to the located spec and is stubbed"() {
+    given:
+    def fixtures = new MockCreatingFixture(this)
+
+    when:
+    Greeter mock = fixtures.createAndStub()
+
+    then:
+    mock.greet() == "hi"
+  }
+
+  def "a class that is both a Specification and MockInteractionSupport is a compile error"() {
+    when:
+    compiler.compileWithImports('''
+      import spock.lang.Specification
+      import spock.mock.MockInteractionSupport
+      abstract class Bad extends Specification implements MockInteractionSupport {}
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("must not be both a Specification and a MockInteractionSupport")
+  }
+
+  def "a rewritten method fails with a clear error when the located spec is null"() {
+    given:
+    def fixture = new UnattachedFixture()
+    List<String> collaborator = Mock()
+
+    when:
+    fixture.expectOneCharge(collaborator)
+
+    then:
+    IllegalArgumentException e = thrown()
+    e.message == "Cannot declare mock interactions: the owning Specification is null. Attach the MockInteractionSupport to a running Specification through a constructor field."
+  }
+
+  def "a static method in a MockInteractionSupport class cannot declare interactions"() {
+    when: "the spec is reached via this.getSpecification(), which a static method cannot do"
+    compiler.compileWithImports('''
+      import spock.lang.Specification
+      import spock.mock.MockInteractionSupport
+      abstract class Fix implements MockInteractionSupport {
+        static void stub(List l) { 1 * l.add(_) }
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.startsWith("Interactions cannot be declared in static scope")
+  }
+
+  def "a static method in a MockInteractionSupport class cannot create mocks"() {
+    when: "the spec is reached via this.getSpecification(), which a static method cannot do"
+    compiler.compileWithImports('''
+      import spock.lang.Specification
+      import spock.mock.MockInteractionSupport
+      abstract class Fix implements MockInteractionSupport {
+        static List createMock() { def m = Mock(List); return m }
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("Mocks cannot be created in static scope")
+  }
+
+  static class UnattachedFixture implements MockInteractionSupport {
+    Specification getSpecification() { null } // never attached
+
+    void expectOneCharge(List<String> collaborator) {
+      1 * collaborator.add("charge")
+    }
+  }
+
+  static class StubbingFixture implements MockInteractionSupport {
+    final Specification specification
+    StubbingFixture(Specification specification) { this.specification = specification }
+
+    void stubContains(List<String> collaborator) {
+      collaborator.contains("x") >> true
+    }
+  }
+
+  static class MockCreatingFixture implements MockInteractionSupport {
+    final Specification specification
+    MockCreatingFixture(Specification specification) { this.specification = specification }
+
+    Greeter createAndStub() {
+      Greeter g = Mock()
+      g.greet() >> "hi"
+      return g
+    }
+  }
+
+  interface Greeter { String greet() }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/util/ChecksSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/ChecksSpec.groovy
@@ -1,0 +1,22 @@
+package org.spockframework.util
+
+import spock.lang.Specification
+
+class ChecksSpec extends Specification {
+  def "notNull(object, String) returns the object when not null"() {
+    given:
+    def value = "x"
+
+    expect:
+    Checks.notNull(value, "must not be null").is(value)
+  }
+
+  def "notNull(object, String) throws IllegalArgumentException with the message when null"() {
+    when:
+    Checks.notNull(null, "must not be null")
+
+    then:
+    IllegalArgumentException e = thrown()
+    e.message == "must not be null"
+  }
+}

--- a/spock-specs/src/test/groovy/spock/mock/MockingApiInvalidUsageSpec.groovy
+++ b/spock-specs/src/test/groovy/spock/mock/MockingApiInvalidUsageSpec.groovy
@@ -30,8 +30,9 @@ class MockingApiInvalidUsageSpec extends Specification {
 
   def "Invalid usage check"() {
     when:
-    def api = new MockingApi()
+    def api = new MockingApi() {}
     InvokerHelper.invokeMethod(api, methodName, args.toArray())
+
     then:
     InvalidSpecException ex = thrown()
     ex.message == "Mock objects can only be created inside a spec, and only during the lifetime of a feature (iteration)"
@@ -95,6 +96,6 @@ class MockingApiInvalidUsageSpec extends Specification {
     "GroovySpy"  | [CLOSURE]
 
     "SpyStatic"  | [Runnable]
-    "SpyStatic" | [Runnable, MockMakers.mockito]
+    "SpyStatic"  | [Runnable, MockMakers.mockito]
   }
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/MockInteractionSupport_class_rewrites_creation_and_interactions_in_place_against_getSpecification__-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/MockInteractionSupport_class_rewrites_creation_and_interactions_in_place_against_getSpecification__-groovy5.groovy
@@ -1,0 +1,20 @@
+import spock.lang.Specification
+import spock.mock.MockInteractionSupport
+
+public class OrderFixtures extends java.lang.Object implements spock.mock.MockInteractionSupport {
+
+    private final spock.lang.Specification specification
+
+    public OrderFixtures(spock.lang.Specification specification) {
+        this.specification = specification
+    }
+
+    public java.lang.Object createAndStub() {
+        org.spockframework.util.Checks.notNull(this.getSpecification(), 'Cannot declare mock interactions: the owning Specification is null. Attach the MockInteractionSupport to a running Specification through a constructor field.')
+        java.lang.Object gateway = org.spockframework.runtime.SpecInternals.MockImpl(this.getSpecification(), 'gateway', null, java.util.List)
+        this.getSpecification().getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(11, 5, 'gateway.add(\"x\") >> true').addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('x').addConstantResponse(true).build())
+        this.getSpecification().getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(12, 5, '1 * gateway.add(\"y\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('y').build())
+        return gateway
+    }
+
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/MockInteractionSupport_class_rewrites_creation_and_interactions_in_place_against_getSpecification__.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/MockInteractionSupport_class_rewrites_creation_and_interactions_in_place_against_getSpecification__.groovy
@@ -1,0 +1,20 @@
+import spock.lang.Specification as Specification
+import spock.mock.MockInteractionSupport as MockInteractionSupport
+
+public class OrderFixtures extends java.lang.Object implements spock.mock.MockInteractionSupport {
+
+    private final spock.lang.Specification specification
+
+    public OrderFixtures(spock.lang.Specification specification) {
+        this.specification = specification
+    }
+
+    public java.lang.Object createAndStub() {
+        org.spockframework.util.Checks.notNull(this.getSpecification(), 'Cannot declare mock interactions: the owning Specification is null. Attach the MockInteractionSupport to a running Specification through a constructor field.')
+        java.lang.Object gateway = org.spockframework.runtime.SpecInternals.MockImpl(this.getSpecification(), 'gateway', null, java.util.List)
+        this.getSpecification().getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(11, 5, 'gateway.add(\"x\") >> true').addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('x').addConstantResponse(true).build())
+        this.getSpecification().getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(12, 5, '1 * gateway.add(\"y\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('y').build())
+        return gateway
+    }
+
+}


### PR DESCRIPTION
Introduce the compiler SPI for routing mock interactions (and mock creation)
through an owning Specification located outside the spec, plus the first
mechanism that uses it: the `MockInteractionSupport` interface.

A class implementing `spock.mock.MockInteractionSupport` supplies the owning
spec through `getSpecification()`; its methods may then declare interactions
and create mocks exactly as inside a spec. `SpockTransform` rewrites each
declared method in place, routing creation/interactions through
`getSpecification()`. A class cannot be both a `Specification` and a
`MockInteractionSupport`. Rewritten methods are guarded with `Checks.notNull`
so a missing (unattached) spec fails fast with a clear error.

Foundation included here:
- Spec-locator seam: `IRewriteResources.getSpecificationReference()` and
  `SpecialMethodCall.expand(Expression)`, consumed by `DeepBlockRewriter`,
  `SpecRewriter`, and `DefaultConditionRewriterResources`.
- `MockingApi` converted from a class to an interface (with default methods) so
  non-spec types can mix in the factory methods; `Specification implements
  MockingApi`; `ClosureParameterTypeFromVariableType` accepts interface
  implementors.
- External-rewriter infra: `ExternalRewriteResources`, `ExternalInteractionRewriter`,
  `ExternalInteractionMethod`, and the `Checks.notNull(T, String)` overload.

Tests cover the seam, the MockingApi interface conversion, the closure-param
path, the external rewrite resources, and MockInteractionSupport behaviour
(cardinality, stubbing, mock creation, null-spec guard, static-scope error,
both-spec-and-support error), plus an AST snapshot of the rewritten output.