### PR TITLE
Add @Interactions for declaring interactions on passed-in mocks

### DIFF
--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -1263,8 +1263,8 @@ include::{sourcedir}/interaction/DetachedMockFactoryDocSpec.groovy[tags=use-cust
 === Declaring Interactions Outside Specifications
 
 `DetachedMockFactory` lets you create a mock outside a `Specification`, but the mock's interactions still have to be declared inside the spec.
-`MockInteractionSupport` lets you encapsulate interactions (and mock creation) in a reusable fixture.
-It routes everything through the owning spec's mock controller, so the interactions behave exactly like interactions declared in a `setup:` block: the spec must be live (called from within a feature's lifecycle), and cardinality interactions are verified when the spec's controller scope leaves.
+Two mechanisms let you encapsulate interactions (and, for the first one, mock creation) in reusable fixtures.
+Both route everything through the owning spec's mock controller, so the interactions behave exactly like interactions declared in a `setup:` block: the spec must be live (called from within a feature's lifecycle), and cardinality interactions are verified when the spec's controller scope leaves.
 
 [[MockInteractionSupport]]
 ==== MockInteractionSupport
@@ -1287,6 +1287,42 @@ include::{sourcedir}/interaction/ExternalMockInteractionsDocSpec.groovy[tags=sup
 A class cannot be both a `Specification` and a `MockInteractionSupport`, because a spec already has the full capability.
 
 If you forget to attach the fixture, using it fails fast with a clear error that tells you the spec is missing.
+
+[[Interactions]]
+==== @Interactions
+
+Annotate a helper method with `spock.lang.Interactions` to declare interactions on mocks that are passed in as parameters.
+The method is written naturally, with no spec parameter.
+Mock creation is not allowed in such a method (pass the mocks in, or use `MockInteractionSupport`).
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/interaction/ExternalMockInteractionsDocSpec.groovy[tags=interactions-helper]
+----
+
+When the helper is called from a spec on a strongly-typed receiver, its interactions are routed through the spec:
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/interaction/ExternalMockInteractionsDocSpec.groovy[tags=interactions-usage]
+----
+
+The receiver must be strongly typed (not `def`), otherwise the call fails with an error explaining what went wrong.
+An overload that takes the `Specification` as an explicit first argument is also available, so you can call the helper with the spec directly where needed.
+
+`@Interactions` helpers compose: an `@Interactions` method (or a `MockInteractionSupport` method) may call another `@Interactions` helper on a strongly-typed receiver, and the spec is passed along automatically.
+
+A few constraints apply, each enforced with a compile error:
+the method must have a body (it cannot be abstract or declared in a trait),
+it must not declare a leading `Specification` parameter (the compiler adds that parameter to the synthesized overload),
+and if one overload of a method name is annotated, all overloads of that name must be annotated, because calls to `@Interactions` helpers are matched by method name.
+
+An `@Interactions` method may be `static` (the spec is passed in as a parameter, so no instance is required), as long as you call it class-qualified (`Fixtures.stub(mock)`).
+A `static` import (`import static ...stub`) does not work; call it class-qualified instead.
+This differs from interactions inside a `Specification` or a `MockInteractionSupport` class, which rely on an implicit spec instance and therefore remain forbidden in `static` scope.
+
+Like an inline interaction, a call to an `@Interactions` helper in a `then:` block is recognized as an interaction declaration and scoped to the preceding `when:` block (see <<Scope of Interactions>>).
+This is specific to `@Interactions` helpers: a call to a `MockInteractionSupport` method is an ordinary method call whose interactions are active from the point it is called, exactly as if they were declared there.
 
 == Further Reading
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -10,7 +10,7 @@ include::include.adoc[]
 
 * Add support for `final` local variables in `where:` blocks, declared at their beginning and evaluated once per feature, scoped to the where-block spockIssue:138[]
 * Improve `TooManyInvocationsError` now reports unsatisfied interactions with argument mismatch details, making it easier to diagnose why invocations didn't match expected interactions spockPull:2315[]
-* Allow declaring mock interactions and creating mocks outside a `Specification` via the `MockInteractionSupport` interface, see <<interaction_based_testing.adoc#external-interactions,Declaring Interactions Outside Specifications>>
+* Allow declaring mock interactions outside a `Specification` via the `MockInteractionSupport` interface (which also supports mock creation) and the `@Interactions` method annotation, see <<interaction_based_testing.adoc#external-interactions,Declaring Interactions Outside Specifications>>
 
 === Misc
 

--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -46,6 +46,7 @@ public class AstNodeCache {
   public final ClassNode MockController = ClassHelper.makeWithoutCaching(MockController.class);
   public final ClassNode SpecificationContext = ClassHelper.makeWithoutCaching(SpecificationContext.class);
   public final ClassNode MockInteractionSupport = ClassHelper.makeWithoutCaching(spock.mock.MockInteractionSupport.class);
+  public final ClassNode InvalidSpecException = ClassHelper.makeWithoutCaching(InvalidSpecException.class);
   public final ClassNode Checks = ClassHelper.makeWithoutCaching(org.spockframework.util.Checks.class);
   public final ClassNode DataVariableMultiplication = ClassHelper.makeWithoutCaching(DataVariableMultiplication.class);
   public final ClassNode DataVariableMultiplicationFactor = ClassHelper.makeWithoutCaching(DataVariableMultiplicationFactor.class);

--- a/spock-core/src/main/java/org/spockframework/compiler/CompanionMethodBuilder.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/CompanionMethodBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler;
+
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.ConstructorCallExpression;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ThrowStatement;
+
+import java.util.ArrayList;
+
+/**
+ * Builds the companion overload for a {@code @Interactions} method and the
+ * throwing replacement body for the original method.
+ *
+ * <p>The companion has the same name, return type, generics, varargs, thrown
+ * exceptions and visibility as the original, with a {@code Specification $spec}
+ * parameter prepended. It is NOT marked synthetic, so it is a first-class,
+ * directly-callable overload.
+ */
+public class CompanionMethodBuilder {
+  public static final String SPEC_PARAM_NAME = "$spec";
+
+  private final AstNodeCache nodeCache;
+
+  public CompanionMethodBuilder(AstNodeCache nodeCache) {
+    this.nodeCache = nodeCache;
+  }
+
+  public MethodNode buildCompanion(MethodNode original) {
+    Parameter[] originalParams = original.getParameters();
+    Parameter[] params = new Parameter[originalParams.length + 1];
+    params[0] = new Parameter(nodeCache.Specification, SPEC_PARAM_NAME);
+    System.arraycopy(originalParams, 0, params, 1, originalParams.length);
+
+    MethodNode companion = new MethodNode(
+        original.getName(),
+        original.getModifiers(),
+        original.getReturnType(),
+        params,
+        original.getExceptions(),
+        new BlockStatement());
+    companion.setGenericsTypes(original.getGenericsTypes());
+    companion.addAnnotations(new ArrayList<>(original.getAnnotations()));
+    companion.setSourcePosition(original);
+    return companion;
+  }
+
+  public BlockStatement buildThrowingBody(MethodNode original) {
+    String message = "Method '" + original.getName() + "' is annotated with @Interactions and can only declare "
+        + "interactions when called from a Specification with a strongly-typed receiver, or when its explicit-spec "
+        + "overload (with a leading Specification argument) is called directly.";
+    ConstructorCallExpression exception = new ConstructorCallExpression(
+        nodeCache.InvalidSpecException,
+        new ArgumentListExpression(new ConstantExpression(message)));
+    BlockStatement body = new BlockStatement();
+    body.addStatement(new ThrowStatement(exception));
+    return body;
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DeepBlockRewriter.java
@@ -15,6 +15,7 @@
 
 package org.spockframework.compiler;
 
+import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.expr.*;
 import org.codehaus.groovy.ast.stmt.AssertStatement;
@@ -151,12 +152,22 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
   protected void doVisitMethodCallExpression(MethodCallExpression expr) {
     super.doVisitMethodCallExpression(expr);
 
-    boolean handled = handleMockCall(expr)
+    boolean handled = handleInteractionsCall(expr)
+        || handleMockCall(expr)
         || handleThrownCall(expr)
         || handleOldCall(expr)
         || handleInteractionBlockCall(expr)
         || handleImplicitCallOnMethodParam(expr)
         || forbidUseOfSuperInFixtureMethod(expr);
+  }
+
+  private boolean handleInteractionsCall(MethodCallExpression expr) {
+    return InteractionsCallDetector.rewriteToCompanionCall(
+        expr, resources::getSpecificationReference, resources.getAstNodeCache(), enclosingType());
+  }
+
+  private ClassNode enclosingType() {
+    return resources.getCurrentMethod().getAst().getDeclaringClass();
   }
 
   private boolean handleImplicitCallOnMethodParam(MethodCallExpression expr) {
@@ -177,6 +188,11 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
   }
 
   private boolean handleInteraction(InteractionRewriter rewriter, ExpressionStatement stat) {
+    if (isRelocatableInteractionsAnnotatedCall(stat)) {
+      interactionFound = true;
+      return true;
+    }
+
     ExpressionStatement interaction = rewriter.rewrite(stat);
     if (interaction == null) return false;
 
@@ -197,6 +213,17 @@ public class DeepBlockRewriter extends AbstractDeepBlockRewriter {
     replaceVisitedStatementWith(interaction);
     interactionFound = true;
     return true;
+  }
+
+  /**
+   * Checks if stat is a bare top-level call to an {@code @Interactions} helper in a then-block, eligible to be moved
+   * before the preceding when-block.
+   */
+  private boolean isRelocatableInteractionsAnnotatedCall(ExpressionStatement stat) {
+    return block instanceof ThenBlock
+        && stat == currTopLevelStat
+        && stat.getExpression() instanceof MethodCallExpression
+        && InteractionsCallDetector.isInteractionsCall((MethodCallExpression) stat.getExpression(), enclosingType());
   }
 
   private boolean handleImplicitCondition(ExpressionStatement stat) {

--- a/spock-core/src/main/java/org/spockframework/compiler/ExternalInteractionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ExternalInteractionRewriter.java
@@ -16,6 +16,7 @@
 
 package org.spockframework.compiler;
 
+import org.codehaus.groovy.ast.CodeVisitorSupport;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
@@ -41,7 +42,9 @@ import static org.spockframework.compiler.AstUtil.createDirectMethodCall;
  * the registration call ({@code mockController.addInteraction(...)}). Built-in
  * creation calls ({@code Mock()}/{@code Stub()}/{@code Spy()} ...) are either
  * expanded (interface mechanism) or rejected as a compile error (annotation
- * mechanism), controlled by {@code allowCreation}.
+ * mechanism), controlled by {@code allowCreation}. Calls to other
+ * {@code @Interactions} helpers anywhere in the body are rewritten to pass the
+ * located spec along, so helpers compose.
  *
  * <p>Only top-level statements are rewritten; closure-nested interaction forms
  * ({@code with(mock) { ... }}) are not handled here.
@@ -51,18 +54,27 @@ public class ExternalInteractionRewriter {
   private final ErrorReporter errorReporter;
   private final SourceLookup sourceLookup;
   private final boolean allowCreation;
+  private final boolean allowStaticScope;
+  private final String specNullMessage;
 
   /**
-   * @param allowCreation whether built-in creation calls may be expanded
-   *                      (interface mechanism) or are rejected (annotation
-   *                      mechanism).
+   * @param allowCreation    whether built-in creation calls may be expanded
+   *                         (interface mechanism) or are rejected (annotation
+   *                         mechanism).
+   * @param allowStaticScope see {@link IRewriteResources#isStaticInteractionScopeAllowed()}.
+   * @param specNullMessage  the message of the {@code Checks.notNull} guard that
+   *                         is prepended to every rewritten method, protecting
+   *                         against a {@code null} located spec; mechanism-specific
+   *                         so the failure tells the user what to fix.
    */
   public ExternalInteractionRewriter(AstNodeCache nodeCache, ErrorReporter errorReporter,
-      SourceLookup sourceLookup, boolean allowCreation) {
+      SourceLookup sourceLookup, boolean allowCreation, boolean allowStaticScope, String specNullMessage) {
     this.nodeCache = nodeCache;
     this.errorReporter = errorReporter;
     this.sourceLookup = sourceLookup;
     this.allowCreation = allowCreation;
+    this.allowStaticScope = allowStaticScope;
+    this.specNullMessage = specNullMessage;
   }
 
   /**
@@ -74,11 +86,10 @@ public class ExternalInteractionRewriter {
     if (!(method.getCode() instanceof BlockStatement)) return;
 
     ExternalRewriteResources resources = new ExternalRewriteResources(
-        specificationReferenceFactory, new ExternalInteractionMethod(method), nodeCache, sourceLookup, errorReporter);
+        specificationReferenceFactory, new ExternalInteractionMethod(method), nodeCache, sourceLookup, errorReporter,
+        allowStaticScope);
 
-    // the spec is located through `this`, which is unavailable in static scope;
-    // interactions in static methods are rejected by InteractionRewriter itself
-    boolean staticScopeViolation = method.isStatic();
+    boolean staticScopeViolation = method.isStatic() && !allowStaticScope;
 
     BlockStatement body = (BlockStatement) method.getCode();
     List<Statement> statements = body.getStatements();
@@ -97,6 +108,10 @@ public class ExternalInteractionRewriter {
         rewrote = true;
       }
     }
+
+    // route calls to other @Interactions helpers through the located spec, so
+    // helpers compose (the helper's $spec parameter has no user-visible name)
+    rewrote |= rewriteNestedInteractionsCalls(method, body, specificationReferenceFactory);
 
     // guard the located spec: anything we rewrote depends on it being non-null
     if (rewrote) {
@@ -130,19 +145,35 @@ public class ExternalInteractionRewriter {
   }
 
   /**
+   * Rewrites every call to an {@code @Interactions} helper anywhere in
+   * {@code body} (including nested statements and closures) to pass the located
+   * spec as the leading argument, selecting the helper's companion overload.
+   */
+  private boolean rewriteNestedInteractionsCalls(MethodNode method, BlockStatement body,
+      Supplier<Expression> specificationReferenceFactory) {
+    boolean[] rewrote = {false};
+    new CodeVisitorSupport() {
+      @Override
+      public void visitMethodCallExpression(MethodCallExpression call) {
+        super.visitMethodCallExpression(call);
+        rewrote[0] |= InteractionsCallDetector.rewriteToCompanionCall(
+            call, specificationReferenceFactory, nodeCache, method.getDeclaringClass());
+      }
+    }.visitBlockStatement(body);
+    return rewrote[0];
+  }
+
+  /**
    * Builds {@code Checks.notNull(<specRef>, "...")}, guarding against a missing
    * owning spec (e.g. a {@code MockInteractionSupport} whose
-   * {@code getSpecification()} was never attached).
+   * {@code getSpecification()} was never attached, or a {@code null} passed for
+   * the companion's {@code $spec} parameter).
    */
   private Statement createSpecificationNotNullCheck(Expression specificationReference) {
     MethodCallExpression check = createDirectMethodCall(
         new ClassExpression(nodeCache.Checks),
         nodeCache.Checks_NotNull,
-        new ArgumentListExpression(specificationReference, new ConstantExpression(SPEC_NULL_MESSAGE)));
+        new ArgumentListExpression(specificationReference, new ConstantExpression(specNullMessage)));
     return new ExpressionStatement(check);
   }
-
-  private static final String SPEC_NULL_MESSAGE =
-      "Cannot declare mock interactions: the owning Specification is null. Attach the MockInteractionSupport to a "
-          + "running Specification through a constructor field.";
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/ExternalRewriteResources.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ExternalRewriteResources.java
@@ -47,25 +47,34 @@ public class ExternalRewriteResources implements IRewriteResources {
   private final AstNodeCache nodeCache;
   private final SourceLookup sourceLookup;
   private final ErrorReporter errorReporter;
+  private final boolean staticInteractionScopeAllowed;
 
   /**
    * @param specificationReferenceFactory produces a fresh spec-reference
    *        expression on each call; a fresh node is required because the
    *        reference is embedded into a new AST location for every interaction
    *        or creation it locates.
+   * @param staticInteractionScopeAllowed see {@link IRewriteResources#isStaticInteractionScopeAllowed()}.
    */
   public ExternalRewriteResources(Supplier<Expression> specificationReferenceFactory, Method currentMethod,
-      AstNodeCache nodeCache, SourceLookup sourceLookup, ErrorReporter errorReporter) {
+      AstNodeCache nodeCache, SourceLookup sourceLookup, ErrorReporter errorReporter,
+      boolean staticInteractionScopeAllowed) {
     this.specificationReferenceFactory = specificationReferenceFactory;
     this.currentMethod = currentMethod;
     this.nodeCache = nodeCache;
     this.sourceLookup = sourceLookup;
     this.errorReporter = errorReporter;
+    this.staticInteractionScopeAllowed = staticInteractionScopeAllowed;
   }
 
   @Override
   public Expression getSpecificationReference() {
     return specificationReferenceFactory.get();
+  }
+
+  @Override
+  public boolean isStaticInteractionScopeAllowed() {
+    return staticInteractionScopeAllowed;
   }
 
   @Override

--- a/spock-core/src/main/java/org/spockframework/compiler/IRewriteResources.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/IRewriteResources.java
@@ -37,6 +37,19 @@ public interface IRewriteResources {
    */
   Expression getSpecificationReference();
 
+  /**
+   * Whether interactions may be declared in a {@code static} method here. The
+   * default is {@code false}: the spec reference normally depends on {@code this}
+   * (a real spec, or {@code this.getSpecification()} for a
+   * {@code MockInteractionSupport}), which is unavailable in static scope. It is
+   * {@code true} only when the spec reference is instance-independent, i.e. an
+   * injected parameter such as a {@code @Interactions} companion's
+   * {@code $spec}.
+   */
+  default boolean isStaticInteractionScopeAllowed() {
+    return false;
+  }
+
   Method getCurrentMethod();
 
   Block getCurrentBlock();

--- a/spock-core/src/main/java/org/spockframework/compiler/InteractionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/InteractionRewriter.java
@@ -92,7 +92,7 @@ public class InteractionRewriter {
 
     Expression expr = parseCount(parseResults(stat.getExpression()));
     boolean interaction = (count != null || !responses.isEmpty()) && parseCall(expr);
-    if (interaction && resources.getCurrentMethod().getAst().isStatic()) {
+    if (interaction && resources.getCurrentMethod().getAst().isStatic() && !resources.isStaticInteractionScopeAllowed()) {
       throw new InvalidSpecCompileException(stat, "Interactions cannot be declared in static scope");
     }
 

--- a/spock-core/src/main/java/org/spockframework/compiler/InteractionsCallDetector.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/InteractionsCallDetector.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler;
+
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import spock.lang.Interactions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Detects calls to {@code @Interactions}-annotated helper methods, using the
+ * same static-type resolution as {@code @ConditionBlock} detection
+ * ({@code SpecialMethodCall#checkIsConditionBlock}). Works for implicit-this and
+ * strongly-typed receivers; silently misses {@code def}-typed receivers (which
+ * fall through to the throwing original at runtime, by design).
+ */
+final class InteractionsCallDetector {
+  private InteractionsCallDetector() {}
+
+  static boolean isInteractionsCall(MethodCallExpression call, ClassNode enclosingType) {
+    String methodName = call.getMethodAsString();
+    if (methodName == null) return false;
+    // an implicit-this (or explicit this/super) receiver carries no useful static
+    // type at this phase; the enclosing class is the receiver type then
+    ClassNode targetType = AstUtil.isThisOrSuperExpression(call.getObjectExpression())
+        ? enclosingType
+        : call.getObjectExpression().getType();
+    if (targetType == null) return false;
+    try {
+      // resolving methods may fail with NoClassDefFoundError if a parameter or
+      // return type is not on the compile classpath; treat that as "no match"
+      for (MethodNode method : targetType.getMethods(methodName))
+        if (AstUtil.hasAnnotation(method, Interactions.class)) return true;
+    } catch (NoClassDefFoundError e) {
+      // no match
+    }
+    return false;
+  }
+
+  /**
+   * If {@code call} targets an {@code @Interactions} helper and does not already
+   * pass a {@code Specification} as its first argument, prepends the spec
+   * reference produced by {@code specificationReferenceFactory} so the call
+   * dispatches to the synthesized companion overload.
+   *
+   * @return whether the call was rewritten
+   */
+  static boolean rewriteToCompanionCall(MethodCallExpression call, Supplier<Expression> specificationReferenceFactory,
+      AstNodeCache nodeCache, ClassNode enclosingType) {
+    if (!isInteractionsCall(call, enclosingType)) return false;
+    if (firstArgIsSpecification(call, nodeCache)) return false; // already an explicit-spec overload call
+
+    List<Expression> args = new ArrayList<>();
+    args.add(specificationReferenceFactory.get());
+    args.addAll(AstUtil.getArgumentList(call));
+    ArgumentListExpression newArgs = new ArgumentListExpression(args);
+    AstUtil.copySourcePosition(call.getArguments(), newArgs);
+    call.setArguments(newArgs);
+    return true;
+  }
+
+  private static boolean firstArgIsSpecification(MethodCallExpression expr, AstNodeCache nodeCache) {
+    List<Expression> args = AstUtil.getArgumentList(expr);
+    if (args.isEmpty()) return false;
+    Expression first = args.get(0);
+    // an explicit-spec overload call inside a spec passes `this`/`super`, or a
+    // variable whose static type is a Specification
+    return AstUtil.isThisOrSuperExpression(first)
+        || first.getType().isDerivedFrom(nodeCache.Specification);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
@@ -17,14 +17,19 @@
 package org.spockframework.compiler;
 
 import org.codehaus.groovy.classgen.VariableScopeVisitor;
+import org.codehaus.groovy.transform.trait.Traits;
 import org.spockframework.compiler.model.Spec;
 import org.spockframework.util.VersionChecker;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import spock.lang.Interactions;
+
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.ast.expr.*;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.control.*;
 import org.codehaus.groovy.transform.*;
 
@@ -54,12 +59,25 @@ public class SpockTransform implements ASTTransformation {
   private static class Impl {
     static final AstNodeCache nodeCache = new AstNodeCache();
 
+    static final String SUPPORT_SPEC_NULL_MESSAGE =
+        "Cannot declare mock interactions: the owning Specification is null. Attach the MockInteractionSupport to a "
+            + "running Specification through a constructor field.";
+
+    static final String INTERACTIONS_SPEC_NULL_MESSAGE =
+        "Cannot declare mock interactions: the Specification passed to this @Interactions method is null.";
+
     void visit(ASTNode[] nodes, SourceUnit sourceUnit) {
       ErrorReporter errorReporter = new ErrorReporter(sourceUnit);
 
       try (SourceLookup sourceLookup = new SourceLookup(sourceUnit)) {
         List<ClassNode> classes = sourceUnit.getAST().getClasses();
 
+        // Pass 1: synthesize @Interactions companions across the whole unit,
+        // so same-unit call sites can be rewritten to the companion in pass 2.
+        for (ClassNode clazz : classes)
+          processInteractionsMethods(clazz, errorReporter, sourceLookup);
+
+        // Pass 2: process specs and MockInteractionSupport classes.
         for (ClassNode clazz : classes) {
           boolean spec = isSpec(clazz);
           boolean support = isMockInteractionSupport(clazz);
@@ -80,6 +98,133 @@ public class SpockTransform implements ASTTransformation {
       }
     }
 
+    void processInteractionsMethods(ClassNode clazz, ErrorReporter errorReporter, SourceLookup sourceLookup) {
+      // copy to avoid concurrent modification while adding the companion; also lets
+      // us skip the common (no-@Interactions) class before allocating anything
+      List<MethodNode> methods = new ArrayList<>(clazz.getMethods());
+      if (methods.stream().noneMatch(this::hasInteractions)) return;
+
+      boolean onSpec = isSpec(clazz);
+      boolean onTrait = Traits.isTrait(clazz);
+      boolean onSupport = isMockInteractionSupport(clazz);
+      CompanionMethodBuilder builder = new CompanionMethodBuilder(nodeCache);
+      // allowCreation=false (mocks are passed in); allowStaticScope=true (the
+      // companion receives the spec as the injected $spec parameter, so a static
+      // companion can still reach it)
+      ExternalInteractionRewriter rewriter =
+          new ExternalInteractionRewriter(nodeCache, errorReporter, sourceLookup, false, true,
+              INTERACTIONS_SPEC_NULL_MESSAGE);
+
+      for (MethodNode method : methods) {
+        if (!hasInteractions(method)) continue;
+
+        if (onSpec) {
+          errorReporter.error(
+              "Method '%s' is annotated with @Interactions but declared on a Specification; declare interactions directly in a block instead.",
+              method.getName());
+          continue;
+        }
+        if (onTrait) {
+          errorReporter.error(
+              "Method '%s' is annotated with @Interactions but declared in a trait, which is not supported.",
+              method.getName());
+          continue;
+        }
+        if (onSupport) {
+          // class-level processing rewrites the body in place; annotation is redundant here
+          continue;
+        }
+        if (method.isAbstract()) {
+          errorReporter.error(
+              "Method '%s' is annotated with @Interactions but is abstract; @Interactions requires a method body.",
+              method.getName());
+          continue;
+        }
+        if (hasLeadingSpecificationParameter(method)) {
+          errorReporter.error(
+              "Method '%s' is annotated with @Interactions and must not declare a leading Specification parameter; "
+                  + "the Spock compiler adds the Specification parameter to the synthesized companion overload automatically.",
+              method.getName());
+          continue;
+        }
+        MethodNode unannotatedOverload = findUnannotatedOverload(clazz, method);
+        if (unannotatedOverload != null) {
+          errorReporter.error(
+              "Method '%s' is annotated with @Interactions, but the overload with parameter types %s is not; "
+                  + "calls to @Interactions helpers are matched by method name, so all overloads must be annotated if one is.",
+              method.getName(), parameterTypeNames(unannotatedOverload));
+          continue;
+        }
+
+        MethodNode companion = builder.buildCompanion(method);
+        if (signatureCollides(clazz, companion, method)) {
+          errorReporter.error(
+              "Cannot synthesize a companion for @Interactions method '%s': a method with the companion signature (leading Specification parameter) already exists.",
+              method.getName());
+          continue;
+        }
+
+        BlockStatement companionBody = (BlockStatement) companion.getCode();
+        if (method.getCode() instanceof BlockStatement) {
+          companionBody.addStatements(((BlockStatement) method.getCode()).getStatements());
+        }
+        // add before rewriting, so the rewrite sees the companion's declaring class
+        // (needed to resolve implicit-this calls to sibling @Interactions helpers)
+        clazz.addMethod(companion);
+        rewriter.rewriteInPlace(companion,
+            () -> new VariableExpression(CompanionMethodBuilder.SPEC_PARAM_NAME, nodeCache.Specification));
+
+        // original body becomes a diagnostic throw
+        method.setCode(builder.buildThrowingBody(method));
+      }
+    }
+
+    boolean hasInteractions(MethodNode method) {
+      return AstUtil.hasAnnotation(method, Interactions.class);
+    }
+
+    boolean hasLeadingSpecificationParameter(MethodNode method) {
+      Parameter[] parameters = method.getParameters();
+      return parameters.length > 0 && parameters[0].getType().isDerivedFrom(nodeCache.Specification);
+    }
+
+    /**
+     * Finds a same-name overload (declared or inherited) that lacks the
+     * {@code @Interactions} annotation. Call sites are matched by name alone, so
+     * such an overload would have the spec prepended to its arguments and fail
+     * to dispatch.
+     */
+    MethodNode findUnannotatedOverload(ClassNode clazz, MethodNode original) {
+      for (MethodNode candidate : clazz.getMethods(original.getName())) {
+        if (candidate == original) continue;
+        if (!hasInteractions(candidate)) return candidate;
+      }
+      return null;
+    }
+
+    String parameterTypeNames(MethodNode method) {
+      List<String> names = new ArrayList<>();
+      for (Parameter parameter : method.getParameters()) {
+        names.add(parameter.getType().getNameWithoutPackage());
+      }
+      return names.toString();
+    }
+
+    boolean signatureCollides(ClassNode clazz, MethodNode companion, MethodNode original) {
+      for (MethodNode existing : clazz.getMethods(companion.getName())) {
+        if (existing == original) continue;
+        if (parametersMatch(existing.getParameters(), companion.getParameters())) return true;
+      }
+      return false;
+    }
+
+    boolean parametersMatch(Parameter[] a, Parameter[] b) {
+      if (a.length != b.length) return false;
+      for (int i = 0; i < a.length; i++)
+        if (!a[i].getType().equals(b[i].getType())) return false;
+      return true;
+    }
+
     boolean isSpec(ClassNode clazz) {
       return clazz.isDerivedFrom(nodeCache.Specification);
     }
@@ -92,13 +237,14 @@ public class SpockTransform implements ASTTransformation {
       Supplier<Expression> specRef = () -> AstUtil.createDirectMethodCall(
           VariableExpression.THIS_EXPRESSION, nodeCache.MockInteractionSupport_GetSpecification,
           ArgumentListExpression.EMPTY_ARGUMENTS);
-      // allowCreation=true (mocks can be created here). The spec is reached via
-      // this.getSpecification(), so static methods that declare interactions or
-      // create mocks get a clear "static scope" compile error. The located spec is
-      // always guarded with Checks.notNull, since getSpecification() may be null
-      // if the fixture was never attached.
+      // allowCreation=true (mocks can be created here); allowStaticScope=false
+      // (the spec is reached via this.getSpecification(), so static methods that
+      // declare interactions/creation get a clear "static scope" compile error).
+      // The located spec is always guarded with Checks.notNull, since
+      // getSpecification() may be null if the fixture was never attached.
       ExternalInteractionRewriter rewriter =
-          new ExternalInteractionRewriter(nodeCache, errorReporter, sourceLookup, true);
+          new ExternalInteractionRewriter(nodeCache, errorReporter, sourceLookup, true, false,
+              SUPPORT_SPEC_NULL_MESSAGE);
       rewriteDeclaredMethods(clazz, rewriter, specRef);
       if (!sourceUnit.getErrorCollector().hasErrors()) {
         new VariableScopeVisitor(sourceUnit).visitClass(clazz);

--- a/spock-core/src/main/java/spock/lang/Interactions.java
+++ b/spock-core/src/main/java/spock/lang/Interactions.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spock.lang;
+
+import org.spockframework.util.Beta;
+import spock.mock.MockInteractionSupport;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a helper method (written naturally, with mocks passed in as parameters)
+ * whose body declares mock interactions. The Spock compiler synthesizes a
+ * companion overload that takes the owning {@code Specification} as an injected
+ * first parameter and routes interactions through it; calls from a spec with a
+ * strongly-typed receiver are rewritten to invoke the companion. Mock creation
+ * is not allowed in such methods (pass mocks in as parameters, or use
+ * {@link MockInteractionSupport}).
+ *
+ * <p>Example:
+ * <pre>
+ * class OrderFixtures {
+ *   {@literal @}Interactions
+ *   void stubHappyPath(PaymentGateway gateway) {
+ *     gateway.charge(_) &gt;&gt; Result.OK
+ *     1 * gateway.audit(_)
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>Runtime retention is required so specs can detect calls to precompiled
+ * annotated helpers in other compilation units (same rationale as
+ * {@code @ConditionBlock}).
+ *
+ * @since 2.5
+ */
+@Beta
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Interactions {}

--- a/spock-specs/src/test/groovy/org/spockframework/docs/interaction/ExternalMockInteractionsDocSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/interaction/ExternalMockInteractionsDocSpec.groovy
@@ -2,6 +2,7 @@ package org.spockframework.docs.interaction
 
 import spock.lang.Specification
 import spock.mock.MockInteractionSupport
+import spock.lang.Interactions
 
 class ExternalMockInteractionsDocSpec extends Specification {
 
@@ -35,6 +36,32 @@ class ExternalMockInteractionsDocSpec extends Specification {
     charged
   }
   // end::support-usage[]
+
+  // tag::interactions-helper[]
+  static class GatewayInteractions {
+    @Interactions
+    void expectCharged(PaymentGateway gateway) {
+      gateway.charge(42) >> true
+      1 * gateway.audit("processed")
+    }
+  }
+  // end::interactions-helper[]
+
+  // tag::interactions-usage[]
+  def "an @Interactions helper declares interactions on a passed-in mock"() {
+    given:
+    PaymentGateway gateway = Mock()
+    GatewayInteractions interactions = new GatewayInteractions()
+
+    when:
+    interactions.expectCharged(gateway)    // strongly-typed receiver: rewritten to pass the spec
+    boolean charged = gateway.charge(42)
+    gateway.audit("processed")
+
+    then:
+    charged
+  }
+  // end::interactions-usage[]
 
   interface PaymentGateway {
     boolean charge(int amount)

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec.groovy
@@ -49,4 +49,82 @@ class OrderFixtures implements MockInteractionSupport {
     then:
     snapshotter.assertThat(result.source).matchesSnapshot(SNAPSHOT_ID)
   }
+
+  def "@Interactions synthesizes a companion overload and replaces the original body with a throw"() {
+    when:
+    def result = compiler.transpile('''
+import spock.lang.Interactions
+
+class OrderFixtures {
+  @Interactions
+  void stubHappyPath(List<String> gateway) {
+    gateway.add("x") >> true
+    1 * gateway.add("y")
+  }
+}
+''')
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot(SNAPSHOT_ID)
+  }
+
+  def "@Interactions call from a spec with a typed receiver is rewritten to pass the spec"() {
+    given:
+    snapshotter.specBody()
+
+    when:
+    def result = compiler.transpileSpecBody('''
+static class OrderFixtures {
+  @spock.lang.Interactions
+  void stubHappyPath(List<String> gateway) {
+    1 * gateway.add("y")
+  }
+}
+
+def "a feature"() {
+  given:
+  List<String> gateway = Mock()
+  OrderFixtures fixtures = new OrderFixtures()
+
+  when:
+  fixtures.stubHappyPath(gateway)
+
+  then:
+  true
+}
+''')
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot(SNAPSHOT_ID)
+  }
+
+  def "an @Interactions call in a then-block is relocated before the preceding when-block"() {
+    given:
+    snapshotter.specBody()
+
+    when:
+    def result = compiler.transpileSpecBody('''
+static class OrderFixtures {
+  @spock.lang.Interactions
+  void expectCharge(List<String> gateway) {
+    1 * gateway.add("charge")
+  }
+}
+
+def "a feature"() {
+  given:
+  List<String> gateway = Mock()
+  OrderFixtures fixtures = new OrderFixtures()
+
+  when:
+  gateway.add("charge")
+
+  then:
+  fixtures.expectCharge(gateway)
+}
+''')
+
+    then: "the companion call is moved out of the then-block to before the when-block, like an inline interaction"
+    snapshotter.assertThat(result.source).matchesSnapshot(SNAPSHOT_ID)
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/InteractionsSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/InteractionsSpec.groovy
@@ -1,0 +1,538 @@
+package org.spockframework.smoke.mock
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.mock.TooFewInvocationsError
+import org.spockframework.runtime.InvalidSpecException
+import spock.lang.Specification
+import spock.lang.Interactions
+import spock.mock.MockInteractionSupport
+import spock.util.EmbeddedSpecCompiler
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+class InteractionsSpec extends EmbeddedSpecification {
+  def "annotation targets methods with runtime retention"() {
+    expect:
+    Interactions.getAnnotation(Retention).value() == RetentionPolicy.RUNTIME
+    Interactions.getAnnotation(Target).value().toList() == [ElementType.METHOD]
+  }
+
+  def "an @Interactions helper enforces interactions when called from a spec with a typed receiver"() {
+    given:
+    List<String> gateway = Mock()
+    OrderFixtures fixtures = new OrderFixtures()
+
+    when:
+    fixtures.stubHappyPath(gateway)
+    def result = gateway.get(0)
+
+    then: "the interaction is enforced and the stubbed value is returned"
+    result == "item"
+  }
+
+  def "the companion overload is directly callable with an explicit spec, even if the type is dynamic"() {
+    given:
+    List<String> gateway = Mock()
+    def fixtures = new OrderFixtures()
+
+    when:
+    fixtures.stubHappyPath(this, gateway)
+    def result = gateway.get(0)
+
+    then:
+    result == "item"
+  }
+
+  def "a def-typed receiver invokes the throwing original with a diagnostic message"() {
+    given:
+    List<String> gateway = Mock()
+    def fixtures = new OrderFixtures() // def-typed receiver -> detection misses
+
+    when:
+    fixtures.stubHappyPath(gateway)
+
+    then:
+    InvalidSpecException e = thrown()
+    e.message == "Method 'stubHappyPath' is annotated with @Interactions and can only declare interactions when called from a Specification with a strongly-typed receiver, or when its explicit-spec overload (with a leading Specification argument) is called directly."
+  }
+
+  def "a Mock() creation inside an @Interactions method is a compile error"() {
+    when:
+    compiler.compileWithImports('''
+      import spock.lang.Interactions
+      class BadFix {
+        @Interactions
+        void bad() {
+          def m = Mock(List)
+          1 * m.add(_)
+        }
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("creation is not allowed in an @Interactions method")
+  }
+
+  def "@Interactions on a Specification method is a compile error"() {
+    when:
+    compiler.compileWithImports('''
+      import spock.lang.Specification
+      import spock.lang.Interactions
+      class BadSpec extends Specification {
+        @Interactions
+        void helper(List l) { 1 * l.add(_) }
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("declared on a Specification")
+  }
+
+  def "a pre-existing method matching the companion signature is a compile error"() {
+    when:
+    compiler.compileWithImports('''
+      import spock.lang.Specification
+      import spock.lang.Interactions
+      class CollideFix {
+        @Interactions
+        void stub(List l) { 1 * l.add(_) }
+        @Interactions
+        void stub(Specification s, List l) {}
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("companion signature")
+  }
+
+  def "an @Interactions method with an unannotated same-name overload is a compile error"() {
+    when:
+    compiler.compileWithImports('''
+      import spock.lang.Interactions
+      class MixedFix {
+        @Interactions
+        void stub(List l) { 1 * l.add(_) }
+        String stub(String plain) { return plain }
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("all overloads must be annotated")
+  }
+
+  def "an @Interactions method must not declare a leading Specification parameter"() {
+    when:
+    compiler.compileWithImports('''
+      import spock.lang.Specification
+      import spock.lang.Interactions
+      class LeadingFix {
+        @Interactions
+        void stub(Specification spec, List l) { 1 * l.add(_) }
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("must not declare a leading Specification parameter")
+  }
+
+  def "an abstract @Interactions method is a compile error"() {
+    when:
+    compiler.compileWithImports('''
+      import spock.lang.Interactions
+      abstract class AbstractFix {
+        @Interactions
+        abstract void stub(List l)
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("requires a method body")
+  }
+
+  def "an @Interactions method in a trait is a compile error"() {
+    when:
+    compiler.compileWithImports('''
+      import spock.lang.Interactions
+      trait BadTrait {
+        @Interactions
+        void stub(List l) { 1 * l.add(_) }
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("declared in a trait")
+  }
+
+  def "an @Interactions helper can call another @Interactions helper, passing the spec along"() {
+    given:
+    List<String> gateway = Mock()
+    ComposedFixtures fixtures = new ComposedFixtures()
+
+    when:
+    fixtures.stubAll(gateway)
+    def result = gateway.get(0)
+
+    then: "the inner helper's interaction took effect through the outer helper"
+    result == "item"
+  }
+
+  def "a MockInteractionSupport method can call an @Interactions helper, passing the spec along"() {
+    given:
+    List<String> gateway = Mock()
+    def support = new ComposingSupport(this)
+
+    when:
+    support.applyStubs(gateway)
+    def result = gateway.get(0)
+
+    then:
+    result == "item"
+  }
+
+  def "a @CompileStatic spec resolves the rewritten companion call"() {
+    when:
+    def specs = compiler.compileWithImports('''
+      import groovy.transform.CompileStatic
+      import spock.lang.Specification
+      import spock.lang.Interactions
+
+      class Fix {
+        @Interactions
+        void stub(List<String> l) { 1 * l.add("x") }
+      }
+
+      @CompileStatic
+      class CsSpec extends Specification {
+        def "f"() {
+          given:
+          List<String> l = Mock()
+          Fix fix = new Fix()
+
+          when:
+          fix.stub(l)
+          l.add("x")
+
+          then:
+          true
+        }
+      }
+    ''')
+
+    then:
+    specs.find { it.simpleName == "CsSpec" } != null
+  }
+
+  def "detection works against a precompiled @Interactions helper in another compilation unit"() {
+    given: "the helper is compiled and loaded in its own compilation unit"
+    compiler.compile('''
+      package ext
+      import spock.lang.Interactions
+      class ExtHelper {
+        @Interactions
+        void stub(List<String> gateway) { 1 * gateway.add("x") }
+      }
+    ''')
+
+    and: "a second compiler whose classpath includes the precompiled helper"
+    def crossCompiler = new EmbeddedSpecCompiler(compiler.loader)
+
+    when: "a spec in a separate unit calls the helper with a strongly-typed receiver"
+    def result = crossCompiler.transpileSpecBody('''
+      def "f"() {
+        given:
+        List<String> gateway = Mock()
+        ext.ExtHelper helper = new ext.ExtHelper()
+
+        when:
+        helper.stub(gateway)
+
+        then:
+        true
+      }
+    ''')
+
+    then: "the call is rewritten to select the precompiled companion (RUNTIME-retained annotation read from bytecode)"
+    result.source.contains("helper.stub(this, gateway)")
+  }
+
+  def "the companion fails with a clear error when called with a null spec"() {
+    given:
+    List<String> gateway = Mock()
+    OrderFixtures fixtures = new OrderFixtures()
+
+    when:
+    fixtures.stubHappyPath((Specification) null, gateway)
+
+    then:
+    IllegalArgumentException e = thrown()
+    e.message == "Cannot declare mock interactions: the Specification passed to this @Interactions method is null."
+  }
+
+  def "a static @Interactions helper works when called class-qualified from a spec"() {
+    given:
+    List<String> gateway = Mock()
+
+    when:
+    OrderFixtures.staticStubHappyPath(gateway)
+    def result = gateway.get(0)
+
+    then: "the spec is passed as \$spec, so static scope is allowed"
+    result == "item"
+  }
+
+  def "a statically-imported @Interactions call cannot be resolved at compile time, so it hits the throwing original"() {
+    when: "the unqualified call is resolved by Groovy's static-import handling, not our detection"
+    runner.runWithImports('''
+      import static apackage.ImportFixtures.stub
+
+      class ImportFixtures {
+        @Interactions
+        static void stub(List l) { 1 * l.add("x") }
+      }
+
+      class CallerSpec extends Specification {
+        def "f"() {
+          given:
+          List l = Mock()
+
+          when:
+          stub(l)
+
+          then:
+          true
+        }
+      }
+    ''')
+
+    then:
+    InvalidSpecException e = thrown()
+    e.message.contains("strongly-typed receiver")
+  }
+
+  def "a statically-imported @Interactions call is left unqualified-original, not rewritten to pass the spec"() {
+    when:
+    def result = compiler.transpile('''
+package apkg
+import spock.lang.Specification
+import spock.lang.Interactions
+import spock.mock.MockInteractionSupport
+import static apkg.Fixtures.stub
+
+class Fixtures {
+  @Interactions
+  static void stub(List l) { 1 * l.add("x") }
+}
+
+class CallerSpec extends Specification {
+  def "f"() {
+    given:
+    List l = Mock()
+
+    when:
+    stub(l)
+
+    then:
+    true
+  }
+}
+''')
+
+    then: "the call site keeps the original (throwing) overload; no spec was prepended"
+    result.source.contains("apkg.Fixtures.stub(l)")
+    !result.source.contains("stub(this")
+  }
+
+  def "an @Interactions stubbing helper placed in a then-block is relocated before the when-block"() {
+    when:
+    runner.runWithImports('''
+      class StubFixtures {
+        @Interactions
+        void stub(List<String> gateway) {
+          gateway.get(0) >> "item"
+        }
+      }
+
+      class CallerSpec extends Specification {
+        def "the stub takes effect on the when-action"() {
+          given:
+          List<String> gateway = Mock()
+          StubFixtures fixtures = new StubFixtures()
+
+          when:
+          def result = gateway.get(0)
+
+          then: "the helper, though written in the then-block, was moved before the when-block"
+          fixtures.stub(gateway)
+          result == "item"
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "an @Interactions cardinality helper placed in a then-block is enforced when satisfied"() {
+    when:
+    runner.runWithImports('''
+      class ExpectFixtures {
+        @Interactions
+        void expectCharge(List<String> gateway) {
+          1 * gateway.add("charge")
+        }
+      }
+
+      class CallerSpec extends Specification {
+        def "the cardinality is enforced against the when-action"() {
+          given:
+          List<String> gateway = Mock()
+          ExpectFixtures fixtures = new ExpectFixtures()
+
+          when:
+          gateway.add("charge")
+
+          then:
+          fixtures.expectCharge(gateway)
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "an @Interactions cardinality helper placed in a then-block fails when unsatisfied"() {
+    when:
+    runner.runWithImports('''
+      class ExpectFixtures {
+        @Interactions
+        void expectCharge(List<String> gateway) {
+          1 * gateway.add("charge")
+        }
+      }
+
+      class CallerSpec extends Specification {
+        def "the cardinality is enforced against the when-action"() {
+          given:
+          List<String> gateway = Mock()
+          ExpectFixtures fixtures = new ExpectFixtures()
+
+          when:
+          gateway.add("not charge")
+
+          then:
+          fixtures.expectCharge(gateway)
+        }
+      }
+    ''')
+
+    then:
+    thrown(TooFewInvocationsError)
+  }
+
+  def "relocation works across a chain of then/and-then blocks"() {
+    when:
+    runner.runWithImports('''
+      class ExpectFixtures {
+        @Interactions
+        void expectCharge(List<String> gateway) {
+          1 * gateway.add("charge")
+        }
+      }
+
+      class CallerSpec extends Specification {
+        def "the helper in a trailing and-block is still relocated"() {
+          given:
+          List<String> gateway = Mock()
+          ExpectFixtures fixtures = new ExpectFixtures()
+
+          when:
+          gateway.add("charge")
+
+          then:
+          true
+
+          and:
+          fixtures.expectCharge(gateway)
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "a non-top-level @Interactions call in a then-block is not relocated"() {
+    when: "the call's result is consumed, so it cannot move as a whole statement"
+    runner.runWithImports('''
+      class StubFixtures {
+        @Interactions
+        void stub(List<String> gateway) {
+          gateway.get(0) >> "item"
+        }
+      }
+
+      class CallerSpec extends Specification {
+        def "the stub registers too late to affect the when-action"() {
+          given:
+          List<String> gateway = Mock()
+          StubFixtures fixtures = new StubFixtures()
+
+          when:
+          def result = gateway.get(0)
+
+          then: "the call runs in place (after the action), so the stub did not apply"
+          def ignored = fixtures.stub(gateway)
+          result == null
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+
+  static class ComposedFixtures {
+    @Interactions
+    void stubAll(List<String> gateway) {
+      stubOne(gateway)
+    }
+
+    @Interactions
+    void stubOne(List<String> gateway) {
+      1 * gateway.get(0) >> "item"
+    }
+  }
+
+  static class ComposingSupport implements MockInteractionSupport {
+    final Specification specification
+    ComposingSupport(Specification specification) { this.specification = specification }
+
+    void applyStubs(List<String> gateway) {
+      OrderFixtures fixtures = new OrderFixtures()
+      fixtures.stubHappyPath(gateway)
+    }
+  }
+
+  static class OrderFixtures {
+    @Interactions
+    void stubHappyPath(List<String> gateway) {
+      1 * gateway.get(0) >> "item"
+    }
+
+    @Interactions
+    static void staticStubHappyPath(List<String> gateway) {
+      1 * gateway.get(0) >> "item"
+    }
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MockInteractionSupportSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/MockInteractionSupportSpec.groovy
@@ -129,6 +129,19 @@ class MockInteractionSupportSpec extends EmbeddedSpecification {
     e.message.contains("Mocks cannot be created in static scope")
   }
 
+  def "interactions declared in a MockInteractionSupport fixture are NOT relocated out of a then-block"() {
+    given: "unlike @Interactions helpers, fixture methods are not moved before the when-block"
+    def collaborator = Mock(List)
+    def fixtures = new StubbingFixture(this)
+
+    when:
+    def result = collaborator.contains("x")
+
+    then: "the fixture runs in place (after the action), so the stub did not apply"
+    fixtures.stubContains(collaborator)
+    result == false
+  }
+
   static class UnattachedFixture implements MockInteractionSupport {
     Specification getSpecification() { null } // never attached
 

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/_Interactions_call_from_a_spec_with_a_typed_receiver_is_rewritten_to_pass_the_spec-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/_Interactions_call_from_a_spec_with_a_typed_receiver_is_rewritten_to_pass_the_spec-groovy5.groovy
@@ -1,0 +1,40 @@
+package aPackage
+import spock.lang.*
+
+class ASpec extends Specification {
+/*--------- tag::snapshot[] ---------*/
+@org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 8, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.SETUP, texts = []), @org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.WHEN, texts = []), @org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.THEN, texts = [])], parameterNames = [])
+public void $spock_feature_0_0() {
+    org.spockframework.runtime.ValueRecorder $spock_valueRecorder = new org.spockframework.runtime.ValueRecorder()
+    org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
+    java.util.List<String> gateway = org.spockframework.runtime.SpecInternals.MockImpl(this, 'gateway', java.util.List)
+    apackage.ASpec$OrderFixtures fixtures = new apackage.ASpec$OrderFixtures()
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
+    fixtures.stubHappyPath(this, gateway)
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
+    try {
+        org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'true', 17, 3, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true))
+    }
+    catch (java.lang.Throwable $spock_condition_throwable) {
+        org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 17, 3, null, $spock_condition_throwable)}
+    finally {
+    }
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
+    this.getSpecificationContext().getMockController().leaveScope()
+}
+
+@spock.lang.Interactions
+public void stubHappyPath(java.util.List<String> gateway) {
+    throw new org.spockframework.runtime.InvalidSpecException('Method \'stubHappyPath\' is annotated with @Interactions and can only declare interactions when called from a Specification with a strongly-typed receiver, or when its explicit-spec overload (with a leading Specification argument) is called directly.')
+}
+
+@spock.lang.Interactions
+public void stubHappyPath(spock.lang.Specification $spec, java.util.List<String> gateway) {
+    org.spockframework.util.Checks.notNull($spec, 'Cannot declare mock interactions: the Specification passed to this @Interactions method is null.')
+    $spec.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(4, 5, '1 * gateway.add(\"y\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('y').build())
+}
+/*--------- end::snapshot[] ---------*/
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/_Interactions_call_from_a_spec_with_a_typed_receiver_is_rewritten_to_pass_the_spec.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/_Interactions_call_from_a_spec_with_a_typed_receiver_is_rewritten_to_pass_the_spec.groovy
@@ -1,0 +1,40 @@
+package aPackage
+import spock.lang.*
+
+class ASpec extends Specification {
+/*--------- tag::snapshot[] ---------*/
+@org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 8, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.SETUP, texts = []), @org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.WHEN, texts = []), @org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.THEN, texts = [])], parameterNames = [])
+public void $spock_feature_0_0() {
+    org.spockframework.runtime.ValueRecorder $spock_valueRecorder = new org.spockframework.runtime.ValueRecorder()
+    org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
+    java.util.List<String> gateway = org.spockframework.runtime.SpecInternals.MockImpl(this, 'gateway', java.util.List)
+    apackage.ASpec$OrderFixtures fixtures = new apackage.ASpec$OrderFixtures()
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
+    fixtures.stubHappyPath(this, gateway)
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
+    try {
+        org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'true', 17, 3, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true))
+    }
+    catch (java.lang.Throwable $spock_condition_throwable) {
+        org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 17, 3, null, $spock_condition_throwable)}
+    finally {
+    }
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
+    this.getSpecificationContext().getMockController().leaveScope()
+}
+
+@spock.lang.Interactions
+public void stubHappyPath(java.util.List<String> gateway) {
+    throw new org.spockframework.runtime.InvalidSpecException('Method \'stubHappyPath\' is annotated with @Interactions and can only declare interactions when called from a Specification with a strongly-typed receiver, or when its explicit-spec overload (with a leading Specification argument) is called directly.')
+}
+
+@spock.lang.Interactions
+public void stubHappyPath(spock.lang.Specification $spec, java.util.List<String> gateway) {
+    org.spockframework.util.Checks.notNull($spec, 'Cannot declare mock interactions: the Specification passed to this @Interactions method is null.')
+    $spec.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(4, 5, '1 * gateway.add(\"y\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('y').build())
+}
+/*--------- end::snapshot[] ---------*/
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/_Interactions_synthesizes_a_companion_overload_and_replaces_the_original_body_with_a_throw-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/_Interactions_synthesizes_a_companion_overload_and_replaces_the_original_body_with_a_throw-groovy5.groovy
@@ -1,0 +1,17 @@
+import spock.lang.Interactions
+
+public class OrderFixtures extends java.lang.Object {
+
+    @spock.lang.Interactions
+    public void stubHappyPath(java.util.List<String> gateway) {
+        throw new org.spockframework.runtime.InvalidSpecException('Method \'stubHappyPath\' is annotated with @Interactions and can only declare interactions when called from a Specification with a strongly-typed receiver, or when its explicit-spec overload (with a leading Specification argument) is called directly.')
+    }
+
+    @spock.lang.Interactions
+    public void stubHappyPath(spock.lang.Specification $spec, java.util.List<String> gateway) {
+        org.spockframework.util.Checks.notNull($spec, 'Cannot declare mock interactions: the Specification passed to this @Interactions method is null.')
+        $spec.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(7, 5, 'gateway.add(\"x\") >> true').addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('x').addConstantResponse(true).build())
+        $spec.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(8, 5, '1 * gateway.add(\"y\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('y').build())
+    }
+
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/_Interactions_synthesizes_a_companion_overload_and_replaces_the_original_body_with_a_throw.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/_Interactions_synthesizes_a_companion_overload_and_replaces_the_original_body_with_a_throw.groovy
@@ -1,0 +1,17 @@
+import spock.lang.Interactions as Interactions
+
+public class OrderFixtures extends java.lang.Object {
+
+    @spock.lang.Interactions
+    public void stubHappyPath(java.util.List<String> gateway) {
+        throw new org.spockframework.runtime.InvalidSpecException('Method \'stubHappyPath\' is annotated with @Interactions and can only declare interactions when called from a Specification with a strongly-typed receiver, or when its explicit-spec overload (with a leading Specification argument) is called directly.')
+    }
+
+    @spock.lang.Interactions
+    public void stubHappyPath(spock.lang.Specification $spec, java.util.List<String> gateway) {
+        org.spockframework.util.Checks.notNull($spec, 'Cannot declare mock interactions: the Specification passed to this @Interactions method is null.')
+        $spec.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(7, 5, 'gateway.add(\"x\") >> true').addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('x').addConstantResponse(true).build())
+        $spec.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(8, 5, '1 * gateway.add(\"y\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('y').build())
+    }
+
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/an__Interactions_call_in_a_then_block_is_relocated_before_the_preceding_when_block-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/an__Interactions_call_in_a_then_block_is_relocated_before_the_preceding_when_block-groovy5.groovy
@@ -1,0 +1,34 @@
+package aPackage
+import spock.lang.*
+
+class ASpec extends Specification {
+/*--------- tag::snapshot[] ---------*/
+@org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 8, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.SETUP, texts = []), @org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.WHEN, texts = []), @org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.THEN, texts = [])], parameterNames = [])
+public void $spock_feature_0_0() {
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
+    java.util.List<String> gateway = org.spockframework.runtime.SpecInternals.MockImpl(this, 'gateway', java.util.List)
+    apackage.ASpec$OrderFixtures fixtures = new apackage.ASpec$OrderFixtures()
+    this.getSpecificationContext().getMockController().enterScope()
+    fixtures.expectCharge(this, gateway)
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
+    gateway.add('charge')
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
+    this.getSpecificationContext().getMockController().leaveScope()
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
+    this.getSpecificationContext().getMockController().leaveScope()
+}
+
+@spock.lang.Interactions
+public void expectCharge(java.util.List<String> gateway) {
+    throw new org.spockframework.runtime.InvalidSpecException('Method \'expectCharge\' is annotated with @Interactions and can only declare interactions when called from a Specification with a strongly-typed receiver, or when its explicit-spec overload (with a leading Specification argument) is called directly.')
+}
+
+@spock.lang.Interactions
+public void expectCharge(spock.lang.Specification $spec, java.util.List<String> gateway) {
+    org.spockframework.util.Checks.notNull($spec, 'Cannot declare mock interactions: the Specification passed to this @Interactions method is null.')
+    $spec.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(4, 5, '1 * gateway.add(\"charge\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('charge').build())
+}
+/*--------- end::snapshot[] ---------*/
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/an__Interactions_call_in_a_then_block_is_relocated_before_the_preceding_when_block.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/an__Interactions_call_in_a_then_block_is_relocated_before_the_preceding_when_block.groovy
@@ -1,0 +1,34 @@
+package aPackage
+import spock.lang.*
+
+class ASpec extends Specification {
+/*--------- tag::snapshot[] ---------*/
+@org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 8, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.SETUP, texts = []), @org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.WHEN, texts = []), @org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.THEN, texts = [])], parameterNames = [])
+public void $spock_feature_0_0() {
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
+    java.util.List<String> gateway = org.spockframework.runtime.SpecInternals.MockImpl(this, 'gateway', java.util.List)
+    apackage.ASpec$OrderFixtures fixtures = new apackage.ASpec$OrderFixtures()
+    this.getSpecificationContext().getMockController().enterScope()
+    fixtures.expectCharge(this, gateway)
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
+    gateway.add('charge')
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
+    org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
+    this.getSpecificationContext().getMockController().leaveScope()
+    org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
+    this.getSpecificationContext().getMockController().leaveScope()
+}
+
+@spock.lang.Interactions
+public void expectCharge(java.util.List<String> gateway) {
+    throw new org.spockframework.runtime.InvalidSpecException('Method \'expectCharge\' is annotated with @Interactions and can only declare interactions when called from a Specification with a strongly-typed receiver, or when its explicit-spec overload (with a leading Specification argument) is called directly.')
+}
+
+@spock.lang.Interactions
+public void expectCharge(spock.lang.Specification $spec, java.util.List<String> gateway) {
+    org.spockframework.util.Checks.notNull($spec, 'Cannot declare mock interactions: the Specification passed to this @Interactions method is null.')
+    $spec.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(4, 5, '1 * gateway.add(\"charge\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('charge').build())
+}
+/*--------- end::snapshot[] ---------*/
+}


### PR DESCRIPTION
Build on the external-interaction SPI with a second mechanism. Annotate a
helper method with `spock.lang.Interactions` to declare interactions on
mocks received as parameters; the method needs no spec parameter and is written
naturally. Mock creation is not allowed (pass the mocks in, or use
`MockInteractionSupport`).

The compiler synthesizes a companion overload that takes the owning
`Specification` as an explicit leading parameter and rewrites the original
method body into a diagnostic-throwing stub. When the helper is called from a
spec on a strongly-typed receiver, `DeepBlockRewriter` rewrites the call to pass
the spec to the companion; a `def`-typed receiver falls through to the throwing
original with a clear message. Static helpers are supported when called
class-qualified (the spec arrives as the injected parameter).

Helpers compose: calls to other @Interactions helpers inside a companion or a
`MockInteractionSupport` method are rewritten to pass the located spec along
(the $spec parameter has no user-visible name, so this is the only way to
chain helpers).

Invalid declarations are rejected with compile errors: a leading Specification
parameter (the compiler adds that parameter to the companion), an abstract
method, a trait method, and a method name where only some overloads carry the
annotation (calls are matched by name, so an unannotated overload would
mis-dispatch after spec injection). The null-spec guard message is
mechanism-specific, so a null $spec no longer reports MockInteractionSupport
advice.

Adds `Interactions`, `CompanionMethodBuilder`, `InteractionsCallDetector`,
the `@Interactions` call-site handling in `DeepBlockRewriter`, and Pass 1 of
`SpockTransform` (companion synthesis across the unit). Tests cover companion
synthesis, typed/def receivers, the explicit-spec overload, static + static-import
behaviour, cross-compilation-unit detection, @CompileStatic resolution,
composition, the validation errors, and AST snapshots of the generated code.