### PR TITLE
Allow declaring mock interactions in @SelfType(Specification) traits

### DIFF
--- a/docs/interaction_based_testing.adoc
+++ b/docs/interaction_based_testing.adoc
@@ -1263,8 +1263,8 @@ include::{sourcedir}/interaction/DetachedMockFactoryDocSpec.groovy[tags=use-cust
 === Declaring Interactions Outside Specifications
 
 `DetachedMockFactory` lets you create a mock outside a `Specification`, but the mock's interactions still have to be declared inside the spec.
-Two mechanisms let you encapsulate interactions (and, for the first one, mock creation) in reusable fixtures.
-Both route everything through the owning spec's mock controller, so the interactions behave exactly like interactions declared in a `setup:` block: the spec must be live (called from within a feature's lifecycle), and cardinality interactions are verified when the spec's controller scope leaves.
+Three mechanisms let you encapsulate interactions (and, for some of them, mock creation) in reusable fixtures.
+All of them route their interactions through the owning spec, so they behave exactly like interactions declared in a `setup:` block: the spec must be live (running inside a feature's lifecycle), and cardinality interactions are verified when the feature method ends.
 
 [[MockInteractionSupport]]
 ==== MockInteractionSupport
@@ -1310,7 +1310,7 @@ include::{sourcedir}/interaction/ExternalMockInteractionsDocSpec.groovy[tags=int
 The receiver must be strongly typed (not `def`), otherwise the call fails with an error explaining what went wrong.
 An overload that takes the `Specification` as an explicit first argument is also available, so you can call the helper with the spec directly where needed.
 
-`@Interactions` helpers compose: an `@Interactions` method (or a `MockInteractionSupport` method) may call another `@Interactions` helper on a strongly-typed receiver, and the spec is passed along automatically.
+`@Interactions` helpers compose: an `@Interactions` method (or a `MockInteractionSupport` method, or a `@SelfType(Specification)` trait method) may call another `@Interactions` helper on a strongly-typed receiver, and the spec is passed along automatically.
 
 A few constraints apply, each enforced with a compile error:
 the method must have a body (it cannot be abstract or declared in a trait),
@@ -1322,7 +1322,27 @@ A `static` import (`import static ...stub`) does not work; call it class-qualifi
 This differs from interactions inside a `Specification` or a `MockInteractionSupport` class, which rely on an implicit spec instance and therefore remain forbidden in `static` scope.
 
 Like an inline interaction, a call to an `@Interactions` helper in a `then:` block is recognized as an interaction declaration and scoped to the preceding `when:` block (see <<Scope of Interactions>>).
-This is specific to `@Interactions` helpers: a call to a `MockInteractionSupport` method is an ordinary method call whose interactions are active from the point it is called, exactly as if they were declared there.
+This is specific to `@Interactions` helpers: a call to a `@SelfType(Specification)` trait helper or a `MockInteractionSupport` method is an ordinary method call whose interactions are active from the point it is called, exactly as if they were declared there.
+
+[[SpecificationTrait]]
+==== @SelfType(Specification) traits
+
+A Groovy trait annotated with `@groovy.transform.SelfType(Specification)` is, by construction, a fragment of a `Specification`: `this` is guaranteed to be a spec wherever the trait is mixed in.
+Such a trait may therefore declare interactions and create mocks directly, exactly as if the code were written inside the spec.
+The methods become reusable helpers that any spec can inherit by implementing the trait.
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/interaction/ExternalMockInteractionsDocSpec.groovy[tags=trait-fixture]
+----
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/interaction/ExternalMockInteractionsDocSpec.groovy[tags=trait-usage]
+----
+
+The self-type may also be a subclass of `Specification`.
+Because a trait method is ultimately invoked on a real spec instance, interactions and mock creation are forbidden in `static` trait methods (a static method has no such instance).
 
 == Further Reading
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -10,7 +10,7 @@ include::include.adoc[]
 
 * Add support for `final` local variables in `where:` blocks, declared at their beginning and evaluated once per feature, scoped to the where-block spockIssue:138[]
 * Improve `TooManyInvocationsError` now reports unsatisfied interactions with argument mismatch details, making it easier to diagnose why invocations didn't match expected interactions spockPull:2315[]
-* Allow declaring mock interactions outside a `Specification` via the `MockInteractionSupport` interface (which also supports mock creation) and the `@Interactions` method annotation, see <<interaction_based_testing.adoc#external-interactions,Declaring Interactions Outside Specifications>>
+* Allow declaring mock interactions outside a `Specification` via the `MockInteractionSupport` interface, the `@Interactions` method annotation, and `@SelfType(Specification)` traits, see <<interaction_based_testing.adoc#external-interactions,Declaring Interactions Outside Specifications>>
 
 === Misc
 

--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -46,6 +46,7 @@ public class AstNodeCache {
   public final ClassNode MockController = ClassHelper.makeWithoutCaching(MockController.class);
   public final ClassNode SpecificationContext = ClassHelper.makeWithoutCaching(SpecificationContext.class);
   public final ClassNode MockInteractionSupport = ClassHelper.makeWithoutCaching(spock.mock.MockInteractionSupport.class);
+  public final ClassNode SelfType = ClassHelper.makeWithoutCaching(groovy.transform.SelfType.class);
   public final ClassNode InvalidSpecException = ClassHelper.makeWithoutCaching(InvalidSpecException.class);
   public final ClassNode Checks = ClassHelper.makeWithoutCaching(org.spockframework.util.Checks.class);
   public final ClassNode DataVariableMultiplication = ClassHelper.makeWithoutCaching(DataVariableMultiplication.class);

--- a/spock-core/src/main/java/org/spockframework/compiler/ExternalInteractionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ExternalInteractionRewriter.java
@@ -28,6 +28,7 @@ import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
 import org.spockframework.compiler.model.ExternalInteractionMethod;
+import org.spockframework.util.Nullable;
 import org.spockframework.util.ObjectUtil;
 
 import java.util.List;
@@ -41,8 +42,9 @@ import static org.spockframework.compiler.AstUtil.createDirectMethodCall;
  * offered to {@link InteractionRewriter}; matched statements are replaced with
  * the registration call ({@code mockController.addInteraction(...)}). Built-in
  * creation calls ({@code Mock()}/{@code Stub()}/{@code Spy()} ...) are either
- * expanded (interface mechanism) or rejected as a compile error (annotation
- * mechanism), controlled by {@code allowCreation}. Calls to other
+ * expanded ({@code MockInteractionSupport} classes and
+ * {@code @SelfType(Specification)} traits) or rejected as a compile error
+ * ({@code @Interactions} methods), controlled by {@code allowCreation}. Calls to other
  * {@code @Interactions} helpers anywhere in the body are rewritten to pass the
  * located spec along, so helpers compose.
  *
@@ -59,16 +61,19 @@ public class ExternalInteractionRewriter {
 
   /**
    * @param allowCreation    whether built-in creation calls may be expanded
-   *                         (interface mechanism) or are rejected (annotation
-   *                         mechanism).
+   *                         (support classes and spec traits) or are rejected
+   *                         ({@code @Interactions} methods).
    * @param allowStaticScope see {@link IRewriteResources#isStaticInteractionScopeAllowed()}.
    * @param specNullMessage  the message of the {@code Checks.notNull} guard that
    *                         is prepended to every rewritten method, protecting
    *                         against a {@code null} located spec; mechanism-specific
-   *                         so the failure tells the user what to fix.
+   *                         so the failure tells the user what to fix. May be
+   *                         {@code null} to skip the guard when the reference is
+   *                         non-null by construction (a
+   *                         {@code @SelfType(Specification)} trait's {@code this}).
    */
   public ExternalInteractionRewriter(AstNodeCache nodeCache, ErrorReporter errorReporter,
-      SourceLookup sourceLookup, boolean allowCreation, boolean allowStaticScope, String specNullMessage) {
+      SourceLookup sourceLookup, boolean allowCreation, boolean allowStaticScope, @Nullable String specNullMessage) {
     this.nodeCache = nodeCache;
     this.errorReporter = errorReporter;
     this.sourceLookup = sourceLookup;
@@ -114,7 +119,7 @@ public class ExternalInteractionRewriter {
     rewrote |= rewriteNestedInteractionsCalls(method, body, specificationReferenceFactory);
 
     // guard the located spec: anything we rewrote depends on it being non-null
-    if (rewrote) {
+    if (rewrote && specNullMessage != null) {
       statements.add(0, createSpecificationNotNullCheck(specificationReferenceFactory.get()));
     }
   }

--- a/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpockTransform.java
@@ -77,9 +77,10 @@ public class SpockTransform implements ASTTransformation {
         for (ClassNode clazz : classes)
           processInteractionsMethods(clazz, errorReporter, sourceLookup);
 
-        // Pass 2: process specs and MockInteractionSupport classes.
+        // Pass 2: process specs, @SelfType(Specification) traits and MockInteractionSupport classes.
         for (ClassNode clazz : classes) {
           boolean spec = isSpec(clazz);
+          boolean trait = isSpecificationTrait(clazz);
           boolean support = isMockInteractionSupport(clazz);
 
           if (spec && support) {
@@ -91,6 +92,8 @@ public class SpockTransform implements ASTTransformation {
 
           if (spec) {
             processSpec(sourceUnit, clazz, errorReporter, sourceLookup);
+          } else if (trait) {
+            processSpecificationTrait(sourceUnit, clazz, errorReporter, sourceLookup);
           } else if (support) {
             processMockInteractionSupport(sourceUnit, clazz, errorReporter, sourceLookup);
           }
@@ -126,7 +129,8 @@ public class SpockTransform implements ASTTransformation {
         }
         if (onTrait) {
           errorReporter.error(
-              "Method '%s' is annotated with @Interactions but declared in a trait, which is not supported.",
+              "Method '%s' is annotated with @Interactions but declared in a trait, which is not supported; "
+                  + "a @SelfType(Specification) trait can declare interactions without the annotation.",
               method.getName());
           continue;
         }
@@ -233,6 +237,40 @@ public class SpockTransform implements ASTTransformation {
       return clazz.implementsInterface(nodeCache.MockInteractionSupport);
     }
 
+    /**
+     * A trait whose {@code @SelfType} constraint guarantees that {@code this} is a
+     * {@code Specification}. SpockTransform (a global transform) runs before
+     * Groovy's trait transform, so the trait is still a plain class with
+     * instance-method bodies here; rewriting them against {@code this} lets the
+     * trait transform relocate the bodies into the {@code $Trait$Helper} and
+     * rewrite {@code this} to the {@code $self} parameter (the real spec instance).
+     */
+    boolean isSpecificationTrait(ClassNode clazz) {
+      return Traits.isTrait(clazz) && selfTypeIsSpecification(clazz);
+    }
+
+    boolean selfTypeIsSpecification(ClassNode clazz) {
+      for (AnnotationNode annotation : clazz.getAnnotations(nodeCache.SelfType)) {
+        Expression value = annotation.getMember("value");
+        for (ClassNode selfType : selfTypes(value)) {
+          if (selfType.isDerivedFrom(nodeCache.Specification) || selfType.equals(nodeCache.Specification))
+            return true;
+        }
+      }
+      return false;
+    }
+
+    List<ClassNode> selfTypes(Expression value) {
+      List<ClassNode> types = new ArrayList<>();
+      if (value instanceof ClassExpression) {
+        types.add(value.getType());
+      } else if (value instanceof ListExpression) {
+        for (Expression element : ((ListExpression) value).getExpressions())
+          if (element instanceof ClassExpression) types.add(element.getType());
+      }
+      return types;
+    }
+
     void processMockInteractionSupport(SourceUnit sourceUnit, ClassNode clazz, ErrorReporter errorReporter, SourceLookup sourceLookup) {
       Supplier<Expression> specRef = () -> AstUtil.createDirectMethodCall(
           VariableExpression.THIS_EXPRESSION, nodeCache.MockInteractionSupport_GetSpecification,
@@ -257,6 +295,21 @@ public class SpockTransform implements ASTTransformation {
         if (method.isAbstract() || method.getDeclaringClass() != clazz) continue;
         rewriter.rewriteInPlace(method, specRef);
       }
+    }
+
+    void processSpecificationTrait(SourceUnit sourceUnit, ClassNode clazz, ErrorReporter errorReporter, SourceLookup sourceLookup) {
+      // The spec is `this` (guaranteed a Specification by @SelfType); Groovy's
+      // trait transform later relocates the body and rewrites `this` to `$self`.
+      Supplier<Expression> specRef = () -> new VariableExpression("this");
+      // allowCreation=true (`this` is the spec, so Mock() can route through it);
+      // allowStaticScope=false (a static trait method's `$static$self` is a Class,
+      // not a spec instance, so it cannot reach the controller);
+      // specNullMessage=null skips the guard (`this`/`$self` is non-null by construction).
+      ExternalInteractionRewriter rewriter =
+          new ExternalInteractionRewriter(nodeCache, errorReporter, sourceLookup, true, false, null);
+      rewriteDeclaredMethods(clazz, rewriter, specRef);
+      // No VariableScopeVisitor here: Groovy's trait transform reshapes the bodies
+      // (this -> $self) afterwards and runs its own scope handling.
     }
 
     void processSpec(SourceUnit sourceUnit, ClassNode clazz, ErrorReporter errorReporter, SourceLookup sourceLookup) {

--- a/spock-specs/src/test/groovy/org/spockframework/docs/interaction/ExternalMockInteractionsDocSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/interaction/ExternalMockInteractionsDocSpec.groovy
@@ -1,5 +1,6 @@
 package org.spockframework.docs.interaction
 
+import groovy.transform.SelfType
 import spock.lang.Specification
 import spock.mock.MockInteractionSupport
 import spock.lang.Interactions
@@ -69,3 +70,32 @@ class ExternalMockInteractionsDocSpec extends Specification {
     void audit(String message)
   }
 }
+
+interface GreetingService {
+  String greet(String name)
+}
+
+// tag::trait-fixture[]
+@SelfType(Specification)                       // guarantees `this` is a Specification
+trait GreetingInteractions {
+  void expectHello(GreetingService service) {
+    1 * service.greet("world") >> "hello"
+  }
+}
+// end::trait-fixture[]
+
+// tag::trait-usage[]
+class GreetingSpec extends Specification implements GreetingInteractions {
+  def "a @SelfType(Specification) trait mixes interaction helpers into the spec"() {
+    given:
+    GreetingService service = Mock()
+
+    when:
+    expectHello(service)                       // trait method, inherited by the spec
+    def reply = service.greet("world")
+
+    then:
+    reply == "hello"
+  }
+}
+// end::trait-usage[]

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec.groovy
@@ -127,4 +127,25 @@ def "a feature"() {
     then: "the companion call is moved out of the then-block to before the when-block, like an inline interaction"
     snapshotter.assertThat(result.source).matchesSnapshot(SNAPSHOT_ID)
   }
+
+  def "a @SelfType(Specification) trait has its creation and interactions rewritten, then relocated to the helper against \$self"() {
+    when:
+    def result = compiler.transpile('''
+import groovy.transform.SelfType
+import spock.lang.Specification
+
+@SelfType(Specification)
+trait OrderInteractions {
+  def createAndStub() {
+    def gateway = Mock(List)
+    gateway.add("x") >> true
+    1 * gateway.add("y")
+    return gateway
+  }
+}
+''')
+
+    then: "SpockTransform rewrote against `this` (pre-relocation); the trait transform moved the body into the helper and rewrote `this` to `\$self`"
+    snapshotter.assertThat(result.source).matchesSnapshot(SNAPSHOT_ID)
+  }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/TraitInteractionsSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/TraitInteractionsSpec.groovy
@@ -1,0 +1,247 @@
+package org.spockframework.smoke.mock
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.mock.TooFewInvocationsError
+
+class TraitInteractionsSpec extends EmbeddedSpecification {
+  def "an unsatisfied cardinality interaction declared in a @SelfType(Specification) trait is enforced on the mixing spec"() {
+    when:
+    runner.runWithImports('''
+      import groovy.transform.SelfType
+
+      @SelfType(Specification)
+      trait OrderInteractions {
+        void expectCharge(List<String> gateway) {
+          1 * gateway.add("charge")
+        }
+      }
+
+      class OrderSpec extends Specification implements OrderInteractions {
+        def "charges once"() {
+          given:
+          List<String> gateway = Mock()
+
+          when:
+          expectCharge(gateway)
+          // gateway.add("charge") is never invoked -> interaction unsatisfied
+
+          then:
+          true
+        }
+      }
+    ''')
+
+    then:
+    thrown(TooFewInvocationsError)
+  }
+
+  def "a satisfied cardinality interaction declared in a trait passes"() {
+    when:
+    runner.runWithImports('''
+      import groovy.transform.SelfType
+
+      @SelfType(Specification)
+      trait OrderInteractions {
+        void expectCharge(List<String> gateway) {
+          1 * gateway.add("charge")
+        }
+      }
+
+      class OrderSpec extends Specification implements OrderInteractions {
+        def "charges once"() {
+          given:
+          List<String> gateway = Mock()
+
+          when:
+          expectCharge(gateway)
+          gateway.add("charge")
+
+          then:
+          true
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "a stubbing interaction declared in a trait takes effect on the spec"() {
+    when:
+    runner.runWithImports('''
+      import groovy.transform.SelfType
+
+      @SelfType(Specification)
+      trait StubbingTrait {
+        void stubContains(List<String> collaborator) {
+          collaborator.contains("x") >> true
+        }
+      }
+
+      class StubbingSpec extends Specification implements StubbingTrait {
+        def "stub takes effect"() {
+          given:
+          List<String> collaborator = Mock()
+
+          when:
+          stubContains(collaborator)
+
+          then:
+          collaborator.contains("x")
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "a trait method can create and stub a mock that routes through the mixing spec"() {
+    when:
+    runner.runWithImports('''
+      import groovy.transform.SelfType
+
+      interface Greeter { String greet() }
+
+      @SelfType(Specification)
+      trait MockFactoryTrait {
+        Greeter createGreeter() {
+          Greeter g = Mock(Greeter)
+          g.greet() >> "hi"
+          return g
+        }
+      }
+
+      class FactorySpec extends Specification implements MockFactoryTrait {
+        def "created mock is stubbed"() {
+          when:
+          Greeter g = createGreeter()
+
+          then:
+          g.greet() == "hi"
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "a static trait method cannot declare interactions"() {
+    when: "a static method has no instance to reach the spec through"
+    compiler.compileWithImports('''
+      import groovy.transform.SelfType
+
+      @SelfType(Specification)
+      trait BadStaticTrait {
+        static void stub(List<String> l) { 1 * l.add("x") }
+      }
+    ''')
+
+    then:
+    Exception e = thrown()
+    e.message.contains("static scope")
+  }
+
+  def "a trait whose self-type extends Specification is also supported"() {
+    when:
+    runner.runWithImports('''
+      import groovy.transform.SelfType
+
+      abstract class BaseSpec extends Specification {}
+
+      @SelfType(BaseSpec)
+      trait OrderInteractions {
+        void expectCharge(List<String> gateway) {
+          1 * gateway.add("charge")
+        }
+      }
+
+      class OrderSpec extends BaseSpec implements OrderInteractions {
+        def "charges once"() {
+          given:
+          List<String> gateway = Mock()
+
+          when:
+          expectCharge(gateway)
+
+          then:
+          true
+        }
+      }
+    ''')
+
+    then:
+    thrown(TooFewInvocationsError)
+  }
+
+  def "a trait method can call an @Interactions helper, passing the spec along"() {
+    when:
+    runner.runWithImports('''
+      import groovy.transform.SelfType
+      import spock.lang.Interactions
+
+      class StubFixtures {
+        @Interactions
+        void stubGet(List<String> collaborator) {
+          collaborator.get(0) >> "item"
+        }
+      }
+
+      @SelfType(Specification)
+      trait ComposingTrait {
+        void applyStubs(List<String> collaborator) {
+          StubFixtures fixtures = new StubFixtures()
+          fixtures.stubGet(collaborator)
+        }
+      }
+
+      class ComposingSpec extends Specification implements ComposingTrait {
+        def "the helper's stub takes effect through the trait"() {
+          given:
+          List<String> collaborator = Mock()
+
+          when:
+          applyStubs(collaborator)
+
+          then:
+          collaborator.get(0) == "item"
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+
+  def "interactions declared in a trait are NOT relocated out of a then-block"() {
+    when: "unlike @Interactions helpers, trait interaction methods are not moved before the when-block"
+    runner.runWithImports('''
+      import groovy.transform.SelfType
+
+      @SelfType(Specification)
+      trait StubbingTrait {
+        void stubGet(List<String> collaborator) {
+          collaborator.get(0) >> "item"
+        }
+      }
+
+      class StubbingSpec extends Specification implements StubbingTrait {
+        def "the stub registers too late to affect the when-action"() {
+          given:
+          List<String> collaborator = Mock()
+
+          when:
+          def result = collaborator.get(0)
+
+          then: "the trait helper runs in place (after the action), so the stub did not apply"
+          stubGet(collaborator)
+          result == null
+        }
+      }
+    ''')
+
+    then:
+    noExceptionThrown()
+  }
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/a__SelfType_Specification__trait_has_its_creation_and_interactions_rewritten__then_relocated_to_the_helper_against__self-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/a__SelfType_Specification__trait_has_its_creation_and_interactions_rewritten__then_relocated_to_the_helper_against__self-groovy5.groovy
@@ -1,0 +1,33 @@
+import groovy.transform.SelfType
+import spock.lang.Specification
+
+@groovy.transform.Trait
+@groovy.transform.SelfType(value = spock.lang.Specification)
+public abstract interface OrderInteractions extends java.lang.Object {
+
+    @org.codehaus.groovy.transform.trait.Traits$Implemented
+    public abstract java.lang.Object createAndStub() {
+    }
+
+}
+import groovy.transform.SelfType
+import spock.lang.Specification
+
+@groovy.transform.SelfType(value = spock.lang.Specification)
+@groovy.transform.Generated
+public abstract static class OrderInteractions$Trait$Helper extends java.lang.Object {
+
+    public static void $init$(OrderInteractions $self) {
+    }
+
+    public static void $static$init$(java.lang.Class<OrderInteractions> $static$self) {
+    }
+
+    public static java.lang.Object createAndStub(OrderInteractions $self) {
+        java.lang.Object gateway = org.spockframework.runtime.SpecInternals.MockImpl($self, 'gateway', null, java.util.List)
+        $self.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(9, 5, 'gateway.add(\"x\") >> true').addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('x').addConstantResponse(true).build())
+        $self.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(10, 5, '1 * gateway.add(\"y\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('y').build())
+        return gateway
+    }
+
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/a__SelfType_Specification__trait_has_its_creation_and_interactions_rewritten__then_relocated_to_the_helper_against__self.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/mock/ExternalMockInteractionsAstSpec/a__SelfType_Specification__trait_has_its_creation_and_interactions_rewritten__then_relocated_to_the_helper_against__self.groovy
@@ -1,0 +1,33 @@
+import groovy.transform.SelfType as SelfType
+import spock.lang.Specification as Specification
+
+@groovy.transform.Trait
+@groovy.transform.SelfType(value = spock.lang.Specification)
+public abstract interface OrderInteractions extends java.lang.Object {
+
+    @org.codehaus.groovy.transform.trait.Traits$Implemented
+    public abstract java.lang.Object createAndStub() {
+    }
+
+}
+import groovy.transform.SelfType as SelfType
+import spock.lang.Specification as Specification
+
+@groovy.transform.SelfType(value = spock.lang.Specification)
+@groovy.transform.Generated
+public abstract static class OrderInteractions$Trait$Helper extends java.lang.Object {
+
+    public static void $init$(OrderInteractions $self) {
+    }
+
+    public static void $static$init$(java.lang.Class<OrderInteractions> $static$self) {
+    }
+
+    public static java.lang.Object createAndStub(OrderInteractions $self) {
+        java.lang.Object gateway = org.spockframework.runtime.SpecInternals.MockImpl($self, 'gateway', null, java.util.List)
+        $self.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(9, 5, 'gateway.add(\"x\") >> true').addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('x').addConstantResponse(true).build())
+        $self.getSpecificationContext().getMockController().addInteraction(new org.spockframework.mock.runtime.InteractionBuilder(10, 5, '1 * gateway.add(\"y\")').setFixedCount(1).addEqualTarget(gateway).addEqualMethodName('add').setArgListKind(true, false).addEqualArg('y').build())
+        return gateway
+    }
+
+}


### PR DESCRIPTION
Add a third external-interaction mechanism: a Groovy trait annotated with
`@groovy.transform.SelfType(Specification)`. The self-type guarantees that
`this` is a Specification wherever the trait is mixed in, so the trait's methods
may declare interactions and create mocks exactly as inside a spec, becoming
reusable helpers that any spec inherits by implementing the trait.

SpockTransform (a global transform) runs before Groovy's trait transform, so it
sees the trait as a plain class with instance-method bodies and rewrites them
against `this`. Groovy's trait transform then relocates each body into the
`$Trait$Helper` and rewrites `this` to the `$self` parameter (the real spec
instance at runtime). Detection is `Traits.isTrait` plus a `@SelfType` value
assignable to `Specification`; the trait rewriter reuses the external SPI with
`guardSpecNotNull=false` (the receiver is non-null by construction). The
self-type may be a subclass of `Specification`; static trait methods cannot
declare interactions (no instance to reach the spec through).

Adds the trait detection and `processSpecificationTrait` in `SpockTransform`, the
`SelfType` AST node, behaviour tests (cardinality, stubbing, mock creation,
self-type subclass, static-method error), and an AST snapshot showing the
relocated `$self`-based output.