### PR TITLE
Add standalone @DataProvider methods

### DIFF
--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -556,6 +556,7 @@ include::{sourcedir}/datadriven/DataSpec.groovy[tag=standalone-data-provider]
 The body accepts the full `where:` block grammar: <<Local Variables in the where-block,local variables>>, data tables, data pipes, derived data variables, `combined:` multiplications, and a trailing `filter:` block.
 All resulting data variables become the tuple columns, in declaration order; where-block local variables do not.
 A single column yields `Tuple1` rows, so it is consumed as `[a] << provider()`, not as `a << provider()`.
+The body may optionally open with a `where:` label, mirroring a feature method's where-block; any other label (a feature-method label such as `expect:`, or a misplaced `where:`) is a compile error.
 
 [source,groovy,indent=0]
 ----

--- a/docs/data_driven_testing.adoc
+++ b/docs/data_driven_testing.adoc
@@ -541,6 +541,44 @@ include::{sourcedir}/datadriven/DataSpec.groovy[tag=excluding-iterations]
 After all iterations have completed, the zero-argument `close` method is called on all data providers that have
 such a method.
 
+== Standalone Data Provider Methods
+
+Sometimes the same data should drive several features, possibly even across specifications.
+A method annotated with `@DataProvider` makes the `where:` block grammar reusable:
+its body is written exactly like the content of a `where:` block, and calling the method returns a fresh, lazy `Iterator` over the resulting rows.
+Each row is an arity-specific Groovy tuple (`Tuple1`, `Tuple2`, ...), so the method can feed any feature through the existing <<Multi-Variable Data Pipes,multi-variable data pipe>>:
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/datadriven/DataSpec.groovy[tag=standalone-data-provider]
+----
+
+The body accepts the full `where:` block grammar: <<Local Variables in the where-block,local variables>>, data tables, data pipes, derived data variables, `combined:` multiplications, and a trailing `filter:` block.
+All resulting data variables become the tuple columns, in declaration order; where-block local variables do not.
+A single column yields `Tuple1` rows, so it is consumed as `[a] << provider()`, not as `a << provider()`.
+
+[source,groovy,indent=0]
+----
+include::{sourcedir}/datadriven/DataSpec.groovy[tag=standalone-data-provider-parameters]
+----
+
+A `@DataProvider` method:
+
+* may be declared on any class, not only on specifications, and may be `static` or an instance method;
+* inside a specification may read `@Shared` and `static` fields but not plain instance fields, exactly like a `where:` block; on any other class instance fields are accessible as usual;
+* may declare method parameters; like where-block local variables they are in scope for the whole body without becoming tuple columns, and a name collision between a parameter and a data variable or where-block local variable is a compile error.
+  Unlike where-block local variables, parameters are owned by the caller and are never closed automatically;
+* may be declared `def`, in which case the return type is replaced by `Iterator<TupleN>` matching the column count; an explicitly declared return type must be `java.util.Iterator` and is validated at compile time;
+* does not support `@CompileStatic`, since the `where:` block grammar is inherently dynamic.
+
+The returned iterator implements `AutoCloseable`.
+Closing it closes any `AutoCloseable` where-block local variables in reverse declaration order, and the iterator also closes itself once it is exhausted, so the variables are released even if the iterator is consumed indirectly, for example via `provider().collect { ... }`.
+A feature consuming the provider through a data pipe closes the iterator automatically when the feature finishes, as described in <<Closing of Data Providers>>.
+The iterator also reports the expected number of rows, so the consuming feature gets an accurate <<Number of Iterations,iteration count>> where it is known.
+
+NOTE: The arity-specific tuple classes are version-dependent: Groovy 2.5 only ships `Tuple1` through `Tuple9`, Groovy 3.0 and newer add `Tuple10` through `Tuple16`.
+For arities the current Groovy version does not ship, the rows fall back to the generic `groovy.lang.Tuple`.
+
 == Unrolled Iteration Names
 
 By default, the names of unrolled iterations are the name of the feature, plus the data variables and the iteration

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -9,6 +9,7 @@ include::include.adoc[]
 === Enhancements
 
 * Add support for `final` local variables in `where:` blocks, declared at their beginning and evaluated once per feature, scoped to the where-block spockIssue:138[]
+* Add standalone `@DataProvider` methods whose body uses the `where:` block grammar and which return a lazy `Iterator` of tuples, consumable by any feature via `[a, b] << provider()`
 * Improve `TooManyInvocationsError` now reports unsatisfied interactions with argument mismatch details, making it easier to diagnose why invocations didn't match expected interactions spockPull:2315[]
 
 === Misc

--- a/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/AstNodeCache.java
@@ -125,6 +125,14 @@ public class AstNodeCache {
   public final MethodNode SpecificationContext_SetCurrentBlock =
       SpecificationContext.getDeclaredMethods(org.spockframework.runtime.SpecificationContext.SET_CURRENT_BLOCK).get(0);
 
+  // standalone @DataProvider support; intentionally contains no Tuple1..Tuple16 entries,
+  // those classes are version-dependent and resolved dynamically where needed
+  public final ClassNode StandaloneDataProviders = ClassHelper.makeWithoutCaching(org.spockframework.runtime.StandaloneDataProviders.class);
+  public final ClassNode StandaloneDataProviderDescriptor = ClassHelper.makeWithoutCaching(org.spockframework.runtime.StandaloneDataProviderDescriptor.class);
+
+  public final MethodNode StandaloneDataProviders_DataIterator =
+      StandaloneDataProviders.getDeclaredMethods("dataIterator").get(0);
+
   public final MethodNode List_Get =
       ClassHelper.LIST_TYPE.getDeclaredMethods("get").get(0);
 
@@ -140,6 +148,7 @@ public class AstNodeCache {
   public final ClassNode FieldMetadata = ClassHelper.makeWithoutCaching(FieldMetadata.class);
   public final ClassNode FeatureMetadata = ClassHelper.makeWithoutCaching(FeatureMetadata.class);
   public final ClassNode DataProviderMetadata = ClassHelper.makeWithoutCaching(DataProviderMetadata.class);
+  public final ClassNode StandaloneDataProviderMetadata = ClassHelper.makeWithoutCaching(StandaloneDataProviderMetadata.class);
   public final ClassNode DataProcessorMetadata = ClassHelper.makeWithoutCaching(DataProcessorMetadata.class);
   public final ClassNode BlockMetadata = ClassHelper.makeWithoutCaching(BlockMetadata.class);
   public final ClassNode BlockKind = ClassHelper.makeWithoutCaching(BlockKind.class);

--- a/spock-core/src/main/java/org/spockframework/compiler/BlockParser.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/BlockParser.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler;
+
+import org.spockframework.compiler.model.*;
+
+import java.util.List;
+
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.stmt.Statement;
+
+/**
+ * Splits the statements of a {@link Method} into {@link Block}s by their statement labels and
+ * validates the block grammar via {@link BlockParseInfo} successors.
+ * <p>
+ * Extracted from {@link SpecParser} so that both feature methods and standalone
+ * {@code @DataProvider} methods (see {@link DataProviderMethodRewriter}) share the same block
+ * detection, label handling and grammar validation.
+ */
+final class BlockParser {
+  private BlockParser() {}
+
+  static void parseBlocks(Method method) throws InvalidSpecCompileException {
+    List<Statement> stats = AstUtil.getStatements(method.getAst());
+    Block currBlock = method.addBlock(new AnonymousBlock(method));
+
+    String statementLabelToTransplant = null;
+    for (Statement stat : stats) {
+      if (stat.getStatementLabel() == null) {
+        if (statementLabelToTransplant != null) {
+          stat.setStatementLabel(statementLabelToTransplant);
+        }
+        currBlock.getAst().add(stat);
+      } else {
+        currBlock = addBlock(method, stat);
+      }
+      // Usually, you have a label on a statement like
+      //
+      // combined:
+      //   x << [1]
+      //
+      // and the label stays on that statement and could be used in later stages of the AST processing.
+      // Especially for "combined" this is essential for proper operation.
+      //
+      // But if the label has a description like
+      //
+      // combined: 'combined with x'
+      //   x << [1]
+      //
+      // then the description is added as "text" to the current block and the whole statement is swallowed.
+      // If the label is needed for further processing like for "combined", this is then missing,
+      // so transplant the label to the following statement which it actually affects.
+      statementLabelToTransplant = (getDescription(stat) == null) ? null : stat.getStatementLabel();
+    }
+
+    checkIsValidSuccessor(method, BlockParseInfo.METHOD_END,
+        method.getAst().getLastLineNumber(), method.getAst().getLastColumnNumber());
+
+    // set the block metadata index for each block this must be equal to the index of the block in the @BlockMetadata annotation
+    int i = -1;
+    for (Block block : method.getBlocks()) {
+      if(!block.hasBlockMetadata()) continue;
+      block.setBlockMetaDataIndex(++i);
+    }
+    // now that statements have been copied to blocks, the original statement
+    // list is cleared; statements will be copied back after rewriting is done
+    stats.clear();
+  }
+
+  private static Block addBlock(Method method, Statement stat) throws InvalidSpecCompileException {
+    String label = stat.getStatementLabel();
+
+    for (BlockParseInfo blockInfo: BlockParseInfo.values()) {
+      if (!label.equals(blockInfo.toString())) continue;
+
+      checkIsValidSuccessor(method, blockInfo, stat.getLineNumber(), stat.getColumnNumber());
+      Block block = blockInfo.addNewBlock(method);
+      String description = getDescription(stat);
+      if (description == null)
+        block.getAst().add(stat);
+      else
+        block.getDescriptions().add(description);
+
+      return block;
+    }
+
+    throw new InvalidSpecCompileException(stat, "Unrecognized block label: " + label);
+  }
+
+  private static String getDescription(Statement stat) {
+    ConstantExpression constExpr = AstUtil.getExpression(stat, ConstantExpression.class);
+    return constExpr == null || !(constExpr.getValue() instanceof String) ?
+        null : (String)constExpr.getValue();
+  }
+
+  private static void checkIsValidSuccessor(Method method, BlockParseInfo blockInfo, int line, int column)
+      throws InvalidSpecCompileException {
+    BlockParseInfo oldBlockInfo = method.getLastBlock().getParseInfo();
+    if (!oldBlockInfo.getSuccessors(method).contains(blockInfo))
+      throw new InvalidSpecCompileException(line, column, "'%s' is not allowed here; instead, use one of: %s",
+          blockInfo, oldBlockInfo.getSuccessors(method), method.getName(), oldBlockInfo, blockInfo);
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/DataProviderMethodRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DataProviderMethodRewriter.java
@@ -1,0 +1,519 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler;
+
+import groovy.lang.Tuple;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.GenericsType;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.expr.*;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ReturnStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.classgen.VariableScopeVisitor;
+import org.codehaus.groovy.control.SourceUnit;
+import org.spockframework.compiler.WhereBlockRewriter.DataProviderArtifact;
+import org.spockframework.compiler.condition.DefaultConditionErrorRecorders;
+import org.spockframework.compiler.condition.IConditionErrorRecorders;
+import org.spockframework.compiler.model.*;
+import org.spockframework.runtime.model.StandaloneDataProviderMetadata;
+import org.spockframework.util.Nullable;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Rewrites a single standalone {@code @DataProvider} method: parses its body as where-block
+ * content via the shared {@link WhereBlockRewriter} builder, then replaces the body with a call
+ * to {@code StandaloneDataProviders.dataIterator(...)} whose arguments are the parsed artifacts
+ * emitted as inline closures.
+ * <p>
+ * Emitting inline (rather than as sibling methods like the feature path) is what makes the
+ * method's parameters and {@code this} visible to the where-block variables, data providers,
+ * data processor and filter, via ordinary closure capture.
+ *
+ * @since 2.5
+ */
+class DataProviderMethodRewriter {
+  private static final String ITERATOR_NAME = Iterator.class.getName();
+  private static final String GENERIC_TUPLE_NAME = Tuple.class.getName();
+  private static final int HIGHEST_FIXED_TUPLE_ARITY = 16;
+
+  private final MethodNode methodNode;
+  private final AstNodeCache nodeCache;
+  private final SourceUnit sourceUnit;
+  private final ErrorReporter errorReporter;
+  private final SourceLookup sourceLookup;
+
+  private boolean inSpec;
+  private IRewriteResources resources;
+  private InstanceFieldAccessChecker instanceFieldAccessChecker;
+  private ErrorRethrowerUsageDetector errorRethrowerUsageDetector;
+  private boolean defineErrorRethrower;
+  private WhereBlock whereBlock;
+  @Nullable
+  private FilterBlock filterBlock;
+
+  DataProviderMethodRewriter(MethodNode methodNode, AstNodeCache nodeCache, SourceUnit sourceUnit,
+                             ErrorReporter errorReporter, SourceLookup sourceLookup) {
+    this.methodNode = methodNode;
+    this.nodeCache = nodeCache;
+    this.sourceUnit = sourceUnit;
+    this.errorReporter = errorReporter;
+    this.sourceLookup = sourceLookup;
+  }
+
+  void rewrite() {
+    if (AstUtil.hasAnnotation(methodNode, groovy.transform.CompileStatic.class)
+      || AstUtil.hasAnnotation(methodNode.getDeclaringClass(), groovy.transform.CompileStatic.class)) {
+      errorReporter.error(methodNode,
+        "@DataProvider methods do not support @CompileStatic, because the where-block grammar is inherently dynamic");
+      return;
+    }
+
+    List<Statement> bodyStats = methodNode.getCode() == null ? null : AstUtil.getStatements(methodNode);
+    if (bodyStats == null || bodyStats.isEmpty()) {
+      errorReporter.error(methodNode, atLeastOneDataVariable());
+      return;
+    }
+
+    inSpec = methodNode.getDeclaringClass().isDerivedFrom(nodeCache.Specification);
+
+    buildBlocks(bodyStats);
+
+    resources = new DataProviderMethodRewriteResources(whereBlock.getParent(), nodeCache, sourceLookup, errorReporter,
+      new DefaultConditionErrorRecorders(nodeCache));
+    instanceFieldAccessChecker = new InstanceFieldAccessChecker(resources);
+    errorRethrowerUsageDetector = new ErrorRethrowerUsageDetector();
+
+    DeepBlockRewriter deep = new DeepBlockRewriter(resources);
+    deep.visit(whereBlock);
+    defineErrorRethrower = deep.isDeepNonGroupedConditionFound();
+
+    WhereBlockRewriter parsed = WhereBlockRewriter.parse(whereBlock, resources, inSpec);
+
+    validate(parsed);
+    if (sourceUnit.getErrorCollector().hasErrors()) {
+      return;
+    }
+
+    rewriteBody(parsed);
+    addMetadataAnnotation(parsed);
+    // the inline closures emitted above capture the method's parameters and 'this'; their
+    // scopes must be rebuilt because any class-wide scope fixup (SpockTransform's, for a
+    // spec) already ran on the raw body, and on a plain class none ran at all
+    new VariableScopeVisitor(sourceUnit).visitClass(methodNode.getDeclaringClass());
+  }
+
+  // splits the method body into where-block content and the optional trailing filter-block
+  // content, mirroring how SpecParser separates the blocks of a feature method
+  private void buildBlocks(List<Statement> bodyStats) {
+    Spec spec = new Spec(methodNode.getDeclaringClass());
+    HelperMethod method = new HelperMethod(spec, methodNode);
+    whereBlock = (WhereBlock) method.addBlock(new WhereBlock(method));
+
+    List<Statement> currentBlockStats = whereBlock.getAst();
+    for (Statement stat : bodyStats) {
+      if (filterBlock == null && isFilterLabeled(stat)) {
+        filterBlock = (FilterBlock) method.addBlock(new FilterBlock(method));
+        currentBlockStats = filterBlock.getAst();
+      }
+      currentBlockStats.add(stat);
+    }
+    bodyStats.clear();
+  }
+
+  private static boolean isFilterLabeled(Statement stat) {
+    List<String> labels = stat.getStatementLabels();
+    return labels != null && labels.contains(BlockParseInfo.FILTER.toString());
+  }
+
+  private void validate(WhereBlockRewriter parsed) {
+    List<VariableExpression> dataVariables = parsed.getDataProcessorVariables();
+    if (dataVariables.isEmpty()) {
+      // parsing errors (including where-block variables without a data variable) have
+      // already been reported; only a silently empty body still needs one
+      if (!sourceUnit.getErrorCollector().hasErrors()) {
+        errorReporter.error(methodNode, atLeastOneDataVariable());
+      }
+      return;
+    }
+
+    validateParameterNames(parsed);
+    handleReturnType(dataVariables);
+  }
+
+  // method parameters are body-wide inputs sharing the body's name namespace with
+  // where-block variables and data variables, so collisions are rejected
+  private void validateParameterNames(WhereBlockRewriter parsed) {
+    List<String> dataVariableNames = dataVariableNames(parsed);
+    for (Parameter parameter : methodNode.getParameters()) {
+      String name = parameter.getName();
+      if (dataVariableNames.contains(name)) {
+        errorReporter.error(positionOf(parameter),
+          "Data variable '%s' collides with a method parameter of the same name", name);
+      } else if (parsed.getWhereBlockVariableNames().contains(name)) {
+        errorReporter.error(positionOf(parameter),
+          "where-block variable '%s' collides with a method parameter of the same name", name);
+      }
+    }
+  }
+
+  private ASTNode positionOf(Parameter parameter) {
+    return parameter.getLineNumber() > 0 ? parameter : methodNode;
+  }
+
+  private void handleReturnType(List<VariableExpression> dataVariables) {
+    int arity = dataVariables.size();
+    if (methodNode.isDynamicReturnType() || ClassHelper.OBJECT_TYPE.equals(methodNode.getReturnType())) {
+      methodNode.setReturnType(createIteratorOfTupleType(arity));
+      return;
+    }
+
+    ClassNode returnType = methodNode.getReturnType();
+    if (!ITERATOR_NAME.equals(returnType.getName())) {
+      errorReporter.error(methodNode,
+        "@DataProvider method '%s' must be declared 'def' or with a return type of java.util.Iterator, but is declared as '%s'",
+        methodNode.getName(), returnType.getName());
+      return;
+    }
+
+    GenericsType[] generics = returnType.getGenericsTypes();
+    if (generics == null || generics.length != 1 || generics[0].isWildcard()) {
+      // raw Iterator (or an unbounded wildcard) is acceptable
+      return;
+    }
+
+    String elementTypeName = generics[0].getType().getName();
+    if (GENERIC_TUPLE_NAME.equals(elementTypeName)) {
+      return;
+    }
+    Integer declaredArity = tupleArity(elementTypeName);
+    if (declaredArity == null) {
+      errorReporter.error(methodNode,
+        "@DataProvider method '%s' declares return type Iterator<%s>, but the element type must be groovy.lang.Tuple or an arity-specific Tuple class",
+        methodNode.getName(), elementTypeName);
+    } else if (declaredArity != arity) {
+      errorReporter.error(methodNode,
+        "@DataProvider method '%s' declares return type Iterator<Tuple%d>, but produces %d data variable(s) %s; declare Iterator<Tuple%d> or 'def'",
+        methodNode.getName(), declaredArity, arity,
+        dataVariables.stream().map(VariableExpression::getName).collect(toList()), arity);
+    }
+    // any element type arguments (e.g. Iterator<Tuple2<Integer, Integer>>) are accepted as
+    // the user's authoritative declaration; cells are not always literals, so they are not
+    // re-derived or cross-checked
+  }
+
+  @Nullable
+  private static Integer tupleArity(String className) {
+    String prefix = GENERIC_TUPLE_NAME;
+    if (!className.startsWith(prefix)) {
+      return null;
+    }
+    try {
+      int arity = Integer.parseInt(className.substring(prefix.length()));
+      return (arity >= 1 && arity <= HIGHEST_FIXED_TUPLE_ARITY) ? arity : null;
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private ClassNode createIteratorOfTupleType(int arity) {
+    ClassNode iteratorType = ClassHelper.makeWithoutCaching(Iterator.class).getPlainNodeReference();
+    iteratorType.setGenericsTypes(new GenericsType[]{new GenericsType(resolveTupleType(arity))});
+    return iteratorType;
+  }
+
+  // resolves the arity-specific tuple class dynamically: the available arities depend on
+  // the Groovy version being compiled against (2.5 only ships Tuple1-Tuple9), so no
+  // Tuple1..Tuple16 class may be referenced statically
+  private static ClassNode resolveTupleType(int arity) {
+    if (arity <= HIGHEST_FIXED_TUPLE_ARITY) {
+      try {
+        return ClassHelper.makeWithoutCaching(
+          Class.forName(GENERIC_TUPLE_NAME + arity, false, Tuple.class.getClassLoader())).getPlainNodeReference();
+      } catch (ClassNotFoundException ignored) {
+        // fall through to the generic Tuple
+      }
+    }
+    return ClassHelper.makeWithoutCaching(Tuple.class).getPlainNodeReference();
+  }
+
+  private void rewriteBody(WhereBlockRewriter parsed) {
+    ClosureExpression whereVariablesClosure = createWhereVariablesClosure(parsed);
+    List<Expression> dataProviderDescriptors = createDataProviderDescriptors(parsed);
+    ClosureExpression dataProcessorClosure = createDataProcessorClosure(parsed);
+    ClosureExpression filterClosure = createFilterClosure(parsed);
+    ClosureExpression dataVariableMultiplicationsClosure = createDataVariableMultiplicationsClosure(parsed);
+
+    ArgumentListExpression args = new ArgumentListExpression();
+    args.addExpression(stringArray(dataVariableNames(parsed)));
+    args.addExpression(orNull(whereVariablesClosure));
+    args.addExpression(new ArrayExpression(nodeCache.StandaloneDataProviderDescriptor, dataProviderDescriptors));
+    args.addExpression(dataProcessorClosure);
+    args.addExpression(orNull(filterClosure));
+    args.addExpression(orNull(dataVariableMultiplicationsClosure));
+
+    MethodCallExpression call = AstUtil.createDirectMethodCall(
+      new ClassExpression(nodeCache.StandaloneDataProviders),
+      nodeCache.StandaloneDataProviders_DataIterator,
+      args);
+
+    BlockStatement newCode = new BlockStatement();
+    newCode.addStatement(new ReturnStatement(call));
+    methodNode.setCode(newCode);
+  }
+
+  @Nullable
+  private ClosureExpression createWhereVariablesClosure(WhereBlockRewriter parsed) {
+    if (parsed.getWhereBlockVariableStatements().isEmpty()) {
+      return null;
+    }
+
+    if (inSpec) {
+      instanceFieldAccessChecker.check(parsed.getWhereBlockVariableStatements());
+    }
+
+    List<Statement> stats = new ArrayList<>(parsed.getWhereBlockVariableStatements());
+    List<Expression> values = parsed.getWhereBlockVariableNames().stream()
+      .map(VariableExpression::new)
+      .collect(toList());
+    stats.add(new ReturnStatement(new ArrayExpression(ClassHelper.OBJECT_TYPE, values)));
+
+    return createClosure(Parameter.EMPTY_ARRAY, stats);
+  }
+
+  private List<Expression> createDataProviderDescriptors(WhereBlockRewriter parsed) {
+    List<Expression> descriptors = new ArrayList<>();
+    for (DataProviderArtifact dataProvider : parsed.getDataProviders()) {
+      Expression dataProviderExpr = dataProvider.getExpression();
+
+      List<Statement> stats = new ArrayList<>();
+      if (defineErrorRethrower && errorRethrowerUsageDetector.detectedErrorRethrowerUsage(dataProviderExpr)) {
+        resources.getErrorRecorders().defineErrorRethrower(stats);
+      }
+      ReturnStatement returnStat = new ReturnStatement(dataProviderExpr);
+      returnStat.setSourcePosition(dataProviderExpr);
+      stats.add(returnStat);
+
+      Parameter[] params = concatParameters(
+        dataProvider.getPreviousDataTableVariables().stream()
+          .map(previousDataTableVariable -> new Parameter(
+            ClassHelper.LIST_TYPE.getPlainNodeReference(),
+            WhereBlockRewriter.getDataTableParameterName(previousDataTableVariable)))
+          .toArray(Parameter[]::new),
+        createWhereVariableParameters(parsed));
+
+      descriptors.add(new ConstructorCallExpression(nodeCache.StandaloneDataProviderDescriptor,
+        new ArgumentListExpression(
+          new ArrayList<>(java.util.Arrays.asList(
+            createClosure(params, stats),
+            stringArray(dataProvider.getDataVariables()),
+            stringArray(dataProvider.getPreviousDataTableVariables()),
+            new ConstantExpression(dataProviderExpr.getLineNumber()))))));
+    }
+    return descriptors;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ClosureExpression createDataProcessorClosure(WhereBlockRewriter parsed) {
+    List<Statement> stats = new ArrayList<>(parsed.getDataProcessorStatements());
+
+    if (inSpec) {
+      instanceFieldAccessChecker.check(stats);
+    }
+    if (defineErrorRethrower && errorRethrowerUsageDetector.detectedErrorRethrowerUsage(stats)) {
+      resources.getErrorRecorders().defineErrorRethrower(stats);
+    }
+
+    stats.add(
+      new ReturnStatement(
+        new ArrayExpression(
+          ClassHelper.OBJECT_TYPE,
+          (List) parsed.getDataProcessorVariables())));
+
+    Parameter[] params = concatParameters(
+      parsed.getDataProcessorParameters().toArray(Parameter.EMPTY_ARRAY),
+      createWhereVariableParameters(parsed));
+
+    return createClosure(params, stats);
+  }
+
+  @Nullable
+  private ClosureExpression createFilterClosure(WhereBlockRewriter parsed) {
+    if (filterBlock == null) {
+      return null;
+    }
+
+    DeepBlockRewriter deep = new DeepBlockRewriter(resources);
+    deep.visit(filterBlock);
+
+    List<Statement> filterStats = new ArrayList<>(filterBlock.getAst());
+    filterBlock.getAst().clear();
+
+    if (inSpec) {
+      instanceFieldAccessChecker.check(filterStats);
+    }
+
+    if (deep.isConditionFound()) {
+      resources.getErrorRecorders().defineValueRecorder(filterStats);
+    }
+    if (deep.isDeepNonGroupedConditionFound()) {
+      resources.getErrorRecorders().defineErrorRethrower(filterStats);
+    }
+
+    Parameter[] params = concatParameters(
+      parsed.getDataProcessorVariables()
+        .stream()
+        .map(variable -> new Parameter(ClassHelper.OBJECT_TYPE, variable.getName()))
+        .toArray(Parameter[]::new),
+      createWhereVariableParameters(parsed));
+
+    return createClosure(params, filterStats);
+  }
+
+  @Nullable
+  private ClosureExpression createDataVariableMultiplicationsClosure(WhereBlockRewriter parsed) {
+    if (parsed.getDataVariableMultiplications().isEmpty()) {
+      return null;
+    }
+
+    List<Statement> stats = new ArrayList<>();
+    stats.add(
+      new ReturnStatement(
+        new ArrayExpression(
+          nodeCache.DataVariableMultiplication,
+          parsed.getDataVariableMultiplications())));
+
+    return createClosure(Parameter.EMPTY_ARRAY, stats);
+  }
+
+  private void addMetadataAnnotation(WhereBlockRewriter parsed) {
+    AnnotationNode ann = new AnnotationNode(nodeCache.StandaloneDataProviderMetadata);
+    ann.addMember(StandaloneDataProviderMetadata.DATA_VARIABLES,
+      new ListExpression(dataVariableNames(parsed).stream()
+        .map(ConstantExpression::new)
+        .map(Expression.class::cast)
+        .collect(toList())));
+    ann.addMember(StandaloneDataProviderMetadata.LINE, new ConstantExpression(methodNode.getLineNumber()));
+    methodNode.addAnnotation(ann);
+  }
+
+  private static List<String> dataVariableNames(WhereBlockRewriter parsed) {
+    return parsed.getDataProcessorVariables().stream()
+      .map(VariableExpression::getName)
+      .collect(toList());
+  }
+
+  private static Parameter[] createWhereVariableParameters(WhereBlockRewriter parsed) {
+    return parsed.getWhereBlockVariableNames().stream()
+      .map(name -> new Parameter(ClassHelper.OBJECT_TYPE, name))
+      .toArray(Parameter[]::new);
+  }
+
+  private static Parameter[] concatParameters(Parameter[] a, Parameter[] b) {
+    if (b.length == 0) return a;
+    Parameter[] result = java.util.Arrays.copyOf(a, a.length + b.length);
+    System.arraycopy(b, 0, result, a.length, b.length);
+    return result;
+  }
+
+  private ClosureExpression createClosure(Parameter[] params, List<Statement> stats) {
+    ClosureExpression closure = new ClosureExpression(params, new BlockStatement(stats, null));
+    closure.setSourcePosition(methodNode);
+    return closure;
+  }
+
+  private static Expression stringArray(List<String> values) {
+    return new ArrayExpression(ClassHelper.STRING_TYPE,
+      values.stream().map(ConstantExpression::new).map(Expression.class::cast).collect(toList()));
+  }
+
+  private static Expression orNull(@Nullable Expression expression) {
+    return expression == null ? ConstantExpression.NULL : expression;
+  }
+
+  private String atLeastOneDataVariable() {
+    return String.format(java.util.Locale.ROOT,
+      "@DataProvider method '%s' must declare at least one data variable (e.g. 'x << [1, 2]')",
+      methodNode.getName());
+  }
+
+  private static class DataProviderMethodRewriteResources implements IRewriteResources {
+    private final Method method;
+    private final AstNodeCache nodeCache;
+    private final SourceLookup lookup;
+    private final ErrorReporter errorReporter;
+    private final IConditionErrorRecorders errorRecorders;
+
+    DataProviderMethodRewriteResources(Method method, AstNodeCache nodeCache, SourceLookup lookup,
+                                       ErrorReporter errorReporter, IConditionErrorRecorders errorRecorders) {
+      this.method = method;
+      this.nodeCache = nodeCache;
+      this.lookup = lookup;
+      this.errorReporter = errorReporter;
+      this.errorRecorders = errorRecorders;
+    }
+
+    @Override
+    public Method getCurrentMethod() {
+      return method;
+    }
+
+    @Override
+    public Block getCurrentBlock() {
+      return method.getFirstBlock();
+    }
+
+    @Override
+    public VariableExpression captureOldValue(Expression oldValue) {
+      throw new UnsupportedOperationException("This should only be called when processing a then-block");
+    }
+
+    @Override
+    public MethodCallExpression getMockInvocationMatcher() {
+      return null;
+    }
+
+    @Override
+    public AstNodeCache getAstNodeCache() {
+      return nodeCache;
+    }
+
+    @Override
+    public String getSourceText(ASTNode node) {
+      return lookup.lookup(node);
+    }
+
+    @Override
+    public ErrorReporter getErrorReporter() {
+      return errorReporter;
+    }
+
+    @Override
+    public IConditionErrorRecorders getErrorRecorders() {
+      return errorRecorders;
+    }
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/DataProviderMethodRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DataProviderMethodRewriter.java
@@ -295,13 +295,9 @@ class DataProviderMethodRewriter {
       instanceFieldAccessChecker.check(parsed.getWhereBlockVariableStatements());
     }
 
-    List<Statement> stats = new ArrayList<>(parsed.getWhereBlockVariableStatements());
-    List<Expression> values = parsed.getWhereBlockVariableNames().stream()
-      .map(VariableExpression::new)
-      .collect(toList());
-    stats.add(new ReturnStatement(new ArrayExpression(ClassHelper.OBJECT_TYPE, values)));
-
-    return createClosure(Parameter.EMPTY_ARRAY, stats);
+    // reuse the feature path's value-array construction so a where-block variable initializer that
+    // throws still closes the AutoCloseable values created before it, instead of leaking them
+    return createClosure(Parameter.EMPTY_ARRAY, parsed.createWhereVariableValueStatements());
   }
 
   private List<Expression> createDataProviderDescriptors(WhereBlockRewriter parsed) {

--- a/spock-core/src/main/java/org/spockframework/compiler/DataProviderMethodRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DataProviderMethodRewriter.java
@@ -35,6 +35,7 @@ import org.spockframework.compiler.condition.DefaultConditionErrorRecorders;
 import org.spockframework.compiler.condition.IConditionErrorRecorders;
 import org.spockframework.compiler.model.*;
 import org.spockframework.runtime.model.StandaloneDataProviderMetadata;
+import org.spockframework.util.Identifiers;
 import org.spockframework.util.Nullable;
 
 import java.util.ArrayList;
@@ -100,9 +101,11 @@ class DataProviderMethodRewriter {
 
     inSpec = methodNode.getDeclaringClass().isDerivedFrom(nodeCache.Specification);
 
-    buildBlocks(bodyStats);
+    if (!buildBlocks(bodyStats)) {
+      return;
+    }
 
-    resources = new DataProviderMethodRewriteResources(whereBlock.getParent(), nodeCache, sourceLookup, errorReporter,
+    resources = new DataProviderMethodRewriteResources(whereBlock, nodeCache, sourceLookup, errorReporter,
       new DefaultConditionErrorRecorders(nodeCache));
     instanceFieldAccessChecker = new InstanceFieldAccessChecker(resources);
     errorRethrowerUsageDetector = new ErrorRethrowerUsageDetector();
@@ -126,27 +129,44 @@ class DataProviderMethodRewriter {
     new VariableScopeVisitor(sourceUnit).visitClass(methodNode.getDeclaringClass());
   }
 
-  // splits the method body into where-block content and the optional trailing filter-block
-  // content, mirroring how SpecParser separates the blocks of a feature method
-  private void buildBlocks(List<Statement> bodyStats) {
-    Spec spec = new Spec(methodNode.getDeclaringClass());
-    HelperMethod method = new HelperMethod(spec, methodNode);
-    whereBlock = (WhereBlock) method.addBlock(new WhereBlock(method));
-
-    List<Statement> currentBlockStats = whereBlock.getAst();
-    for (Statement stat : bodyStats) {
-      if (filterBlock == null && isFilterLabeled(stat)) {
-        filterBlock = (FilterBlock) method.addBlock(new FilterBlock(method));
-        currentBlockStats = filterBlock.getAst();
-      }
-      currentBlockStats.add(stat);
+  // A @DataProvider body is where-block content. We open it with a `where:` label (unless the
+  // author already labeled the first statement) and then reuse the shared BlockParser, so the
+  // body is split into blocks and validated against the where-block grammar exactly like a feature
+  // method's where-block. Only where and filter blocks are valid here, so a feature-method block
+  // such as an `expect:` opener is rejected; the parser itself rejects unknown labels and illegal
+  // transitions (a misplaced `where:`, a `combined:`/`filter:` opener, ...).
+  private boolean buildBlocks(List<Statement> bodyStats) {
+    Statement first = bodyStats.get(0);
+    if ((first.getStatementLabels() == null) || first.getStatementLabels().isEmpty()) {
+      first.addStatementLabel(Identifiers.WHERE);
     }
-    bodyStats.clear();
+
+    HelperMethod method = new HelperMethod(new Spec(methodNode.getDeclaringClass()), methodNode);
+    try {
+      BlockParser.parseBlocks(method);
+    } catch (InvalidSpecCompileException e) {
+      errorReporter.error(e);
+      return false;
+    }
+
+    for (Block block : method.getBlocks()) {
+      if (block instanceof WhereBlock) {
+        whereBlock = (WhereBlock) block;
+      } else if (block instanceof FilterBlock) {
+        filterBlock = (FilterBlock) block;
+      } else if (!(block instanceof AnonymousBlock)) {
+        errorReporter.error(blockPosition(block),
+          "'%s:' blocks are not valid in a @DataProvider method; its body uses the where-block grammar, so it may open with an optional 'where:' label and otherwise only use 'and:', 'combined:' and 'filter:'",
+          block.getParseInfo());
+        return false;
+      }
+    }
+    return whereBlock != null;
   }
 
-  private static boolean isFilterLabeled(Statement stat) {
-    List<String> labels = stat.getStatementLabels();
-    return labels != null && labels.contains(BlockParseInfo.FILTER.toString());
+  private ASTNode blockPosition(Block block) {
+    List<Statement> stats = block.getAst();
+    return stats.isEmpty() ? methodNode : stats.get(0);
   }
 
   private void validate(WhereBlockRewriter parsed) {
@@ -457,15 +477,15 @@ class DataProviderMethodRewriter {
   }
 
   private static class DataProviderMethodRewriteResources implements IRewriteResources {
-    private final Method method;
+    private final WhereBlock whereBlock;
     private final AstNodeCache nodeCache;
     private final SourceLookup lookup;
     private final ErrorReporter errorReporter;
     private final IConditionErrorRecorders errorRecorders;
 
-    DataProviderMethodRewriteResources(Method method, AstNodeCache nodeCache, SourceLookup lookup,
+    DataProviderMethodRewriteResources(WhereBlock whereBlock, AstNodeCache nodeCache, SourceLookup lookup,
                                        ErrorReporter errorReporter, IConditionErrorRecorders errorRecorders) {
-      this.method = method;
+      this.whereBlock = whereBlock;
       this.nodeCache = nodeCache;
       this.lookup = lookup;
       this.errorReporter = errorReporter;
@@ -474,12 +494,14 @@ class DataProviderMethodRewriter {
 
     @Override
     public Method getCurrentMethod() {
-      return method;
+      return whereBlock.getParent();
     }
 
     @Override
     public Block getCurrentBlock() {
-      return method.getFirstBlock();
+      // the shared BlockParser prepends an empty AnonymousBlock, so the where block is not
+      // method.getFirstBlock(); deep rewriting operates on the where block itself
+      return whereBlock;
     }
 
     @Override

--- a/spock-core/src/main/java/org/spockframework/compiler/DataProviderMethodTransformation.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/DataProviderMethodTransformation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.compiler;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+
+/**
+ * AST transformation for rewriting standalone {@code @DataProvider} methods.
+ * <p>
+ * This is a local transform attached to the {@code spock.lang.DataProvider} annotation, so it
+ * fires regardless of the enclosing class. Within the {@code SEMANTIC_ANALYSIS} phase the global
+ * {@link SpockTransform} runs first; it leaves {@code @DataProvider} methods untouched (see
+ * {@link SpecParser}), so this transform always receives the raw, unrewritten method body,
+ * whether the method is declared inside a specification or on a plain class.
+ *
+ * @since 2.5
+ */
+@GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
+public class DataProviderMethodTransformation implements ASTTransformation {
+  static final AstNodeCache nodeCache = new AstNodeCache();
+
+  @Override
+  public void visit(ASTNode[] nodes, SourceUnit sourceUnit) {
+    ErrorReporter errorReporter = new ErrorReporter(sourceUnit);
+
+    try (SourceLookup sourceLookup = new SourceLookup(sourceUnit)) {
+      for (ASTNode node : nodes) {
+        if (!(node instanceof MethodNode)) {
+          continue;
+        }
+        MethodNode methodNode = (MethodNode) node;
+        try {
+          new DataProviderMethodRewriter(methodNode, nodeCache, sourceUnit, errorReporter, sourceLookup).rewrite();
+        } catch (Exception e) {
+          errorReporter.error(
+            "Unexpected error during compilation of @DataProvider method '%s'. Maybe you have used invalid Spock syntax? Anyway, please file a bug report at https://issues.spockframework.org.",
+            e, methodNode.getName());
+        }
+      }
+    }
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
@@ -17,6 +17,7 @@
 package org.spockframework.compiler;
 
 import org.spockframework.compiler.model.*;
+import spock.lang.DataProvider;
 import spock.lang.Shared;
 
 import java.util.List;
@@ -101,7 +102,11 @@ public class SpecParser implements GroovyClassVisitor {
   }
 
   private boolean isIgnoredMethod(MethodNode method) {
-    return AstUtil.isSynthetic(method);
+    // @DataProvider methods are owned by their own local transform; they must be skipped
+    // here because their where-block grammar would otherwise classify them as feature
+    // methods (any statement label triggers isFeatureMethod) or relocate their body as
+    // a helper method, before the local transform ever sees them
+    return AstUtil.isSynthetic(method) || AstUtil.hasAnnotation(method, DataProvider.class);
   }
 
   // IDEA: check for misspellings other than wrong capitalization

--- a/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/SpecParser.java
@@ -23,7 +23,6 @@ import spock.lang.Shared;
 import java.util.List;
 
 import org.codehaus.groovy.ast.*;
-import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.ast.stmt.Statement;
 import spock.lang.Verify;
 import spock.lang.VerifyAll;
@@ -180,7 +179,7 @@ public class SpecParser implements GroovyClassVisitor {
   private void buildFeatureMethod(MethodNode method) {
     Method feature = new FeatureMethod(spec, method, featureMethodCount++);
     try {
-      buildBlocks(feature);
+      BlockParser.parseBlocks(feature);
     } catch (InvalidSpecCompileException e) {
       errorReporter.error(e);
       return;
@@ -221,84 +220,4 @@ public class SpecParser implements GroovyClassVisitor {
     stats.clear();
   }
 
-  private void buildBlocks(Method method) throws InvalidSpecCompileException {
-    List<Statement> stats = AstUtil.getStatements(method.getAst());
-    Block currBlock = method.addBlock(new AnonymousBlock(method));
-
-    String statementLabelToTransplant = null;
-    for (Statement stat : stats) {
-      if (stat.getStatementLabel() == null) {
-        if (statementLabelToTransplant != null) {
-          stat.setStatementLabel(statementLabelToTransplant);
-        }
-        currBlock.getAst().add(stat);
-      } else {
-        currBlock = addBlock(method, stat);
-      }
-      // Usually, you have a label on a statement like
-      //
-      // combined:
-      //   x << [1]
-      //
-      // and the label stays on that statement and could be used in later stages of the AST processing.
-      // Especially for "combined" this is essential for proper operation.
-      //
-      // But if the label has a description like
-      //
-      // combined: 'combined with x'
-      //   x << [1]
-      //
-      // then the description is added as "text" to the current block and the whole statement is swallowed.
-      // If the label is needed for further processing like for "combined", this is then missing,
-      // so transplant the label to the following statement which it actually affects.
-      statementLabelToTransplant = (getDescription(stat) == null) ? null : stat.getStatementLabel();
-    }
-
-    checkIsValidSuccessor(method, BlockParseInfo.METHOD_END,
-        method.getAst().getLastLineNumber(), method.getAst().getLastColumnNumber());
-
-    // set the block metadata index for each block this must be equal to the index of the block in the @BlockMetadata annotation
-    int i = -1;
-    for (Block block : method.getBlocks()) {
-      if(!block.hasBlockMetadata()) continue;
-      block.setBlockMetaDataIndex(++i);
-    }
-    // now that statements have been copied to blocks, the original statement
-    // list is cleared; statements will be copied back after rewriting is done
-    stats.clear();
-  }
-
-  private Block addBlock(Method method, Statement stat) throws InvalidSpecCompileException {
-    String label = stat.getStatementLabel();
-
-    for (BlockParseInfo blockInfo: BlockParseInfo.values()) {
-      if (!label.equals(blockInfo.toString())) continue;
-
-      checkIsValidSuccessor(method, blockInfo, stat.getLineNumber(), stat.getColumnNumber());
-      Block block = blockInfo.addNewBlock(method);
-      String description = getDescription(stat);
-      if (description == null)
-        block.getAst().add(stat);
-      else
-        block.getDescriptions().add(description);
-
-      return block;
-    }
-
-    throw new InvalidSpecCompileException(stat, "Unrecognized block label: " + label);
-  }
-
-  private String getDescription(Statement stat) {
-    ConstantExpression constExpr = AstUtil.getExpression(stat, ConstantExpression.class);
-    return constExpr == null || !(constExpr.getValue() instanceof String) ?
-        null : (String)constExpr.getValue();
-  }
-
-  private void checkIsValidSuccessor(Method method, BlockParseInfo blockInfo, int line, int column)
-      throws InvalidSpecCompileException {
-    BlockParseInfo oldBlockInfo = method.getLastBlock().getParseInfo();
-    if (!oldBlockInfo.getSuccessors(method).contains(blockInfo))
-      throw new InvalidSpecCompileException(line, column, "'%s' is not allowed here; instead, use one of: %s",
-          blockInfo, oldBlockInfo.getSuccessors(method), method.getName(), oldBlockInfo, blockInfo);
-  }
 }

--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -1018,11 +1018,29 @@ public class WhereBlockRewriter {
   private void createWhereVariablesMethod() {
     if (whereBlockVariables.isEmpty()) return;
 
-    List<Statement> declarations = whereBlockVariables.stream()
-      .map(var -> var.statement)
-      .collect(toList());
-    instanceFieldAccessChecker.check(declarations);
+    instanceFieldAccessChecker.check(getWhereBlockVariableStatements());
 
+    MethodNode method = new MethodNode(
+      InternalIdentifiers.getWhereVariablesName(whereBlock.getParent().getAst().getName()),
+      Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
+      ClassHelper.OBJECT_TYPE.makeArray(),
+      Parameter.EMPTY_ARRAY,
+      ClassNode.EMPTY_ARRAY,
+      new BlockStatement(createWhereVariableValueStatements(), null));
+
+    whereBlock.getParent().getParent().getAst().addMethod(method);
+  }
+
+  /**
+   * Builds the statements that evaluate every where-block variable initializer and return their
+   * values as an {@code Object[]}, ordered by declaration. Each slot is filled as soon as its
+   * initializer runs, and the whole sequence is wrapped in a try/catch that closes the
+   * {@link AutoCloseable} values created so far when a later initializer throws (slots whose
+   * initializer never ran stay {@code null} and are skipped by the close helper), so a partial
+   * failure never leaks a resource. Shared by the feature where-variables method and the
+   * standalone {@code @DataProvider} where-variables closure so both get the same safety.
+   */
+  public List<Statement> createWhereVariableValueStatements() {
     int variableCount = (int) whereBlockVariableNames().count();
     Statement valuesDecl = new ExpressionStatement(
       new DeclarationExpression(
@@ -1031,9 +1049,6 @@ public class WhereBlockRewriter {
         new ArrayExpression(ClassHelper.OBJECT_TYPE, null,
           singletonList(new ConstantExpression(variableCount)))));
 
-    // each declaration fills its slot(s) right away, so that when a later initializer throws,
-    // the catch block can close the values that already exist; slots whose initializer never
-    // ran are still null and are skipped by the close helper
     List<Statement> tryStats = new ArrayList<>();
     int slot = 0;
     for (WhereBlockVariable variable : whereBlockVariables) {
@@ -1063,15 +1078,7 @@ public class WhereBlockRewriter {
             new VariableExpression(failure)))),
       new ThrowStatement(new VariableExpression(failure))), null)));
 
-    MethodNode method = new MethodNode(
-      InternalIdentifiers.getWhereVariablesName(whereBlock.getParent().getAst().getName()),
-      Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
-      ClassHelper.OBJECT_TYPE.makeArray(),
-      Parameter.EMPTY_ARRAY,
-      ClassNode.EMPTY_ARRAY,
-      new BlockStatement(Arrays.asList(valuesDecl, tryCatch), null));
-
-    whereBlock.getParent().getParent().getAst().addMethod(method);
+    return Arrays.asList(valuesDecl, tryCatch);
   }
 
   /**

--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -101,9 +101,9 @@ public class WhereBlockRewriter {
    * @param checkInstanceFieldAccess whether referenced fields must be {@code @Shared} or static
    *   (required inside a {@code Specification}, not on a plain class)
    */
-  public static WhereBlockRewriter parse(WhereBlock block, FilterBlock filterBlock, IRewriteResources resources,
+  public static WhereBlockRewriter parse(WhereBlock block, IRewriteResources resources,
                                          boolean checkInstanceFieldAccess) {
-    WhereBlockRewriter rewriter = new WhereBlockRewriter(block, filterBlock, resources, false, checkInstanceFieldAccess);
+    WhereBlockRewriter rewriter = new WhereBlockRewriter(block, null, resources, false, checkInstanceFieldAccess);
     rewriter.parse();
     return rewriter;
   }
@@ -551,7 +551,7 @@ public class WhereBlockRewriter {
     return results;
   }
 
-  private String getDataTableParameterName(String dataTableVariable) {
+  static String getDataTableParameterName(String dataTableVariable) {
     return "$spock_p_" + dataTableVariable;
   }
 

--- a/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/WhereBlockRewriter.java
@@ -53,10 +53,12 @@ public class WhereBlockRewriter {
   private final FilterBlock filterBlock;
   private final IRewriteResources resources;
   private final boolean defineErrorRethrower;
+  private final boolean checkInstanceFieldAccess;
   private final InstanceFieldAccessChecker instanceFieldAccessChecker;
   private final ErrorRethrowerUsageDetector errorRethrowerUsageDetector;
 
-  private int dataProviderCount = 0;
+  // artifacts of the data providers (in declaration order), recorded while parsing
+  private final List<DataProviderArtifact> dataProviders = new ArrayList<>();
   private final List<VariableExpression> dataTableVars = new ArrayList<>();
   // parameters of the data processor method (one for each data provider)
   private final List<Parameter> dataProcessorParams = new ArrayList<>();
@@ -73,20 +75,40 @@ public class WhereBlockRewriter {
   // provider/processor method as trailing parameters named after these variables
   private final List<WhereBlockVariable> whereBlockVariables = new ArrayList<>();
 
-  private WhereBlockRewriter(WhereBlock whereBlock, FilterBlock filterBlock, IRewriteResources resources, boolean defineErrorRethrower) {
+  private WhereBlockRewriter(WhereBlock whereBlock, FilterBlock filterBlock, IRewriteResources resources,
+                             boolean defineErrorRethrower, boolean checkInstanceFieldAccess) {
     this.whereBlock = whereBlock;
     this.filterBlock = filterBlock;
     this.resources = resources;
     this.defineErrorRethrower = defineErrorRethrower;
+    this.checkInstanceFieldAccess = checkInstanceFieldAccess;
     instanceFieldAccessChecker = new InstanceFieldAccessChecker(resources);
     errorRethrowerUsageDetector = defineErrorRethrower ? new ErrorRethrowerUsageDetector() : null;
   }
 
   public static void rewrite(WhereBlock block, FilterBlock filterBlock, IRewriteResources resources, boolean defineErrorRethrower) {
-    new WhereBlockRewriter(block, filterBlock, resources, defineErrorRethrower).rewrite();
+    WhereBlockRewriter rewriter = new WhereBlockRewriter(block, filterBlock, resources, defineErrorRethrower, true);
+    rewriter.parse();
+    rewriter.handleFeatureParameters();
+    rewriter.emitFeatureMethods();
   }
 
-  private void rewrite() {
+  /**
+   * Parses the where-block content into its data-flow artifacts (data providers, data processor,
+   * where-block variables, multiplications) without emitting any methods. Used by the standalone
+   * {@code @DataProvider} path, which emits the artifacts as inline closures instead.
+   *
+   * @param checkInstanceFieldAccess whether referenced fields must be {@code @Shared} or static
+   *   (required inside a {@code Specification}, not on a plain class)
+   */
+  public static WhereBlockRewriter parse(WhereBlock block, FilterBlock filterBlock, IRewriteResources resources,
+                                         boolean checkInstanceFieldAccess) {
+    WhereBlockRewriter rewriter = new WhereBlockRewriter(block, filterBlock, resources, false, checkInstanceFieldAccess);
+    rewriter.parse();
+    return rewriter;
+  }
+
+  private void parse() {
     ListIterator<Statement> stats = whereBlock.getAst().listIterator();
     collectWhereBlockVariables(stats);
     ConstructorCallExpression multiplier = null;
@@ -159,8 +181,12 @@ public class WhereBlockRewriter {
       resources.getErrorReporter().error(
         whereBlockVariablesRequireDataVariable(whereBlockVariables.get(0).statement));
     }
+  }
 
-    handleFeatureParameters();
+  private void emitFeatureMethods() {
+    for (int i = 0; i < dataProviders.size(); i++) {
+      createDataProviderMethod(dataProviders.get(i), i);
+    }
     createDataProcessorMethod();
     createWhereVariablesMethod();
     createDataVariableMultiplicationsMethod();
@@ -454,8 +480,26 @@ public class WhereBlockRewriter {
     return result;
   }
 
-  private void createDataProviderMethod(Expression dataProviderExpr, int nextDataVariableIndex, boolean addDataTableParameters) {
-    instanceFieldAccessChecker.check(dataProviderExpr);
+  // records the data provider artifact for later emission; the per-provider state
+  // (data variables, previous data table variables) must be captured eagerly because
+  // it depends on the parse progress at this point
+  private void recordDataProvider(Expression dataProviderExpr, int nextDataVariableIndex, boolean addDataTableParameters) {
+    if (checkInstanceFieldAccess) {
+      instanceFieldAccessChecker.check(dataProviderExpr);
+    }
+
+    List<String> dataVariables = new ArrayList<>();
+    for (int i = nextDataVariableIndex; i < dataProcessorVars.size(); i++) {
+      dataVariables.add(dataProcessorVars.get(i).getName());
+    }
+
+    dataProviders.add(new DataProviderArtifact(dataProviderExpr, dataVariables,
+      addDataTableParameters ? getPreviousDataTableVariables(nextDataVariableIndex) : Collections.emptyList(),
+      addDataTableParameters));
+  }
+
+  private void createDataProviderMethod(DataProviderArtifact dataProvider, int dataProviderIndex) {
+    Expression dataProviderExpr = dataProvider.getExpression();
 
     List<Statement> dataProviderStats = new ArrayList<>();
     if (defineErrorRethrower && errorRethrowerUsageDetector.detectedErrorRethrowerUsage(dataProviderExpr)) {
@@ -468,23 +512,23 @@ public class WhereBlockRewriter {
 
     MethodNode method =
       new MethodNode(
-        InternalIdentifiers.getDataProviderName(whereBlock.getParent().getAst().getName(), dataProviderCount++),
+        InternalIdentifiers.getDataProviderName(whereBlock.getParent().getAst().getName(), dataProviderIndex),
         Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
         ClassHelper.OBJECT_TYPE,
         // previous-data-table parameters (data tables only) followed by the where-block
         // variable parameters that are passed to every provider
         concatParameters(
-          addDataTableParameters ? createPreviousDataTableParameters(nextDataVariableIndex) : Parameter.EMPTY_ARRAY,
+          createPreviousDataTableParameters(dataProvider),
           createWhereVariableParameters()),
         ClassNode.EMPTY_ARRAY,
         new BlockStatement(dataProviderStats, null));
 
-    method.addAnnotation(createDataProviderAnnotation(dataProviderExpr, nextDataVariableIndex, addDataTableParameters));
+    method.addAnnotation(createDataProviderAnnotation(dataProvider));
     whereBlock.getParent().getParent().getAst().addMethod(method);
   }
 
-  private Parameter[] createPreviousDataTableParameters(int nextDataVariableIndex) {
-    return getPreviousDataTableVariables(nextDataVariableIndex)
+  private Parameter[] createPreviousDataTableParameters(DataProviderArtifact dataProvider) {
+    return dataProvider.getPreviousDataTableVariables()
       .stream()
       .map(previousDataTableVariable -> new Parameter(
         ClassHelper.LIST_TYPE.getPlainNodeReference(),
@@ -511,19 +555,20 @@ public class WhereBlockRewriter {
     return "$spock_p_" + dataTableVariable;
   }
 
-  private AnnotationNode createDataProviderAnnotation(Expression dataProviderExpr, int nextDataVariableIndex,
-                                                      boolean addDataTableParameters) {
+  private AnnotationNode createDataProviderAnnotation(DataProviderArtifact dataProvider) {
     AnnotationNode ann = new AnnotationNode(resources.getAstNodeCache().DataProviderMetadata);
 
-    ann.addMember(DataProviderMetadata.LINE, new ConstantExpression(dataProviderExpr.getLineNumber()));
+    ann.addMember(DataProviderMetadata.LINE, new ConstantExpression(dataProvider.getExpression().getLineNumber()));
 
-    List<Expression> dataVariableNames = new ArrayList<>();
-    for (int i = nextDataVariableIndex; i < dataProcessorVars.size(); i++)
-      dataVariableNames.add(new ConstantExpression(dataProcessorVars.get(i).getName()));
-    ann.addMember(DataProviderMetadata.DATA_VARIABLES, new ListExpression(dataVariableNames));
+    ann.addMember(DataProviderMetadata.DATA_VARIABLES, dataProvider.getDataVariables()
+      .stream()
+      .map(ConstantExpression::new)
+      .collect(collectingAndThen(
+        Collectors.<Expression>toList(),
+        ListExpression::new)));
 
-    if (addDataTableParameters) {
-      ListExpression previousDataTableVariables = getPreviousDataTableVariables(nextDataVariableIndex)
+    if (dataProvider.isDataTable()) {
+      ListExpression previousDataTableVariables = dataProvider.getPreviousDataTableVariables()
         .stream()
         .map(ConstantExpression::new)
         .collect(collectingAndThen(
@@ -550,7 +595,7 @@ public class WhereBlockRewriter {
     VariableExpression arg = (VariableExpression) binExpr.getLeftExpression();
     VariableExpression dataVar = createDataProcessorVariable(arg, sourcePos);
     createDataProcessorStatement(dataVar, new VariableExpression(dataProcessorParameter), sourcePos);
-    createDataProviderMethod(binExpr.getRightExpression(), nextDataVariableIndex, addDataTableParameters);
+    recordDataProvider(binExpr.getRightExpression(), nextDataVariableIndex, addDataTableParameters);
   }
 
   // from: [x, y, z] << [[1, 2, 3]]
@@ -563,7 +608,7 @@ public class WhereBlockRewriter {
     Parameter dataProcessorParameter = createDataProcessorParameter();
     ListExpression list = (ListExpression) binExpr.getLeftExpression();
     rewriteMultiParameterization(list, new VariableExpression(dataProcessorParameter), enclosingStat);
-    createDataProviderMethod(binExpr.getRightExpression(), nextDataVariableIndex, false);
+    recordDataProvider(binExpr.getRightExpression(), nextDataVariableIndex, false);
   }
 
   private void rewriteMultiParameterization(ListExpression list, Expression rightBase, Statement enclosingStat)
@@ -1111,6 +1156,70 @@ public class WhereBlockRewriter {
       blockStat);
 
     filterBlock.getParent().getParent().getAst().addMethod(filterMethod);
+  }
+
+  public List<DataProviderArtifact> getDataProviders() {
+    return dataProviders;
+  }
+
+  public List<Parameter> getDataProcessorParameters() {
+    return dataProcessorParams;
+  }
+
+  public List<Statement> getDataProcessorStatements() {
+    return dataProcessorStats;
+  }
+
+  public List<VariableExpression> getDataProcessorVariables() {
+    return dataProcessorVars;
+  }
+
+  public List<Statement> getWhereBlockVariableStatements() {
+    return whereBlockVariables.stream().map(var -> var.statement).collect(toList());
+  }
+
+  public List<String> getWhereBlockVariableNames() {
+    return whereBlockVariableNames().collect(toList());
+  }
+
+  public List<Expression> getDataVariableMultiplications() {
+    return dataVariableMultiplications;
+  }
+
+  /**
+   * A data provider parsed from where-block content: the provider expression plus the
+   * per-provider state captured while parsing (the data variables it supplies, and for
+   * data tables the previously seen data table variables its cells may reference).
+   */
+  public static class DataProviderArtifact {
+    private final Expression expression;
+    private final List<String> dataVariables;
+    private final List<String> previousDataTableVariables;
+    private final boolean dataTable;
+
+    DataProviderArtifact(Expression expression, List<String> dataVariables,
+                         List<String> previousDataTableVariables, boolean dataTable) {
+      this.expression = expression;
+      this.dataVariables = dataVariables;
+      this.previousDataTableVariables = previousDataTableVariables;
+      this.dataTable = dataTable;
+    }
+
+    public Expression getExpression() {
+      return expression;
+    }
+
+    public List<String> getDataVariables() {
+      return dataVariables;
+    }
+
+    public List<String> getPreviousDataTableVariables() {
+      return previousDataTableVariables;
+    }
+
+    public boolean isDataTable() {
+      return dataTable;
+    }
   }
 
   private static InvalidSpecCompileException notAParameterization(ASTNode stat) {

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
@@ -339,24 +339,32 @@ public class DataIteratorFactory {
   }
 
   private static class DataProviderIterators extends BaseDataIterator {
-    private final Object[] dataProviders;
-    private final IDataIterator[] dataProviderIterators;
-    private final int estimatedNumIterations;
-    private final List<String> dataVariableNames;
-    private final Object[] whereVariableValues;
+    private Object[] dataProviders;
+    private IDataIterator[] dataProviderIterators;
+    private int estimatedNumIterations;
+    private List<String> dataVariableNames;
+    private Object[] whereVariableValues;
     private boolean firstIteration = true;
 
     public DataProviderIterators(IDataIterationContext context) {
       super(context);
-      // order is important as they rely on each other
-      whereVariableValues = createWhereVariableValues();
-      dataVariableNames = dataVariableNames();
-      dataProviders = createDataProviders();
-      dataProviderIterators = createDataProviderIterators();
-      if ((dataProviderIterators != null) && (dataProviders != null)) {
-        Assert.that(dataProviderIterators.length == dataProviders.length);
+      try {
+        // order is important as they rely on each other
+        whereVariableValues = createWhereVariableValues();
+        dataVariableNames = dataVariableNames();
+        dataProviders = createDataProviders();
+        dataProviderIterators = createDataProviderIterators();
+        if ((dataProviderIterators != null) && (dataProviders != null)) {
+          Assert.that(dataProviderIterators.length == dataProviders.length);
+        }
+        estimatedNumIterations = estimateNumIterations(dataProviderIterators);
+      } catch (Throwable t) {
+        // a standalone context rethrows errors instead of recording them, so release
+        // everything created so far, in particular AutoCloseable where-block variables
+        // (a feature context records errors and never throws here)
+        close();
+        throw t;
       }
-      estimatedNumIterations = estimateNumIterations(dataProviderIterators);
     }
 
     @Override
@@ -369,6 +377,9 @@ public class DataIteratorFactory {
     // close AutoCloseable where-block variables once the feature is done, in reverse declaration
     // order (a later variable may depend on an earlier one); close failures are ignored
     private void closeWhereVariables() {
+      if (whereVariableValues == null) {
+        return;
+      }
       for (int i = whereVariableValues.length - 1; i >= 0; i--) {
         Object value = whereVariableValues[i];
         if (value instanceof AutoCloseable) {
@@ -463,6 +474,9 @@ public class DataIteratorFactory {
       }
 
       Object[] dataProviders = new Object[dataProviderInfos.size()];
+      // expose the partially filled array so that close() can release already created
+      // providers when a standalone context rethrows an error from a later provider
+      this.dataProviders = dataProviders;
 
       for (int i = 0, size = dataProviderInfos.size(); i < size; i++) {
         DataProviderInfo dataProviderInfo = dataProviderInfos.get(i);

--- a/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/DataIteratorFactory.java
@@ -9,7 +9,6 @@ import java.util.*;
 import org.jetbrains.annotations.NotNull;
 import org.spockframework.util.Assert;
 import org.spockframework.util.Nullable;
-import spock.config.RunnerConfiguration;
 
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.singletonList;
@@ -29,17 +28,24 @@ public class DataIteratorFactory {
     if (context.getCurrentFeature().getDataProcessorMethod() == null) {
       return new SingleEmptyIterationDataIterator();
     }
-    return new IterationFilterIterator(supervisor, context,
-      new DataProcessorIterator(supervisor, context,
-        new FeatureDataProviderIterator(supervisor, context)));
+    return createDataIterator(new FeatureDataIterationContext(supervisor, context));
+  }
+
+  /**
+   * Builds the data provider / processor / filter iterator chain on top of the given context.
+   *
+   * @since 2.5
+   */
+  public static IDataIterator createDataIterator(IDataIterationContext iterationContext) {
+    return new IterationFilterIterator(iterationContext,
+      new DataProcessorIterator(iterationContext,
+        new DataProviderIterators(iterationContext)));
   }
 
   private abstract static class BaseDataIterator implements IDataIterator {
-    protected final IRunSupervisor supervisor;
-    protected final SpockExecutionContext context;
+    protected final IDataIterationContext context;
 
-    public BaseDataIterator(IRunSupervisor supervisor, SpockExecutionContext context) {
-      this.supervisor = supervisor;
+    public BaseDataIterator(IDataIterationContext context) {
       this.context = context;
     }
 
@@ -47,7 +53,7 @@ public class DataIteratorFactory {
       try {
         return method.invoke(target, arguments);
       } catch (Throwable throwable) {
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(method, throwable, getErrorContext()));
+        context.error(method, throwable);
         return null;
       }
     }
@@ -59,12 +65,8 @@ public class DataIteratorFactory {
       return result;
     }
 
-    protected IErrorContext getErrorContext() {
-      return ErrorContext.from((SpecificationContext) context.getCurrentInstance().getSpecificationContext());
-    }
-
     protected int estimateNumIterations(@Nullable Object dataProvider) {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return UNKNOWN_ITERATIONS;
       }
 
@@ -72,10 +74,10 @@ public class DataIteratorFactory {
         return UNKNOWN_ITERATIONS;
       }
 
-      // an IDataIterator probably already has the estimated size
+      // an IBaseDataIterator probably already has the estimated size
       // or knows better how to calculate it
-      if (dataProvider instanceof IDataIterator) {
-        return ((IDataIterator) dataProvider).getEstimatedNumIterations();
+      if (dataProvider instanceof IBaseDataIterator) {
+        return ((IBaseDataIterator<?>) dataProvider).getEstimatedNumIterations();
       }
 
       // unbelievably, DefaultGroovyMethods provides a size() method for Iterators,
@@ -98,7 +100,7 @@ public class DataIteratorFactory {
     }
 
     protected int estimateNumIterations(Object[] dataProviders) {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return UNKNOWN_ITERATIONS;
       }
       if (dataProviders.length == 0) {
@@ -129,14 +131,14 @@ public class DataIteratorFactory {
             boolean hasNext = iterators[i].hasNext();
             if (result != hasNext) {
               DataProviderInfo provider = dataProviderInfos.get(i);
-              supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(provider.getDataProviderMethod(),
-                createDifferentNumberOfDataValuesException(provider, hasNext), getErrorContext()));
+              context.error(provider.getDataProviderMethod(),
+                context.createDifferentNumberOfDataValuesException(provider, hasNext));
               return false;
             }
           }
 
         } catch (Throwable t) {
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(dataProviderInfos.get(i).getDataProviderMethod(), t, getErrorContext()));
+          context.error(dataProviderInfos.get(i).getDataProviderMethod(), t);
           return false;
         }
 
@@ -144,35 +146,22 @@ public class DataIteratorFactory {
     }
 
     protected Iterator<?> createIterator(Object dataProvider, DataProviderInfo dataProviderInfo) {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return null;
       }
 
       try {
         Iterator<?> iter = GroovyRuntimeUtil.asIterator(dataProvider);
         if (iter == null) {
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(dataProviderInfo.getDataProviderMethod(),
-            new SpockExecutionException("Data provider's iterator() method returned null"), getErrorContext()));
+          context.error(dataProviderInfo.getDataProviderMethod(),
+            new SpockExecutionException("Data provider's iterator() method returned null"));
           return null;
         }
         return iter;
       } catch (Throwable t) {
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(dataProviderInfo.getDataProviderMethod(), t, getErrorContext()));
+        context.error(dataProviderInfo.getDataProviderMethod(), t);
         return null;
       }
-    }
-
-    private SpockExecutionException createDifferentNumberOfDataValuesException(DataProviderInfo provider,
-                                                                               boolean hasNext) {
-      String msg = String.format("Data provider for variable '%s' has %s values than previous data provider(s)",
-        provider.getDataVariables().get(0), hasNext ? "more" : "fewer");
-      SpockExecutionException exception = new SpockExecutionException(msg);
-      FeatureInfo feature = provider.getParent();
-      SpecInfo spec = feature.getParent();
-      StackTraceElement elem = new StackTraceElement(spec.getReflection().getName(),
-        feature.getName(), spec.getFilename(), provider.getLine());
-      exception.setStackTrace(new StackTraceElement[]{elem});
-      return exception;
     }
   }
 
@@ -220,21 +209,11 @@ public class DataIteratorFactory {
   private static class IterationFilterIterator extends BaseDataIterator {
     private final IDataIterator delegate;
     private final List<String> dataVariableNames;
-    private final boolean logFilteredIterations;
-    private IStackTraceFilter stackTraceFilter;
 
-    private IterationFilterIterator(IRunSupervisor supervisor, SpockExecutionContext context, IDataIterator delegate) {
-      super(supervisor, context);
+    private IterationFilterIterator(IDataIterationContext context, IDataIterator delegate) {
+      super(context);
       this.delegate = delegate;
       dataVariableNames = delegate.getDataVariableNames();
-
-      RunnerConfiguration runnerConfiguration = context
-        .getRunContext()
-        .getConfiguration(RunnerConfiguration.class);
-      logFilteredIterations = runnerConfiguration.logFilteredIterations;
-      if (logFilteredIterations) {
-        stackTraceFilter = runnerConfiguration.filterStackTrace ? new StackTraceFilter(context.getSpec()) : new DummyStackTraceFilter();
-      }
     }
 
     @Override
@@ -272,24 +251,24 @@ public class DataIteratorFactory {
           return null;
         }
 
-        MethodInfo filterMethod = context.getCurrentFeature().getFilterMethod();
+        MethodInfo filterMethod = context.getFilterMethod();
         if (filterMethod == null) {
           return next;
         }
 
         try {
           // do not use invokeRaw here, as that would report Assertion Error to the supervisor
-          filterMethod.invoke(context.getSharedInstance(), appendArgs(next, delegate.getWhereVariableValues()));
+          filterMethod.invoke(context.getDataProcessorTarget(), appendArgs(next, delegate.getWhereVariableValues()));
           return next;
         } catch (AssertionError ae) {
-          if (logFilteredIterations) {
+          if (context.isLogFilteredIterations()) {
             StringJoiner stringJoiner = new StringJoiner(", ", "Filtered iteration [", "]:\n");
             for (int i = 0; i < dataVariableNames.size(); i++) {
               stringJoiner.add(dataVariableNames.get(i) + ": " + next[i]);
             }
             StringWriter sw = new StringWriter();
             sw.write(stringJoiner.toString());
-            stackTraceFilter.filter(ae);
+            context.getStackTraceFilter().filter(ae);
             try (PrintWriter pw = new PrintWriter(sw)) {
               ae.printStackTrace(pw);
             }
@@ -297,7 +276,7 @@ public class DataIteratorFactory {
           }
           // filter block does not like these values, try next ones if available
         } catch (Throwable t) {
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(filterMethod, t, getErrorContext()));
+          context.error(filterMethod, t);
           return null;
         }
       }
@@ -308,17 +287,10 @@ public class DataIteratorFactory {
     private final IDataIterator delegate;
     private final List<String> dataVariableNames;
 
-    private DataProcessorIterator(IRunSupervisor supervisor, SpockExecutionContext context, IDataIterator delegate) {
-      super(supervisor, context);
+    private DataProcessorIterator(IDataIterationContext context, IDataIterator delegate) {
+      super(context);
       this.delegate = delegate;
-      this.dataVariableNames = readDataVariableNames();
-    }
-
-    @NotNull
-    private List<String> readDataVariableNames() {
-      return Collections.unmodifiableList(Arrays.asList(
-        context.getCurrentFeature().getDataProcessorMethod().getAnnotation(DataProcessorMetadata.class)
-          .dataVariables()));
+      this.dataVariableNames = context.getProcessedDataVariableNames();
     }
 
     @Override
@@ -355,17 +327,18 @@ public class DataIteratorFactory {
         return null;
       }
 
+      MethodInfo dataProcessorMethod = context.getDataProcessorMethod();
       try {
-        return (Object[]) invokeRaw(context.getSharedInstance(), context.getCurrentFeature().getDataProcessorMethod(),
+        return (Object[]) invokeRaw(context.getDataProcessorTarget(), dataProcessorMethod,
           appendArgs(next, delegate.getWhereVariableValues()));
       } catch (Throwable t) {
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProcessorMethod(), t, getErrorContext()));
+        context.error(dataProcessorMethod, t);
         return null;
       }
     }
   }
 
-  private static class FeatureDataProviderIterator extends BaseDataIterator {
+  private static class DataProviderIterators extends BaseDataIterator {
     private final Object[] dataProviders;
     private final IDataIterator[] dataProviderIterators;
     private final int estimatedNumIterations;
@@ -373,8 +346,8 @@ public class DataIteratorFactory {
     private final Object[] whereVariableValues;
     private boolean firstIteration = true;
 
-    public FeatureDataProviderIterator(IRunSupervisor supervisor, SpockExecutionContext context) {
-      super(supervisor, context);
+    public DataProviderIterators(IDataIterationContext context) {
+      super(context);
       // order is important as they rely on each other
       whereVariableValues = createWhereVariableValues();
       dataVariableNames = dataVariableNames();
@@ -406,7 +379,7 @@ public class DataIteratorFactory {
 
     @Override
     public boolean hasNext() {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return false;
       }
       if (dataProviderIterators.length == 0 && !firstIteration) {
@@ -414,15 +387,15 @@ public class DataIteratorFactory {
         return false;
       }
 
-      return haveNext(dataProviderIterators, context.getCurrentFeature().getDataProviders());
+      return haveNext(dataProviderIterators, context.getDataProviders());
     }
 
     @Override
     public Object[] next() {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return null;
       }
-      Assert.that(dataProviders.length == context.getCurrentFeature().getDataProviders().size());
+      Assert.that(dataProviders.length == context.getDataProviders().size());
       firstIteration = false;
 
       // advances iterators and computes args
@@ -446,7 +419,7 @@ public class DataIteratorFactory {
           System.arraycopy(nextValues, 0, next, i, nextValues.length);
           i += nextValues.length;
         } catch (Throwable t) {
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(context.getCurrentFeature().getDataProviders().get(i).getDataProviderMethod(), t, getErrorContext()));
+          context.error(context.getDataProviders().get(i).getDataProviderMethod(), t);
           return null;
         }
       }
@@ -469,22 +442,22 @@ public class DataIteratorFactory {
     }
 
     private Object[] createWhereVariableValues() {
-      MethodInfo method = context.getCurrentFeature().getWhereVariablesMethod();
+      MethodInfo method = context.getWhereVariablesMethod();
       if (method == null) {
         return NO_WHERE_VARIABLE_VALUES;
       }
-      Object values = invokeRaw(context.getCurrentInstance(), method);
+      Object values = invokeRaw(context.getDataProviderTarget(), method);
       // invokeRaw records the error and returns null on failure; the empty array keeps us
       // safe until the constructor's createDataProviders() short-circuits on hasErrors()
       return (values == null) ? NO_WHERE_VARIABLE_VALUES : (Object[]) values;
     }
 
     private Object[] createDataProviders() {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return null;
       }
 
-      List<DataProviderInfo> dataProviderInfos = context.getCurrentFeature().getDataProviders();
+      List<DataProviderInfo> dataProviderInfos = context.getDataProviders();
       if (dataProviderInfos.isEmpty()) {
         return new Object[0];
       }
@@ -496,19 +469,19 @@ public class DataIteratorFactory {
         MethodInfo method = dataProviderInfo.getDataProviderMethod();
 
         Object provider = invokeRaw(
-          context.getCurrentInstance(), method,
+          context.getDataProviderTarget(), method,
           appendArgs(
             getPreviousDataTableProviders(dataVariableNames, dataProviders, dataProviderInfo),
             whereVariableValues));
 
-        if (context.getErrorInfoCollector().hasErrors()) {
+        if (context.hasErrors()) {
           if (provider != null) {
             dataProviders[i] = provider;
           }
           break;
         } else if (provider == null) {
           SpockExecutionException error = new SpockExecutionException("Data provider is null!");
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(method, error, getErrorContext()));
+          context.error(method, error);
           break;
         }
 
@@ -519,11 +492,11 @@ public class DataIteratorFactory {
     }
 
     private IDataIterator[] createDataProviderIterators() {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return null;
       }
 
-      MethodInfo dataVariableMultiplicationsMethod = context.getCurrentFeature().getDataVariableMultiplicationsMethod();
+      MethodInfo dataVariableMultiplicationsMethod = context.getDataVariableMultiplicationsMethod();
       Iterator<DataVariableMultiplication> dataVariableMultiplications;
       DataVariableMultiplication nextDataVariableMultiplication;
       if (dataVariableMultiplicationsMethod != null) {
@@ -531,7 +504,7 @@ public class DataIteratorFactory {
           dataVariableMultiplications = Arrays.stream(((DataVariableMultiplication[]) invokeRaw(null, dataVariableMultiplicationsMethod))).iterator();
           nextDataVariableMultiplication = dataVariableMultiplications.next();
         } catch (Throwable t) {
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(dataVariableMultiplicationsMethod, t, getErrorContext()));
+          context.error(dataVariableMultiplicationsMethod, t);
           return null;
         }
       } else {
@@ -539,7 +512,7 @@ public class DataIteratorFactory {
         nextDataVariableMultiplication = null;
       }
 
-      List<DataProviderInfo> dataProviderInfos = context.getCurrentFeature().getDataProviders();
+      List<DataProviderInfo> dataProviderInfos = context.getDataProviders();
       IDataIterator[] dataIterators = new IDataIterator[dataProviders.length];
       for (int dataProviderIndex = 0, dataVariableNameIndex = 0; dataProviderIndex < dataProviders.length; dataProviderIndex++, dataVariableNameIndex++) {
         String nextDataVariableName = dataVariableNames.get(dataVariableNameIndex);
@@ -563,7 +536,7 @@ public class DataIteratorFactory {
           // not a cross multiplication, just use a data provider iterator
           DataProviderInfo dataProviderInfo = dataProviderInfos.get(dataProviderIndex);
           dataIterators[dataProviderIndex] = new DataProviderIterator(
-            supervisor, context, nextDataVariableName,
+            context, nextDataVariableName,
             dataProviderInfo, dataProviders[dataProviderIndex]);
           dataVariableNameIndex += dataProviderInfo.getDataVariables().size() - 1;
         }
@@ -598,7 +571,7 @@ public class DataIteratorFactory {
         List<Object> multiplicandProviders = new ArrayList<>();
         collectDataProviders(dataProviderOffset + multiplierProvider.getProcessedDataProviders(), multiplicand, multiplicandProviderInfos, multiplicandProviders);
 
-        return new DataProviderMultiplier(supervisor, context,
+        return new DataProviderMultiplier(context,
           Arrays.asList(dataVariableMultiplication.getDataVariables()),
           multiplierProvider.multiplierProviderInfos.subList(0, 1),
           multiplicandProviderInfos, multiplierProvider,
@@ -615,7 +588,7 @@ public class DataIteratorFactory {
         collectDataProviders(dataProviderOffset, multiplier, multiplierProviderInfos, multiplierProviders);
         collectDataProviders(dataProviderOffset + multiplierProviderInfos.size(), multiplicand, multiplicandProviderInfos, multiplicandProviders);
 
-        return new DataProviderMultiplier(supervisor, context,
+        return new DataProviderMultiplier(context,
           Arrays.asList(dataVariableMultiplication.getDataVariables()),
           multiplierProviderInfos, multiplicandProviderInfos,
           multiplierProviders.toArray(new Object[0]),
@@ -625,7 +598,7 @@ public class DataIteratorFactory {
 
     private void collectDataProviders(int dataProviderOffset, DataVariableMultiplicationFactor factor,
                                       List<DataProviderInfo> factorProviderInfos, List<Object> factorProviders) {
-      List<DataProviderInfo> dataProviderInfos = context.getCurrentFeature().getDataProviders();
+      List<DataProviderInfo> dataProviderInfos = context.getDataProviders();
       int factorDataVariables = factor.getDataVariables().length;
       int remainingDataVariables = factorDataVariables;
       while (remainingDataVariables > 0) {
@@ -640,7 +613,7 @@ public class DataIteratorFactory {
 
     @NotNull
     private List<String> dataVariableNames() {
-      return context.getCurrentFeature().getDataProviders()
+      return context.getDataProviders()
         .stream()
         .map(DataProviderInfo::getDataVariables)
         .flatMap(List::stream)
@@ -673,9 +646,9 @@ public class DataIteratorFactory {
     private final Iterator<?> iterator;
     private final int estimatedNumIterations;
 
-    public DataProviderIterator(IRunSupervisor supervisor, SpockExecutionContext context, String dataVariableName,
+    public DataProviderIterator(IDataIterationContext context, String dataVariableName,
                                 DataProviderInfo providerInfo, Object provider) {
-      super(supervisor, context);
+      super(context);
       this.dataVariableNames = singletonList(Objects.requireNonNull(dataVariableName));
       estimatedNumIterations = estimateNumIterations(provider);
       this.providerInfo = Objects.requireNonNull(providerInfo);
@@ -690,28 +663,28 @@ public class DataIteratorFactory {
 
     @Override
     public boolean hasNext() {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return false;
       }
 
       try {
         return iterator.hasNext();
       } catch (Throwable t) {
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(providerInfo.getDataProviderMethod(), t, getErrorContext()));
+        context.error(providerInfo.getDataProviderMethod(), t);
         return false;
       }
     }
 
     @Override
     public Object[] next() {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return null;
       }
 
       try {
         return new Object[]{iterator.next()};
       } catch (Throwable t) {
-        supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(providerInfo.getDataProviderMethod(), t, getErrorContext()));
+        context.error(providerInfo.getDataProviderMethod(), t);
         return null;
       }
     }
@@ -830,18 +803,17 @@ public class DataIteratorFactory {
      * the factors of the multiplication are possibly swapped around to store as few values as possible
      * in memory for the multiplication.
      *
-     * @param supervisor the supervisor that is notified in case of errors
-     * @param context the execution context that for example contains the error collector
+     * @param context the iteration context that for example handles errors
      * @param dataVariableNames the names of the data variables for which values are produced by this multiplier
      * @param multiplierProviderInfos the provider infos for the multiplier for constructing meaningful errors
      * @param multiplicandProviderInfos the provider infos for the multiplicand for constructing meaningful errors
      * @param multiplierProviders the actual providers for the sets of multiplier values
      * @param multiplicandProviders the actual providers for the sets of multiplicand values
      */
-    public DataProviderMultiplier(IRunSupervisor supervisor, SpockExecutionContext context, List<String> dataVariableNames,
+    public DataProviderMultiplier(IDataIterationContext context, List<String> dataVariableNames,
                                   List<DataProviderInfo> multiplierProviderInfos, List<DataProviderInfo> multiplicandProviderInfos,
                                   Object[] multiplierProviders, Object[] multiplicandProviders) {
-      super(supervisor, context);
+      super(context);
       this.dataVariableNames = Objects.requireNonNull(dataVariableNames);
       this.multiplierProviderInfos = multiplierProviderInfos;
       this.multiplicandProviderInfos = multiplicandProviderInfos;
@@ -873,17 +845,16 @@ public class DataIteratorFactory {
      * one of these can be estimated, the factors of the multiplication are possibly swapped around
      * to store as few values as possible in memory for the multiplication.
      *
-     * @param supervisor the supervisor that is notified in case of errors
-     * @param context the execution context that for example contains the error collector
+     * @param context the iteration context that for example handles errors
      * @param dataVariableNames the names of the data variables for which values are produced by this multiplier
      * @param multiplicandProviderInfos the provider infos for the multiplicand for constructing meaningful errors
      * @param multiplierProvider the data provider multiplier that produces the multiplier values
      * @param multiplicandProviders the actual providers for the sets of multiplicand values
      */
-    public DataProviderMultiplier(IRunSupervisor supervisor, SpockExecutionContext context, List<String> dataVariableNames,
+    public DataProviderMultiplier(IDataIterationContext context, List<String> dataVariableNames,
                                   List<DataProviderInfo> multiplierProviderInfos, List<DataProviderInfo> multiplicandProviderInfos,
                                   DataProviderMultiplier multiplierProvider, Object[] multiplicandProviders) {
-      super(supervisor, context);
+      super(context);
       this.dataVariableNames = Objects.requireNonNull(dataVariableNames);
       this.multiplierProviderInfos = multiplierProviderInfos;
       this.multiplicandProviderInfos = multiplicandProviderInfos;
@@ -926,7 +897,7 @@ public class DataIteratorFactory {
 
     @Override
     public boolean hasNext() {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return false;
       }
       return haveNext(multiplicandIterators, multiplicandProviderInfos)
@@ -935,7 +906,7 @@ public class DataIteratorFactory {
 
     @Override
     public Object[] next() {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return null;
       }
 
@@ -958,7 +929,7 @@ public class DataIteratorFactory {
           try {
             multiplicandIterators[i] = collectedMultiplicandValues.get(i).iterator();
           } catch (Throwable t) {
-            supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(multiplicandProviderInfos.get(i).getDataProviderMethod(), t, getErrorContext()));
+            context.error(multiplicandProviderInfos.get(i).getDataProviderMethod(), t);
             return null;
           }
         }
@@ -1013,7 +984,7 @@ public class DataIteratorFactory {
     }
 
     private Iterator<?>[] createIterators(Object[] dataProviders, List<DataProviderInfo> dataProviderInfos) {
-      if (context.getErrorInfoCollector().hasErrors()) {
+      if (context.hasErrors()) {
         return null;
       }
       Assert.that(dataProviders.length == dataProviderInfos.size());
@@ -1037,7 +1008,7 @@ public class DataIteratorFactory {
         try {
           result[i] = iterators[i].next();
         } catch (Throwable t) {
-          supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(providerInfos.get(i).getDataProviderMethod(), t, getErrorContext()));
+          context.error(providerInfos.get(i).getDataProviderMethod(), t);
           return null;
         }
       }

--- a/spock-core/src/main/java/org/spockframework/runtime/FeatureDataIterationContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/FeatureDataIterationContext.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime;
+
+import org.spockframework.runtime.model.*;
+import org.spockframework.util.Nullable;
+import spock.config.RunnerConfiguration;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The {@link IDataIterationContext} for a feature's {@code where:} block, backed by the
+ * Spock execution context; errors are reported to the run supervisor.
+ *
+ * @since 2.5
+ */
+class FeatureDataIterationContext implements IDataIterationContext {
+  private final IRunSupervisor supervisor;
+  private final SpockExecutionContext context;
+  private final boolean logFilteredIterations;
+  private IStackTraceFilter stackTraceFilter;
+
+  FeatureDataIterationContext(IRunSupervisor supervisor, SpockExecutionContext context) {
+    this.supervisor = supervisor;
+    this.context = context;
+
+    RunnerConfiguration runnerConfiguration = context
+      .getRunContext()
+      .getConfiguration(RunnerConfiguration.class);
+    logFilteredIterations = runnerConfiguration.logFilteredIterations;
+    if (logFilteredIterations) {
+      stackTraceFilter = runnerConfiguration.filterStackTrace ? new StackTraceFilter(context.getSpec()) : new DummyStackTraceFilter();
+    }
+  }
+
+  @Override
+  public boolean hasErrors() {
+    return context.getErrorInfoCollector().hasErrors();
+  }
+
+  @Override
+  public void error(@Nullable MethodInfo method, Throwable error) {
+    supervisor.error(context.getErrorInfoCollector(), new ErrorInfo(method, error, getErrorContext()));
+  }
+
+  private IErrorContext getErrorContext() {
+    return ErrorContext.from((SpecificationContext) context.getCurrentInstance().getSpecificationContext());
+  }
+
+  @Override
+  @Nullable
+  public MethodInfo getWhereVariablesMethod() {
+    return context.getCurrentFeature().getWhereVariablesMethod();
+  }
+
+  @Override
+  public MethodInfo getDataProcessorMethod() {
+    return context.getCurrentFeature().getDataProcessorMethod();
+  }
+
+  @Override
+  public List<String> getProcessedDataVariableNames() {
+    return Collections.unmodifiableList(Arrays.asList(
+      context.getCurrentFeature().getDataProcessorMethod().getAnnotation(DataProcessorMetadata.class)
+        .dataVariables()));
+  }
+
+  @Override
+  @Nullable
+  public MethodInfo getFilterMethod() {
+    return context.getCurrentFeature().getFilterMethod();
+  }
+
+  @Override
+  @Nullable
+  public MethodInfo getDataVariableMultiplicationsMethod() {
+    return context.getCurrentFeature().getDataVariableMultiplicationsMethod();
+  }
+
+  @Override
+  public List<DataProviderInfo> getDataProviders() {
+    return context.getCurrentFeature().getDataProviders();
+  }
+
+  @Override
+  public Object getDataProviderTarget() {
+    return context.getCurrentInstance();
+  }
+
+  @Override
+  public Object getDataProcessorTarget() {
+    return context.getSharedInstance();
+  }
+
+  @Override
+  public boolean isLogFilteredIterations() {
+    return logFilteredIterations;
+  }
+
+  @Override
+  public IStackTraceFilter getStackTraceFilter() {
+    return stackTraceFilter;
+  }
+
+  @Override
+  public SpockExecutionException createDifferentNumberOfDataValuesException(DataProviderInfo provider, boolean hasNext) {
+    String msg = String.format("Data provider for variable '%s' has %s values than previous data provider(s)",
+      provider.getDataVariables().get(0), hasNext ? "more" : "fewer");
+    SpockExecutionException exception = new SpockExecutionException(msg);
+    FeatureInfo feature = provider.getParent();
+    SpecInfo spec = feature.getParent();
+    StackTraceElement elem = new StackTraceElement(spec.getReflection().getName(),
+      feature.getName(), spec.getFilename(), provider.getLine());
+    exception.setStackTrace(new StackTraceElement[]{elem});
+    return exception;
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/IBaseDataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IBaseDataIterator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A special iterator that gives access to the data produced by Spock's data providers.
+ * <p>
+ * The creator of the data iterator is responsible to close it.
+ * <p>
+ * On the feature path (i.e. {@link IDataIterator}), {@link #next()} will return {@code null} when an error occurs
+ * during calculation of the values, because errors are reported to the run supervisor instead of being thrown.
+ * Consumers of such a data iterator should check for {@code null} values, and skip the iteration if it is
+ * {@code null}. Standalone implementations have no supervisor and throw instead, so their {@link #next()} never
+ * returns {@code null}.
+ *
+ * @param <T> the row type produced by this iterator
+ * @since 2.5
+ */
+public interface IBaseDataIterator<T> extends Iterator<T>, AutoCloseable {
+  /**
+   * Shared empty result for {@link #getWhereVariableValues()} when no where-block variables are declared.
+   * <p>
+   * This array is shared across all callers and must never be mutated. It is safe to share precisely because a
+   * zero-length array has no elements to write.
+   *
+   * @since 2.5
+   */
+  Object[] NO_WHERE_VARIABLE_VALUES = new Object[0];
+
+  /**
+   * @return the number of data sets that are provided by this iterator. This will be {@code -1} if it cannot be determined.
+   */
+  int getEstimatedNumIterations();
+
+  /**
+   * @return the names of the data variables in the order they are present in the row
+   */
+  List<String> getDataVariableNames();
+
+  /**
+   * @return the values of the where-block variables, computed once, in
+   * declaration order; empty if no where-block variables are declared
+   * @since 2.5
+   */
+  default Object[] getWhereVariableValues() {
+    return NO_WHERE_VARIABLE_VALUES;
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/IDataIterationContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IDataIterationContext.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime;
+
+import org.spockframework.runtime.model.DataProviderInfo;
+import org.spockframework.runtime.model.MethodInfo;
+import org.spockframework.util.Nullable;
+
+import java.util.List;
+
+/**
+ * Abstraction over the environment a data-iterator chain runs in.
+ * <p>
+ * The feature path is backed by the Spock execution context and run supervisor
+ * ({@code FeatureDataIterationContext}); errors are reported to the supervisor and
+ * {@link #hasErrors()} subsequently turns {@code true}, so the chain short-circuits.
+ * Standalone implementations have no supervisor: {@link #error(MethodInfo, Throwable)}
+ * throws instead and {@link #hasErrors()} stays {@code false}.
+ *
+ * @since 2.5
+ */
+public interface IDataIterationContext {
+  /**
+   * @return whether an error has been reported; the iterator chain stops producing values once this is {@code true}
+   */
+  boolean hasErrors();
+
+  /**
+   * Reports an error that occurred while computing data values.
+   * <p>
+   * Feature-path implementations record the error and return normally (callers then return {@code null});
+   * standalone implementations rethrow.
+   *
+   * @param method the generated method whose invocation failed, may be {@code null}
+   * @param error the error that occurred
+   */
+  void error(@Nullable MethodInfo method, Throwable error);
+
+  /**
+   * @return the method computing the where-block variable values, or {@code null} if there are none
+   */
+  @Nullable
+  MethodInfo getWhereVariablesMethod();
+
+  /**
+   * @return the data processor method turning raw provider values into data variable values
+   */
+  MethodInfo getDataProcessorMethod();
+
+  /**
+   * @return the names of the data variables produced by the data processor, in row order
+   */
+  List<String> getProcessedDataVariableNames();
+
+  /**
+   * @return the filter method dropping iterations, or {@code null} if there is none
+   */
+  @Nullable
+  MethodInfo getFilterMethod();
+
+  /**
+   * @return the method providing the data variable multiplications, or {@code null} if there are none
+   */
+  @Nullable
+  MethodInfo getDataVariableMultiplicationsMethod();
+
+  /**
+   * @return the data providers, in declaration order
+   */
+  List<DataProviderInfo> getDataProviders();
+
+  /**
+   * @return the invocation target for data provider and where-variables methods
+   */
+  @Nullable
+  Object getDataProviderTarget();
+
+  /**
+   * @return the invocation target for data processor and filter methods
+   */
+  @Nullable
+  Object getDataProcessorTarget();
+
+  /**
+   * @return whether iterations dropped by the filter method should be logged
+   */
+  boolean isLogFilteredIterations();
+
+  /**
+   * @return the stack trace filter used when logging filtered iterations; only consulted when
+   * {@link #isLogFilteredIterations()} is {@code true}
+   */
+  IStackTraceFilter getStackTraceFilter();
+
+  /**
+   * Creates the exception reported when one data provider runs out of values before the others.
+   *
+   * @param provider the data provider that differs from its predecessors
+   * @param hasNext whether the differing provider still has values
+   * @return the exception to report
+   */
+  SpockExecutionException createDifferentNumberOfDataValuesException(DataProviderInfo provider, boolean hasNext);
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/IDataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IDataIterator.java
@@ -1,8 +1,5 @@
 package org.spockframework.runtime;
 
-import java.util.Iterator;
-import java.util.List;
-
 /**
  * A special iterator, that gives to the data produced by Spock's data providers.
  * <p>
@@ -14,33 +11,5 @@ import java.util.List;
  * @author Leonard Brünings
  * @since 2.2
  */
-public interface IDataIterator extends Iterator<Object[]>, AutoCloseable {
-  /**
-   * Shared empty result for {@link #getWhereVariableValues()} when a feature declares no where-block variables.
-   * <p>
-   * This array is shared across all callers and must never be mutated. It is safe to share precisely because a
-   * zero-length array has no elements to write.
-   *
-   * @since 2.5
-   */
-  Object[] NO_WHERE_VARIABLE_VALUES = new Object[0];
-
-  /**
-   * @return the number of data sets that are provided by this iterator. This will be {@code -1} if it cannot be determined.
-   */
-  int getEstimatedNumIterations();
-
-  /**
-   * @return the names of the data variables in the order they are present in the array
-   */
-  List<String> getDataVariableNames();
-
-  /**
-   * @return the values of the where-block variables, computed once per feature, in
-   * declaration order; empty if the feature declares none
-   * @since 2.5
-   */
-  default Object[] getWhereVariableValues() {
-    return NO_WHERE_VARIABLE_VALUES;
-  }
+public interface IDataIterator extends IBaseDataIterator<Object[]> {
 }

--- a/spock-core/src/main/java/org/spockframework/runtime/IStandaloneDataIterator.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/IStandaloneDataIterator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime;
+
+import groovy.lang.Tuple;
+import org.spockframework.util.Beta;
+
+/**
+ * The iterator returned by a standalone {@code @DataProvider} method: each row is an
+ * arity-specific Groovy tuple.
+ * <p>
+ * Unlike the feature path, {@link #next()} never returns {@code null}; errors during
+ * value calculation are thrown. The iterator closes its {@code AutoCloseable}
+ * where-block variables when it is closed and when it is exhausted; {@link #close()}
+ * is idempotent.
+ *
+ * @since 2.5
+ */
+@Beta
+public interface IStandaloneDataIterator extends IBaseDataIterator<Tuple> {
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/StandaloneDataIterationContext.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/StandaloneDataIterationContext.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime;
+
+import groovy.lang.Closure;
+import org.spockframework.runtime.model.*;
+import org.spockframework.util.ExceptionUtil;
+import org.spockframework.util.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The {@link IDataIterationContext} for a standalone {@code @DataProvider} method, fed with the
+ * closures the transform emitted inline into the method body. There is no supervisor: errors are
+ * rethrown immediately and {@link #hasErrors()} stays {@code false}.
+ *
+ * @since 2.5
+ */
+class StandaloneDataIterationContext implements IDataIterationContext {
+  private final List<String> dataVariableNames;
+  @Nullable
+  private final MethodInfo whereVariablesMethod;
+  private final List<DataProviderInfo> dataProviders;
+  private final MethodInfo dataProcessorMethod;
+  @Nullable
+  private final MethodInfo filterMethod;
+  @Nullable
+  private final MethodInfo dataVariableMultiplicationsMethod;
+
+  StandaloneDataIterationContext(String[] dataVariableNames, @Nullable Closure<?> whereVariables,
+                                 StandaloneDataProviderDescriptor[] dataProviders, Closure<?> dataProcessor,
+                                 @Nullable Closure<?> filter, @Nullable Closure<?> dataVariableMultiplications) {
+    this.dataVariableNames = Collections.unmodifiableList(Arrays.asList(dataVariableNames));
+    whereVariablesMethod = createMethodInfo(whereVariables, MethodKind.WHERE_VARIABLES, "where variables");
+    this.dataProviders = createDataProviderInfos(dataProviders);
+    dataProcessorMethod = createMethodInfo(dataProcessor, MethodKind.DATA_PROCESSOR, "data processor");
+    filterMethod = createMethodInfo(filter, MethodKind.FILTER, "filter");
+    dataVariableMultiplicationsMethod =
+      createMethodInfo(dataVariableMultiplications, MethodKind.DATA_VARIABLE_MULTIPLICATIONS, "data variable multiplications");
+  }
+
+  private static List<DataProviderInfo> createDataProviderInfos(StandaloneDataProviderDescriptor[] descriptors) {
+    List<DataProviderInfo> result = new ArrayList<>(descriptors.length);
+    for (StandaloneDataProviderDescriptor descriptor : descriptors) {
+      DataProviderInfo providerInfo = new DataProviderInfo();
+      providerInfo.setDataVariables(descriptor.getDataVariables());
+      providerInfo.setPreviousDataTableVariables(descriptor.getPreviousDataTableVariables());
+      providerInfo.setLine(descriptor.getLine());
+      providerInfo.setDataProviderMethod(createMethodInfo(descriptor.getCode(), MethodKind.DATA_PROVIDER,
+        "data provider for " + descriptor.getDataVariables()));
+      result.add(providerInfo);
+    }
+    return Collections.unmodifiableList(result);
+  }
+
+  @Nullable
+  private static MethodInfo createMethodInfo(@Nullable Closure<?> code, MethodKind kind, String name) {
+    if (code == null) {
+      return null;
+    }
+    MethodInfo methodInfo = new MethodInfo((Object target, Object... arguments) -> code.call(arguments));
+    methodInfo.setKind(kind);
+    methodInfo.setName(name);
+    return methodInfo;
+  }
+
+  @Override
+  public boolean hasErrors() {
+    return false;
+  }
+
+  @Override
+  public void error(@Nullable MethodInfo method, Throwable error) {
+    ExceptionUtil.sneakyThrow(error);
+  }
+
+  @Override
+  @Nullable
+  public MethodInfo getWhereVariablesMethod() {
+    return whereVariablesMethod;
+  }
+
+  @Override
+  public MethodInfo getDataProcessorMethod() {
+    return dataProcessorMethod;
+  }
+
+  @Override
+  public List<String> getProcessedDataVariableNames() {
+    return dataVariableNames;
+  }
+
+  @Override
+  @Nullable
+  public MethodInfo getFilterMethod() {
+    return filterMethod;
+  }
+
+  @Override
+  @Nullable
+  public MethodInfo getDataVariableMultiplicationsMethod() {
+    return dataVariableMultiplicationsMethod;
+  }
+
+  @Override
+  public List<DataProviderInfo> getDataProviders() {
+    return dataProviders;
+  }
+
+  @Override
+  @Nullable
+  public Object getDataProviderTarget() {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public Object getDataProcessorTarget() {
+    return null;
+  }
+
+  @Override
+  public boolean isLogFilteredIterations() {
+    return false;
+  }
+
+  @Override
+  public IStackTraceFilter getStackTraceFilter() {
+    throw new UnsupportedOperationException("getStackTraceFilter");
+  }
+
+  @Override
+  public SpockExecutionException createDifferentNumberOfDataValuesException(DataProviderInfo provider, boolean hasNext) {
+    return new SpockExecutionException(String.format("Data provider for variable '%s' has %s values than previous data provider(s)",
+      provider.getDataVariables().get(0), hasNext ? "more" : "fewer"));
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/StandaloneDataProviderDescriptor.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/StandaloneDataProviderDescriptor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime;
+
+import groovy.lang.Closure;
+import org.spockframework.util.Beta;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Describes a single data provider of a standalone {@code @DataProvider} method.
+ * <p>
+ * Instances are constructed by code the {@code @DataProvider} transform generates;
+ * this class is not intended to be used directly.
+ *
+ * @since 2.5
+ */
+@Beta
+public class StandaloneDataProviderDescriptor {
+  private final Closure<?> code;
+  private final List<String> dataVariables;
+  private final List<String> previousDataTableVariables;
+  private final int line;
+
+  public StandaloneDataProviderDescriptor(Closure<?> code, String[] dataVariables,
+                                          String[] previousDataTableVariables, int line) {
+    this.code = code;
+    this.dataVariables = Collections.unmodifiableList(Arrays.asList(dataVariables));
+    this.previousDataTableVariables = Collections.unmodifiableList(Arrays.asList(previousDataTableVariables));
+    this.line = line;
+  }
+
+  Closure<?> getCode() {
+    return code;
+  }
+
+  List<String> getDataVariables() {
+    return dataVariables;
+  }
+
+  List<String> getPreviousDataTableVariables() {
+    return previousDataTableVariables;
+  }
+
+  int getLine() {
+    return line;
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/StandaloneDataProviders.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/StandaloneDataProviders.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime;
+
+import groovy.lang.Closure;
+import groovy.lang.Tuple;
+import org.spockframework.util.Beta;
+import org.spockframework.util.InternalSpockError;
+import org.spockframework.util.Nullable;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.spockframework.runtime.GroovyRuntimeUtil.closeQuietly;
+
+/**
+ * Runtime helper for standalone {@code @DataProvider} methods.
+ * <p>
+ * Called by code the {@code @DataProvider} transform generates; this class is not
+ * intended to be used directly.
+ *
+ * @since 2.5
+ */
+@Beta
+public abstract class StandaloneDataProviders {
+  private StandaloneDataProviders() {
+  }
+
+  /**
+   * Builds the row iterator of a standalone {@code @DataProvider} method from the closures
+   * the transform emitted inline into the method body.
+   *
+   * @param dataVariableNames the names of the data variables, i.e. the tuple columns, in row order
+   * @param whereVariables computes the where-block variable values once, or {@code null} if there are none
+   * @param dataProviders the data providers, in declaration order
+   * @param dataProcessor turns one set of raw provider values into the data variable values
+   * @param filter drops rows by throwing an {@code AssertionError}, or {@code null} if there is none
+   * @param dataVariableMultiplications provides the {@code combined:} multiplications, or {@code null} if there are none
+   * @return a fresh, lazy iterator over the rows
+   */
+  public static IStandaloneDataIterator dataIterator(String[] dataVariableNames,
+                                                     @Nullable Closure<?> whereVariables,
+                                                     StandaloneDataProviderDescriptor[] dataProviders,
+                                                     Closure<?> dataProcessor,
+                                                     @Nullable Closure<?> filter,
+                                                     @Nullable Closure<?> dataVariableMultiplications) {
+    return new StandaloneDataIterator(DataIteratorFactory.createDataIterator(
+      new StandaloneDataIterationContext(dataVariableNames, whereVariables, dataProviders,
+        dataProcessor, filter, dataVariableMultiplications)));
+  }
+
+  /**
+   * Decorates the {@code Object[]} row iterator: rows are mapped to arity-specific tuples,
+   * exhaustion closes the underlying iterator (and thereby any {@code AutoCloseable}
+   * where-block variables), and {@code close()} is idempotent.
+   */
+  private static class StandaloneDataIterator implements IStandaloneDataIterator {
+    private final IDataIterator delegate;
+    private Object[] nextRow;
+    private boolean closed = false;
+
+    StandaloneDataIterator(IDataIterator delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (nextRow != null) {
+        return true;
+      }
+      if (closed) {
+        return false;
+      }
+      // the delegate's next() returns null instead of a row when a filter block
+      // dropped all remaining rows, so look ahead until a real row appears
+      while (nextRow == null && delegate.hasNext()) {
+        nextRow = delegate.next();
+      }
+      if (nextRow == null) {
+        // exhausted; close eagerly so AutoCloseable where-block variables are
+        // released even if the iterator is discarded without an explicit close()
+        close();
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public Tuple next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      Object[] row = nextRow;
+      nextRow = null;
+      return createTuple(row);
+    }
+
+    @Override
+    public void close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      closeQuietly(delegate);
+    }
+
+    @Override
+    public int getEstimatedNumIterations() {
+      return delegate.getEstimatedNumIterations();
+    }
+
+    @Override
+    public List<String> getDataVariableNames() {
+      return delegate.getDataVariableNames();
+    }
+
+    @Override
+    public Object[] getWhereVariableValues() {
+      return delegate.getWhereVariableValues();
+    }
+  }
+
+  /**
+   * The highest tuple arity any supported Groovy version ships as a dedicated class;
+   * Groovy 2.5 only ships {@code Tuple1}-{@code Tuple9}, Groovy 3.0+ adds
+   * {@code Tuple10}-{@code Tuple16}.
+   */
+  private static final int HIGHEST_FIXED_TUPLE_ARITY = 16;
+
+  // lazily resolved (benign race); the classes must not be referenced statically
+  // because not all of them exist on every supported Groovy version
+  private static final Constructor<?>[] TUPLE_CONSTRUCTORS = new Constructor<?>[HIGHEST_FIXED_TUPLE_ARITY + 1];
+  private static final boolean[] TUPLE_CONSTRUCTOR_MISSING = new boolean[HIGHEST_FIXED_TUPLE_ARITY + 1];
+
+  private static Tuple createTuple(Object[] row) {
+    Constructor<?> constructor = tupleConstructor(row.length);
+    if (constructor == null) {
+      // arity not available as a dedicated class on the current Groovy version
+      return new Tuple(row.clone());
+    }
+    try {
+      return (Tuple) constructor.newInstance(row);
+    } catch (ReflectiveOperationException e) {
+      throw new InternalSpockError("Failed to create tuple of arity %d", e).withArgs(row.length);
+    }
+  }
+
+  @Nullable
+  private static Constructor<?> tupleConstructor(int arity) {
+    if (arity < 1 || arity > HIGHEST_FIXED_TUPLE_ARITY) {
+      return null;
+    }
+    Constructor<?> constructor = TUPLE_CONSTRUCTORS[arity];
+    if (constructor == null && !TUPLE_CONSTRUCTOR_MISSING[arity]) {
+      constructor = resolveTupleConstructor(arity);
+      if (constructor == null) {
+        TUPLE_CONSTRUCTOR_MISSING[arity] = true;
+      } else {
+        TUPLE_CONSTRUCTORS[arity] = constructor;
+      }
+    }
+    return constructor;
+  }
+
+  @Nullable
+  private static Constructor<?> resolveTupleConstructor(int arity) {
+    Class<?> tupleClass;
+    try {
+      tupleClass = Class.forName("groovy.lang.Tuple" + arity, false, Tuple.class.getClassLoader());
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+    for (Constructor<?> candidate : tupleClass.getConstructors()) {
+      // the element constructor's erased parameter types are all Object, which also
+      // rules out the copy constructor (e.g. Tuple1(Tuple1) vs. Tuple1(T1))
+      if (candidate.getParameterCount() == arity
+        && Arrays.stream(candidate.getParameterTypes()).allMatch(type -> type == Object.class)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+}

--- a/spock-core/src/main/java/org/spockframework/runtime/model/StandaloneDataProviderMetadata.java
+++ b/spock-core/src/main/java/org/spockframework/runtime/model/StandaloneDataProviderMetadata.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.runtime.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Attached to rewritten standalone {@code @DataProvider} methods for tooling and
+ * error messages. Distinct from the internal {@link DataProviderMetadata} used on
+ * the per-variable data provider methods generated for a feature.
+ *
+ * @since 2.5
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface StandaloneDataProviderMetadata {
+  String DATA_VARIABLES = "dataVariables";
+  String LINE = "line";
+
+  /**
+   * @return the names of the data variables, i.e. the tuple columns, in row order
+   */
+  String[] dataVariables();
+
+  /**
+   * @return the line number of the annotated method
+   */
+  int line();
+}

--- a/spock-core/src/main/java/spock/lang/DataProvider.java
+++ b/spock-core/src/main/java/spock/lang/DataProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spock.lang;
+
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+import org.spockframework.compiler.DataProviderMethodTransformation;
+import org.spockframework.util.Beta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Turns a method into a standalone data provider whose body is written in the
+ * same grammar as a feature's {@code where:} block.
+ *
+ * <p>The body accepts the full {@code where:}-block grammar: leading {@code final}
+ * where-block local variables, data tables, {@code <<} data pipes, derived
+ * {@code c = a + b} assignments, {@code combined:} multiplications, and an
+ * optional {@code filter:} block whose assertions drop rows. All resulting data
+ * variables become the tuple columns, in declaration order; where-block local
+ * variables and method parameters do not.
+ *
+ * <p>When invoked, the method returns a fresh, lazy {@code Iterator<Tuple>} of
+ * rows; each row is an arity-specific Groovy tuple ({@code Tuple1},
+ * {@code Tuple2}, ...). The iterator can be fed into any feature via the
+ * existing multi-variable data pipe:
+ *
+ * <pre><code>
+ * &#64;DataProvider
+ * def pairs() {
+ *   a | b
+ *   1 | 2
+ *   2 | 3
+ * }
+ *
+ * // in a feature
+ * where:
+ * [a, b] &lt;&lt; pairs()
+ * </code></pre>
+ *
+ * <p>The annotated method may be static or an instance method, may declare
+ * parameters (which are in scope for the whole body, like {@code final}
+ * where-block variables, but are not tuple columns), and may be declared on any
+ * class, not just specifications. Inside a {@code Specification} only
+ * {@code @Shared} and static fields may be referenced, on any other class
+ * instance fields are accessible as usual.
+ *
+ * <p>The returned iterator is {@link AutoCloseable}; closing it (or exhausting
+ * it) closes any {@code AutoCloseable} where-block local variables in reverse
+ * declaration order. A feature consuming the iterator through a data pipe
+ * closes it automatically.
+ *
+ * <p>{@code @CompileStatic} is not supported on {@code @DataProvider} methods,
+ * because the data provider grammar is inherently dynamic.
+ *
+ * @since 2.5
+ */
+@Beta
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@GroovyASTTransformationClass(classes = DataProviderMethodTransformation.class)
+public @interface DataProvider {
+}

--- a/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/DataSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/docs/datadriven/DataSpec.groovy
@@ -4,6 +4,7 @@ import groovy.sql.Sql
 import groovy.transform.ToString
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.runtime.GroovyRuntimeUtil
+import spock.lang.DataProvider
 import spock.lang.Requires
 import spock.lang.Shared
 
@@ -628,6 +629,46 @@ class CoerceBazToBar {
     i != 3
   }
   // end::excluding-iterations[]
+
+  // tag::standalone-data-provider[]
+  @DataProvider
+  def adjacentPairs() {
+    a | b
+    1 | 2
+    2 | 3
+    3 | 4
+  }
+
+  def "consume a standalone data provider"() {
+    expect:
+    b == a + 1
+
+    where:
+    [a, b] << adjacentPairs()
+  }
+  // end::standalone-data-provider[]
+
+  // tag::standalone-data-provider-parameters[]
+  @DataProvider
+  static squaresUpTo(int max) {
+    final label = "square of "
+    number << (1..max)
+    description = label + number
+    square = number * number
+
+    filter:
+    square <= 20
+  }
+  // end::standalone-data-provider-parameters[]
+
+  def "consume a parameterized standalone data provider"() {
+    expect:
+    square == number * number
+    description == "square of $number"
+
+    where:
+    [number, description, square] << squaresUpTo(10)
+  }
 
   @ToString(includes = ['name'], includePackage = false)
   static class Person {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
@@ -715,6 +715,100 @@ def onlyLocals() {
     e.message.startsWith("where-block variables require at least one data variable")
   }
 
+  def "the body may open with an optional where: label"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+def pairs() {
+  where:
+  a | b
+  1 | 2
+  2 | 3
+}
+
+def feature() {
+  expect:
+  b == a + 1
+
+  where:
+  [a, b] << pairs()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 3
+  }
+
+  def "the opening where: label may carry a description"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+def pairs() {
+  where: "the input pairs"
+  a | b
+  1 | 2
+  2 | 3
+}
+
+def feature() {
+  expect:
+  b == a + 1
+
+  where:
+  [a, b] << pairs()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 3
+  }
+
+  def "an invalid or misplaced label in the body is a compile error"() {
+    when:
+    compiler.compileSpecBody """
+@DataProvider
+def items() {
+$body
+}
+"""
+
+    then:
+    InvalidSpecCompileException e = thrown()
+    e.message.contains(expectedMessagePart)
+
+    where:
+    body                        | expectedMessagePart
+    'expect:\na << [1]'         | "'expect:' blocks are not valid in a @DataProvider method"  // feature-method opener
+    'given:\na << [1]'          | "blocks are not valid in a @DataProvider method"            // feature-method opener (given -> setup)
+    'wheer:\na << [1]'          | "Unrecognized block label: wheer"                           // typo
+    'combined:\na << [1]'       | "'combined' is not allowed here"                            // combined cannot open a body
+    'filter:\na << [1]'         | "'filter' is not allowed here"                              // filter cannot open a body
+    'a << [1]\nwhere:\nb = a'   | "'where' is not allowed here"                               // where: only as the opener
+  }
+
+  def "the body still accepts where-block continuation labels"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+def data() {
+  a << [1, 2]
+  and:
+  b << [10, 20]
+}
+
+def feature() {
+  expect:
+  b == a * 10
+
+  where:
+  [a, b] << data()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 3
+  }
+
   def "where-block variable rules are inherited"() {
     when:
     compiler.compileSpecBody """

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
@@ -16,20 +16,24 @@
 
 package org.spockframework.smoke.parameterization
 
-import groovy.lang.Tuple1
-import groovy.lang.Tuple2
+
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import org.codehaus.groovy.syntax.SyntaxException
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.compiler.InvalidSpecCompileException
 import org.spockframework.runtime.GroovyRuntimeUtil
+import org.spockframework.runtime.model.StandaloneDataProviderMetadata
 import spock.lang.Requires
 
 import java.lang.reflect.ParameterizedType
 
 class StandaloneDataProviderMethods extends EmbeddedSpecification {
 
+  // EmbeddedSpecCompiler.compile() filters its result to specifications, so plain
+  // classes must be parsed directly; reuse the per-test loader so the parsed classes
+  // share the embedded compiler's lifecycle
   private Class compilePlainClass(String source) {
-    new GroovyClassLoader(getClass().classLoader).parseClass("import spock.lang.DataProvider\n\n" + source)
+    compiler.loader.parseClass("import spock.lang.DataProvider\n\n" + source)
   }
 
   def "data table provider in a spec is consumed via multi-variable data pipe"() {
@@ -88,10 +92,10 @@ def pairs() {
 '''
 
     when:
-    def rows = clazz.newInstance().pairs().collect()
+    def rows = instantiate(clazz).pairs().collect()
 
     then:
-    rows.every { it instanceof Tuple2 }
+    verifyEach(rows) { it instanceof Tuple2 }
     rows*.toList() == [[1, 2], [2, 3]]
   }
 
@@ -107,10 +111,12 @@ class Providers {
 '''
 
     when:
-    def rows = clazz.newInstance().values().collect()
+    def rows = instantiate(clazz).values().collect()
 
     then:
-    rows.every { it instanceof Tuple1 }
+    verifyEach(rows) {
+      it instanceof Tuple1
+    }
     rows*.toList() == [[1], [2]]
   }
 
@@ -134,7 +140,7 @@ class Providers {
 '''
 
     when:
-    def rows = clazz.newInstance().rich().collect()
+    def rows = instantiate(clazz).rich().collect()
 
     then:
     rows*.toList() == [[1, 10, 11], [2, 20, 22]]
@@ -154,7 +160,7 @@ class Providers {
 '''
 
     expect:
-    clazz.newInstance().table().collect { it.toList() } == [[1, 2], [2, 4]]
+    instantiate(clazz).table().collect { it.toList() } == [[1, 2], [2, 4]]
   }
 
   def "combined data providers yield the cross product"() {
@@ -171,7 +177,7 @@ class Providers {
 '''
 
     when:
-    def rows = clazz.newInstance().matrix().collect()
+    def rows = instantiate(clazz).matrix().collect()
 
     then:
     rows*.toList() == [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']]
@@ -230,7 +236,7 @@ class Providers {
 '''
 
     expect:
-    clazz.newInstance().items().collect { it.toList() } == [[1], [2], [3]]
+    instantiate(clazz).items().collect { it.toList() } == [[1], [2], [3]]
   }
 
   def "provider in a spec can access @Shared and static fields"() {
@@ -283,7 +289,7 @@ class Providers {
   }
 }
 '''
-    def instance = clazz.newInstance()
+    def instance = instantiate(clazz)
 
     expect:
     instance.values().collect { it.toList() } == [[1], [2]]
@@ -346,7 +352,7 @@ class Providers {
   }
 }
 '''
-    def instance = clazz.newInstance()
+    def instance = instantiate(clazz)
 
     expect:
     instance.known().getEstimatedNumIterations() == 3
@@ -415,7 +421,7 @@ class Providers {
 '''
 
     expect:
-    clazz.newInstance().items().collect { it.toList() } == [[2], [3]]
+    instantiate(clazz).items().collect { it.toList() } == [[2], [3]]
   }
 
   def "the returned iterator exposes the data variable names"() {
@@ -431,7 +437,7 @@ class Providers {
 '''
 
     expect:
-    clazz.newInstance().pairs().getDataVariableNames() == ["a", "b"]
+    instantiate(clazz).pairs().getDataVariableNames() == ["a", "b"]
   }
 
   def "where-block variables are evaluated once and are not columns"() {
@@ -448,11 +454,13 @@ class Providers {
 '''
 
     when:
-    def rows = clazz.newInstance().items().collect()
+    def rows = instantiate(clazz).items().collect()
 
     then:
     rows.size() == 2
-    rows.every { it.size() == 2 }
+    verifyEach(rows) {
+      it.size() == 2
+    }
     rows[0][1].is(rows[1][1])  // single evaluation
   }
 
@@ -477,7 +485,7 @@ class Res implements AutoCloseable {
 '''
 
     when:
-    def iterator = clazz.newInstance().items()
+    def iterator = instantiate(clazz).items()
     iterator.next()
     iterator.close()
 
@@ -505,7 +513,7 @@ class Res implements AutoCloseable {
 '''
 
     when: "the iterator is exhausted and discarded without an explicit close()"
-    def values = clazz.newInstance().items().collect { it[0] }
+    def values = instantiate(clazz).items().collect { it[0] }
 
     then:
     values == [1, 2]
@@ -534,7 +542,7 @@ class Res implements AutoCloseable {
 '''
 
     when:
-    clazz.newInstance().items()
+    instantiate(clazz).items()
 
     then:
     IllegalStateException e = thrown()
@@ -594,7 +602,7 @@ class Res implements AutoCloseable {
 '''
 
     when:
-    def iterator = clazz.newInstance().items()
+    def iterator = instantiate(clazz).items()
     iterator.collect()
     iterator.close()
     iterator.close()
@@ -617,7 +625,7 @@ class Providers {
 '''
 
     expect:
-    clazz.newInstance().items().collect { it.toList() } == [[1], [2], [3]]
+    instantiate(clazz).items().collect { it.toList() } == [[1], [2], [3]]
   }
 
   def "a def provider gets a synthesized Iterator return type"() {
@@ -753,7 +761,7 @@ def upTo(int n) {
 '''
 
     then: "Groovy itself already rejects a local variable shadowing a parameter"
-    org.codehaus.groovy.syntax.SyntaxException e = thrown()
+    SyntaxException e = thrown()
     e.message.contains("variable") && e.message.contains("n")
   }
 
@@ -810,7 +818,7 @@ class Providers {
 '''
 
     when:
-    def rows = clazz.newInstance().wide().collect()
+    def rows = instantiate(clazz).wide().collect()
 
     then:
     rows*.toList() == [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
@@ -832,7 +840,7 @@ class Providers {
 
     when:
     def method = clazz.declaredMethods.find { it.name == "pairs" }
-    def metadata = method.getAnnotation(org.spockframework.runtime.model.StandaloneDataProviderMetadata)
+    def metadata = method.getAnnotation(StandaloneDataProviderMetadata)
 
     then:
     metadata != null
@@ -861,5 +869,9 @@ def feature() {
 
     then:
     result.testsSucceededCount == 3
+  }
+
+  private static <T> T instantiate(Class<T> clazz) {
+    clazz.getDeclaredConstructor().newInstance()
   }
 }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
@@ -512,6 +512,68 @@ class Res implements AutoCloseable {
     clazz.closed == ["res"]
   }
 
+  def "AutoCloseable where-block variables are closed when a data provider fails"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  static List closed = []
+
+  @DataProvider
+  def items() {
+    final res = new Res(name: "res")
+    a << broken()
+  }
+
+  static List broken() { throw new IllegalStateException("boom") }
+}
+
+class Res implements AutoCloseable {
+  String name
+  void close() { Providers.closed << name }
+}
+'''
+
+    when:
+    clazz.newInstance().items()
+
+    then:
+    IllegalStateException e = thrown()
+    e.message == "boom"
+    clazz.closed == ["res"]
+  }
+
+  def "already-created where-block variables are closed in reverse declaration order when a later initializer throws"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  static List closed = []
+
+  @DataProvider
+  def items() {
+    final first = new Res(name: "first")
+    final second = new Res(name: "second")
+    final boom = broken()
+    a << [1, 2]
+  }
+
+  static def broken() { throw new IllegalStateException("boom") }
+}
+
+class Res implements AutoCloseable {
+  String name
+  void close() { Providers.closed << name }
+}
+'''
+
+    when:
+    instantiate(clazz).items()
+
+    then:
+    IllegalStateException e = thrown()
+    e.message == "boom"
+    clazz.closed == ["second", "first"]
+  }
+
   def "close is idempotent"() {
     given:
     def clazz = compilePlainClass '''

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
@@ -1,0 +1,738 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.spockframework.smoke.parameterization
+
+import groovy.lang.Tuple1
+import groovy.lang.Tuple2
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.compiler.InvalidSpecCompileException
+import org.spockframework.runtime.GroovyRuntimeUtil
+import spock.lang.Requires
+
+import java.lang.reflect.ParameterizedType
+
+class StandaloneDataProviderMethods extends EmbeddedSpecification {
+
+  private Class compilePlainClass(String source) {
+    new GroovyClassLoader(getClass().classLoader).parseClass("import spock.lang.DataProvider\n\n" + source)
+  }
+
+  def "data table provider in a spec is consumed via multi-variable data pipe"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+def pairs() {
+  a | b
+  1 | 2
+  2 | 3
+}
+
+def feature() {
+  expect:
+  b == a + 1
+
+  where:
+  [a, b] << pairs()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 3  // the feature node plus one node per iteration
+  }
+
+  def "single column provider uses Tuple1 and is consumed via single-element list pipe"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+def values() {
+  a << [1, 2, 3]
+}
+
+def feature() {
+  expect:
+  a in [1, 2, 3]
+
+  where:
+  [a] << values()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 4
+  }
+
+  def "rows are emitted as arity-specific tuples"() {
+    given:
+    def clazz = compiler.compileSpecBody '''
+@DataProvider
+def pairs() {
+  a | b
+  1 | 2
+  2 | 3
+}
+'''
+
+    when:
+    def rows = clazz.newInstance().pairs().collect()
+
+    then:
+    rows.every { it instanceof Tuple2 }
+    rows*.toList() == [[1, 2], [2, 3]]
+  }
+
+  def "single column rows are emitted as Tuple1"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def values() {
+    a << [1, 2]
+  }
+}
+'''
+
+    when:
+    def rows = clazz.newInstance().values().collect()
+
+    then:
+    rows.every { it instanceof Tuple1 }
+    rows*.toList() == [[1], [2]]
+  }
+
+  def "provider supports the full where-block grammar"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def rich() {
+    a | b
+    1 | 10
+    2 | 20
+    3 | 30
+
+    c = a + b
+
+    filter:
+    c < 33
+  }
+}
+'''
+
+    when:
+    def rows = clazz.newInstance().rich().collect()
+
+    then:
+    rows*.toList() == [[1, 10, 11], [2, 20, 22]]
+  }
+
+  def "data table cells can reference previous columns"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def table() {
+    x | y
+    1 | x + 1
+    2 | x + 2
+  }
+}
+'''
+
+    expect:
+    clazz.newInstance().table().collect { it.toList() } == [[1, 2], [2, 4]]
+  }
+
+  def "combined data providers yield the cross product"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def matrix() {
+    x << [1, 2]
+    combined:
+    y << ['a', 'b']
+  }
+}
+'''
+
+    when:
+    def rows = clazz.newInstance().matrix().collect()
+
+    then:
+    rows*.toList() == [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']]
+  }
+
+  def "provider can be a static method"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  static pairs() {
+    a | b
+    1 | 2
+  }
+}
+'''
+
+    expect:
+    clazz.pairs().collect { it.toList() } == [[1, 2]]
+  }
+
+  def "static provider in a spec is consumed via data pipe"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+static pairs() {
+  a | b
+  1 | 2
+  2 | 3
+}
+
+def feature() {
+  expect:
+  b == a + 1
+
+  where:
+  [a, b] << pairs()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 3
+  }
+
+  def "instance provider on a plain class can access instance fields"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  def values = [1, 2, 3]
+
+  @DataProvider
+  def items() {
+    a << values
+  }
+}
+'''
+
+    expect:
+    clazz.newInstance().items().collect { it.toList() } == [[1], [2], [3]]
+  }
+
+  def "provider in a spec can access @Shared and static fields"() {
+    when:
+    def result = runner.runSpecBody '''
+@Shared
+List shared = [1, 2]
+
+@DataProvider
+def items() {
+  a << shared
+}
+
+def feature() {
+  expect:
+  a in [1, 2]
+
+  where:
+  [a] << items()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 3
+  }
+
+  def "provider in a spec must not access instance fields"() {
+    when:
+    compiler.compileSpecBody '''
+List values = [1, 2]
+
+@DataProvider
+def items() {
+  a << values
+}
+'''
+
+    then:
+    InvalidSpecCompileException e = thrown()
+    e.message.startsWith("Only @Shared and static fields may be accessed from here")
+  }
+
+  def "each invocation returns a fresh iterator"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def values() {
+    a << [1, 2]
+  }
+}
+'''
+    def instance = clazz.newInstance()
+
+    expect:
+    instance.values().collect { it.toList() } == [[1], [2]]
+    instance.values().collect { it.toList() } == [[1], [2]]
+  }
+
+  def "method parameters are body-wide inputs but not columns"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  static upTo(int n) {
+    final base = n * 10
+    a << (1..n)
+    b = a + base
+
+    filter:
+    b < 32
+  }
+}
+'''
+
+    expect:
+    clazz.upTo(3).collect { it.toList() } == [[1, 31]]
+    clazz.upTo(1).collect { it.toList() } == [[1, 11]]
+  }
+
+  def "method parameters are kept verbatim in the rewritten signature"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  static upTo(int n, String tag) {
+    a << (1..n)
+    b = tag + a
+  }
+}
+'''
+
+    when:
+    def method = clazz.declaredMethods.find { it.name == "upTo" }
+
+    then:
+    method.parameterTypes*.simpleName == ["int", "String"]
+    clazz.upTo(2, "x").collect { it.toList() } == [[1, "x1"], [2, "x2"]]
+  }
+
+  def "the estimated iteration count of the returned iterator is accurate for known sizes"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def known() {
+    a << [1, 2, 3]
+  }
+
+  @DataProvider
+  def unknown() {
+    a << [1, 2, 3].iterator()
+  }
+}
+'''
+    def instance = clazz.newInstance()
+
+    expect:
+    instance.known().getEstimatedNumIterations() == 3
+    instance.unknown().getEstimatedNumIterations() == -1
+  }
+
+  def "the returned iterator exposes the data variable names"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def pairs() {
+    a | b
+    1 | 2
+  }
+}
+'''
+
+    expect:
+    clazz.newInstance().pairs().getDataVariableNames() == ["a", "b"]
+  }
+
+  def "where-block variables are evaluated once and are not columns"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def items() {
+    final marker = new Object()
+    a << [1, 2]
+    b = marker
+  }
+}
+'''
+
+    when:
+    def rows = clazz.newInstance().items().collect()
+
+    then:
+    rows.size() == 2
+    rows.every { it.size() == 2 }
+    rows[0][1].is(rows[1][1])  // single evaluation
+  }
+
+  def "AutoCloseable where-block variables are closed in reverse order on close"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  static List closed = []
+
+  @DataProvider
+  def items() {
+    final first = new Res(name: "first")
+    final second = new Res(name: "second")
+    a << [1, 2]
+  }
+}
+
+class Res implements AutoCloseable {
+  String name
+  void close() { Providers.closed << name }
+}
+'''
+
+    when:
+    def iterator = clazz.newInstance().items()
+    iterator.next()
+    iterator.close()
+
+    then:
+    clazz.closed == ["second", "first"]
+  }
+
+  def "AutoCloseable where-block variables are closed on exhaustion"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  static List closed = []
+
+  @DataProvider
+  def items() {
+    final res = new Res(name: "res")
+    a << [1, 2]
+  }
+}
+
+class Res implements AutoCloseable {
+  String name
+  void close() { Providers.closed << name }
+}
+'''
+
+    when: "the iterator is exhausted and discarded without an explicit close()"
+    def values = clazz.newInstance().items().collect { it[0] }
+
+    then:
+    values == [1, 2]
+    clazz.closed == ["res"]
+  }
+
+  def "close is idempotent"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  static List closed = []
+
+  @DataProvider
+  def items() {
+    final res = new Res(name: "res")
+    a << [1]
+  }
+}
+
+class Res implements AutoCloseable {
+  String name
+  void close() { Providers.closed << name }
+}
+'''
+
+    when:
+    def iterator = clazz.newInstance().items()
+    iterator.collect()
+    iterator.close()
+    iterator.close()
+
+    then:
+    clazz.closed == ["res"]
+  }
+
+  @Requires(value = { GroovyRuntimeUtil.MAJOR_VERSION >= 3 }, reason = "'final (a, b) = ...' is only parseable by the Parrot parser (Groovy 3.0+)")
+  def "multiple-assignment where-block variables are supported"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def items() {
+    final (low, high) = [1, 3]
+    a << (low..high)
+  }
+}
+'''
+
+    expect:
+    clazz.newInstance().items().collect { it.toList() } == [[1], [2], [3]]
+  }
+
+  def "a def provider gets a synthesized Iterator return type"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def pairs() {
+    a | b
+    1 | 2
+  }
+}
+'''
+
+    when:
+    def method = clazz.declaredMethods.find { it.name == "pairs" }
+
+    then:
+    method.returnType == Iterator
+    method.genericReturnType instanceof ParameterizedType
+    (method.genericReturnType as ParameterizedType).actualTypeArguments[0].typeName.contains("Tuple2")
+  }
+
+  def "explicit return type declarations are accepted when valid"() {
+    when:
+    compiler.compileSpecBody """
+@DataProvider
+$returnType pairs() {
+  a | b
+  1 | 2
+}
+"""
+
+    then:
+    noExceptionThrown()
+
+    where:
+    returnType << ["Iterator", "Iterator<Tuple2>", "Iterator<Tuple2<Integer, Integer>>"]
+  }
+
+  def "invalid return type declarations are compile errors"() {
+    when:
+    compiler.compileSpecBody """
+@DataProvider
+$returnType pairs() {
+  a | b
+  1 | 2
+}
+"""
+
+    then:
+    InvalidSpecCompileException e = thrown()
+    e.message.contains(expectedMessagePart)
+
+    where:
+    returnType           | expectedMessagePart
+    "List"               | "must be declared 'def' or with a return type of java.util.Iterator"
+    "Iterable"           | "must be declared 'def' or with a return type of java.util.Iterator"
+    "Iterator<Tuple3>"   | "declares return type Iterator<Tuple3>, but produces 2 data variable(s) [a, b]"
+    "Iterator<String>"   | "element type must be groovy.lang.Tuple or an arity-specific Tuple class"
+  }
+
+  def "a body without any data variable is a compile error"() {
+    when:
+    compiler.compileSpecBody '''
+@DataProvider
+def empty() {
+}
+'''
+
+    then:
+    InvalidSpecCompileException e = thrown()
+    e.message.contains("must declare at least one data variable")
+  }
+
+  def "a body with only where-block variables is a compile error"() {
+    when:
+    compiler.compileSpecBody '''
+@DataProvider
+def onlyLocals() {
+  final x = 1
+}
+'''
+
+    then:
+    InvalidSpecCompileException e = thrown()
+    e.message.startsWith("where-block variables require at least one data variable")
+  }
+
+  def "where-block variable rules are inherited"() {
+    when:
+    compiler.compileSpecBody """
+@DataProvider
+def items() {
+$body
+}
+"""
+
+    then:
+    InvalidSpecCompileException e = thrown()
+    e.message.startsWith(expectedMessagePart)
+
+    where:
+    body                                | expectedMessagePart
+    'def sep = "/"\na << [1]'           | "where-block variables must be declared 'final'"
+    'a << [1]\nfinal sep = "/"'         | "where-block variables must be declared at the beginning"
+    'final $spock_x = 1\na << [1]'      | "Variable name '\$spock_x' is invalid"
+    'final sep = "/"\nsep << [1]'       | "Data variable 'sep' collides with a where-block variable of the same name"
+  }
+
+  def "a data variable colliding with a method parameter is a compile error"() {
+    when:
+    compiler.compileSpecBody '''
+@DataProvider
+def upTo(int n) {
+  n << [1]
+}
+'''
+
+    then:
+    InvalidSpecCompileException e = thrown()
+    e.message.startsWith("Data variable 'n' collides with a method parameter of the same name")
+  }
+
+  def "a where-block variable colliding with a method parameter is a compile error"() {
+    when:
+    compiler.compileSpecBody '''
+@DataProvider
+def upTo(int n) {
+  final n = 1
+  a << [n]
+}
+'''
+
+    then: "Groovy itself already rejects a local variable shadowing a parameter"
+    org.codehaus.groovy.syntax.SyntaxException e = thrown()
+    e.message.contains("variable") && e.message.contains("n")
+  }
+
+  def "@CompileStatic on the method is a compile error"() {
+    when:
+    compilePlainClass '''
+import groovy.transform.CompileStatic
+
+class Providers {
+  @CompileStatic
+  @DataProvider
+  def pairs() {
+    a | b
+    1 | 2
+  }
+}
+'''
+
+    then:
+    MultipleCompilationErrorsException e = thrown()
+    e.message.contains("@DataProvider methods do not support @CompileStatic")
+  }
+
+  def "@CompileStatic on the declaring class is a compile error"() {
+    when:
+    compilePlainClass '''
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class Providers {
+  @DataProvider
+  def pairs() {
+    a | b
+    1 | 2
+  }
+}
+'''
+
+    then:
+    MultipleCompilationErrorsException e = thrown()
+    e.message.contains("@DataProvider methods do not support @CompileStatic")
+  }
+
+  def "rows above the highest fixed tuple arity fall back to the generic Tuple"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def wide() {
+    a1 << [1]; a2 << [2]; a3 << [3]; a4 << [4]; a5 << [5]; a6 << [6]
+    a7 << [7]; a8 << [8]; a9 << [9]; a10 << [10]
+  }
+}
+'''
+
+    when:
+    def rows = clazz.newInstance().wide().collect()
+
+    then:
+    rows*.toList() == [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
+    // Groovy 2.5 only ships Tuple1-Tuple9, so arity 10 degrades to the generic Tuple there
+    rows[0].getClass().name == (GroovyRuntimeUtil.MAJOR_VERSION >= 3 ? "groovy.lang.Tuple10" : "groovy.lang.Tuple")
+  }
+
+  def "the rewritten method carries the standalone data provider metadata"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def pairs() {
+    a | b
+    1 | 2
+  }
+}
+'''
+
+    when:
+    def method = clazz.declaredMethods.find { it.name == "pairs" }
+    def metadata = method.getAnnotation(org.spockframework.runtime.model.StandaloneDataProviderMetadata)
+
+    then:
+    metadata != null
+    metadata.dataVariables() == ["a", "b"]
+    metadata.line() > 0
+  }
+
+  def "provider consumed indirectly still works"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+def pairs() {
+  a | b
+  1 | 2
+  2 | 3
+}
+
+def feature() {
+  expect:
+  x in [1, 2]
+
+  where:
+  x << pairs().collect { it[0] }
+}
+'''
+
+    then:
+    result.testsSucceededCount == 3
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/parameterization/StandaloneDataProviderMethods.groovy
@@ -81,9 +81,9 @@ def feature() {
     def clazz = compiler.compileSpecBody '''
 @DataProvider
 def pairs() {
-  a | b
-  1 | 2
-  2 | 3
+  a || b
+  1 || 2
+  2 || 3
 }
 '''
 
@@ -351,6 +351,71 @@ class Providers {
     expect:
     instance.known().getEstimatedNumIterations() == 3
     instance.unknown().getEstimatedNumIterations() == -1
+  }
+
+  def "a consuming feature picks up the estimated iteration count"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+def pairs() {
+  a | b
+  1 | 2
+  2 | 3
+  3 | 4
+}
+
+def feature() {
+  expect:
+  specificationContext.currentIteration.estimatedNumIterations == 3
+
+  where:
+  [a, b] << pairs()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 4
+  }
+
+  def "a consuming feature reports an unknown iteration count for a lazy data pipe"() {
+    when:
+    def result = runner.runSpecBody '''
+@DataProvider
+def lazy() {
+  a << [1, 2, 3].iterator()
+}
+
+def feature() {
+  expect:
+  specificationContext.currentIteration.estimatedNumIterations == -1
+
+  where:
+  [a] << lazy()
+}
+'''
+
+    then:
+    result.testsSucceededCount == 4
+  }
+
+  def "where-block variables are visible to pipes and the filter block"() {
+    given:
+    def clazz = compilePlainClass '''
+class Providers {
+  @DataProvider
+  def items() {
+    final limit = 3
+    final threshold = 2
+    a << (1..limit)
+
+    filter:
+    a >= threshold
+  }
+}
+'''
+
+    expect:
+    clazz.newInstance().items().collect { it.toList() } == [[2], [3]]
   }
 
   def "the returned iterator exposes the data variable names"() {


### PR DESCRIPTION
## Summary

Introduces `@DataProvider` methods: a method whose body is written exactly like the content of a `where:` block, and whose call returns a fresh, lazy `Iterator` over the resulting rows. Each row is an arity-specific Groovy tuple (`Tuple1`, `Tuple2`, ...), so the provider can feed any feature through the existing multi-variable data pipe (`[a, b] << provider()`).

This makes the full `where:` block grammar reusable outside a single feature:

- accepts local variables, data tables, data pipes, derived variables, `combined:` multiplications, and a trailing `filter:` block;
- all resulting data variables become tuple columns in declaration order (where-block local variables do not);
- may be declared on any class (not only specifications), `static` or instance, and may declare method parameters;
- inside a spec it follows the same access rules as a `where:` block (`@Shared`/`static` readable, plain instance fields not);
- `def` providers get an inferred `Iterator<TupleN>` return type; an explicit return type must be `java.util.Iterator`;
- the returned iterator is `AutoCloseable` and closes any `AutoCloseable` where-block local variables in reverse declaration order, including when consumed indirectly or via a feature's data pipe.

## Implementation notes

- Extracts `IDataIterationContext` / `IBaseDataIterator` from `DataIteratorFactory` so standalone providers and feature methods share the tuple-iteration machinery.
- Splits where-block parsing from feature-method emission in `WhereBlockRewriter`, exposing the parsed providers/variables for reuse by the new `DataProviderMethodRewriter`/`DataProviderMethodTransformation`.

## Test plan

- New `StandaloneDataProviderMethods` smoke spec (47 cases), all green.
- Full `org.spockframework.smoke.parameterization.*` and `org.spockframework.docs.datadriven.*` suites pass (501 passed, 1 skipped, 0 failed), confirming existing where-block behavior is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)