### PR TITLE
Migrate to the OSS Community Develocity Instance

### DIFF
--- a/.github/workflows/branches-and-prs.yaml
+++ b/.github/workflows/branches-and-prs.yaml
@@ -127,7 +127,7 @@ jobs:
     - id: 'step-3'
       name: 'Build Spock'
       env:
-        DEVELOCITY_ACCESS_KEY: '${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}'
+        DEVELOCITY_ACCESS_KEY: '${{ secrets.DEVELOCITY_ACCESS_KEY }}'
       run: './gradlew --stacktrace ghActionsBuild "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}"'
     - id: 'step-4'
       name: 'Upload to Codecov.io'

--- a/.github/workflows/common.main.kts
+++ b/.github/workflows/common.main.kts
@@ -32,10 +32,10 @@ import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource.Infer
 import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
 import java.util.Properties
 
-val GRADLE_ENTERPRISE_ACCESS_KEY by secrets
+val DEVELOCITY_ACCESS_KEY by secrets
 
 val commonCredentials = mapOf(
-    "DEVELOCITY_ACCESS_KEY" to expr(GRADLE_ENTERPRISE_ACCESS_KEY)
+    "DEVELOCITY_ACCESS_KEY" to expr(DEVELOCITY_ACCESS_KEY)
 )
 
 // Work-around for https://youtrack.jetbrains.com/issue/KT-86352,

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,7 +100,7 @@ jobs:
     - id: 'step-2'
       name: 'Build Spock'
       env:
-        DEVELOCITY_ACCESS_KEY: '${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}'
+        DEVELOCITY_ACCESS_KEY: '${{ secrets.DEVELOCITY_ACCESS_KEY }}'
       run: './gradlew --stacktrace ghActionsBuild "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}" "-Dscan.tag.main-build"'
     - id: 'step-3'
       name: 'Stop Daemon'
@@ -147,7 +147,7 @@ jobs:
         SONATYPE_OSS_USER: '${{ secrets.SONATYPE_OSS_USER }}'
         SONATYPE_OSS_PASSWORD: '${{ secrets.SONATYPE_OSS_PASSWORD }}'
         SIGNING_PASSWORD: '${{ secrets.SIGNING_GPG_PASSWORD }}'
-        DEVELOCITY_ACCESS_KEY: '${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}'
+        DEVELOCITY_ACCESS_KEY: '${{ secrets.DEVELOCITY_ACCESS_KEY }}'
       run: './gradlew --no-parallel --stacktrace ghActionsPublish "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}" "-Dscan.tag.main-publish"'
   publish-release-docs:
     name: 'Publish Release Docs'
@@ -179,5 +179,5 @@ jobs:
       name: 'Publish Docs'
       env:
         GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        DEVELOCITY_ACCESS_KEY: '${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}'
+        DEVELOCITY_ACCESS_KEY: '${{ secrets.DEVELOCITY_ACCESS_KEY }}'
       run: './gradlew --no-parallel --stacktrace ghActionsDocs "-Dvariant=${{ matrix.variant }}" "-DjavaVersion=${{ matrix.java }}" "-Dscan.tag.main-docs"'

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ Workflow Status (branch)]]
 https://jitpack.io/#org.spockframework/spock[image:https://jitpack.io/v/org.spockframework/spock.svg[Jitpack]]
 https://codecov.io/gh/spockframework/spock[image:https://codecov.io/gh/spockframework/spock/branch/master/graph/badge.svg[Codecov]]
 https://gitter.im/spockframework/spock?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge[image:https://badges.gitter.im/spockframework/spock.svg[Gitter]]
-https://ge.spockframework.org/scans[image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A[Revved
+https://community.develocity.cloud/scans?search.rootProjectNames=spock[image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A[Revved
 up by Develocity]]
 
 image::docs/images/spock-main-logo.png[width=100px,float=right]

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,7 @@ if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
 }
 
 
-def develocityServer = "https://ge.spockframework.org"
+def develocityServer = "https://community.develocity.cloud"
 def isCiServer = System.env["CI"] || System.env["GITHUB_ACTIONS"]
 
 def accessKeysAreMissing() {
@@ -40,6 +40,7 @@ def accessKeysAreMissing() {
 }
 
 develocity {
+  projectId = "spockframework"
   buildScan {
     uploadInBackground = !isCiServer
 


### PR DESCRIPTION
This PR moves Spock's Build Scan publishing and remote Build Cache from
the self-hosted `ge.spockframework.org` instance to the **OSS Community
Develocity Instance** at <https://community.develocity.cloud> under
project ID `spockframework`.

## What this PR changes

- `settings.gradle`: new Develocity server URL and Project-Level Access
Control ID.
- `README.adoc`: "Revved up by Develocity" badge link
- GitHub Actions workflows: renamed `GRADLE_ENTERPRISE_ACCESS_KEY`
to `DEVELOCITY_ACCESS_KEY`

Nothing else is touched: plugin versions, the Terms-of-Use fallback for
unauthenticated CI runs / `--scan` and the HTTP build cache fallback are all
preserved.

## Step 1: Get an access key for `community.develocity.cloud`

1. Visit <https://community.develocity.cloud>.
2. **Sign in as the CI service account that the Develocity Solutions
   team has provisioned for spockframework** — that account was shared
   with you out-of-band when this onboarding was set up. The access key
   inherits that account's project memberships and permissions, which
   is exactly what you want for CI.
3. From the user menu in the top-right, open **My settings** → **Access
   keys**.
4. Click **Generate access key**, give it a description (e.g.
   `GitHub Actions`), and copy the generated key. Keep this tab open
   until you complete Step 2 — the key is only shown once.

## Step 2: Add the `DEVELOCITY_ACCESS_KEY` secret on this repository

CI exposes a repository secret named `DEVELOCITY_ACCESS_KEY`
to the build as `DEVELOCITY_ACCESS_KEY` (via
`.github/workflows/common.main.kts`). The secret **name** stays the
same; only the **value** needs to change to point at the new instance.

1. Open this repository on GitHub.
2. Click **Settings**.
3. In the left sidebar, click **Secrets and variables** → **Actions**.
4. Find the `DEVELOCITY_ACCESS_KEY` secret and click **Update**.
5. Set the new value to the line below, replacing
   `PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE` with the key you copied in
   Step 1:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required** — without
   the host name, the access key is silently ignored. This is the most
   common point of failure when onboarding, so please double-check the
   format.
6. Click **Update secret**.

## Step 3: Provision an access key for your local builds

Developers building spock locally should provision a personal access
key for `community.develocity.cloud` so their Build Scans publish and
they get reads from the remote Build Cache. The Develocity Gradle
plugin's `provisionDevelocityAccessKey` task does this in a single
command — it opens the browser, asks the developer to confirm, and
writes the key to `~/.gradle/develocity/keys.properties` automatically.

**Before running this command**, sign out of
`community.develocity.cloud` in your browser (or use a
private/incognito window) so the access key gets associated with
**your personal account**, not the CI service account you signed in
as for Step 1.

```
./gradlew provisionDevelocityAccessKey
```

## Note on the CI run on this PR

This PR was prepared from a fork. Forks can't read this repository's
secrets, which means the workflow run on this PR cannot publish to
`community.develocity.cloud`. If you'd rather see a scan published to
the new instance before merging, you're welcome to reopen this PR from
your own account.
