### PR TITLE
Fix Mock does not intercept package-private methods in OSGi correctly

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -19,6 +19,8 @@ include::include.adoc[]
 * Fix `SourceToAstNodeAndSourceTranspiler` dropping nested generic type arguments, so signatures like `Iterator<Tuple2<Integer, Integer>>` are now rendered faithfully instead of `Iterator<Tuple2>` spockPull:2393[]
 * Fix `SourceToAstNodeAndSourceTranspiler` rendering of several other constructs: the elvis operator, attribute access (`.@`), implicit-`it` closures, safe index access (`?[]`), numeric literal type suffixes (`L`, `F`, `D`, `G`), left-open ranges (`<..`), explicit type arguments of method calls, `for (index, value in iterable)` loops, multiple-assignment declarations on Groovy 5, and spurious empty `finally` blocks and `default` labels spockPull:2393[]
 * Fix interaction mismatch rendering failing with a lexer error and dropping the similarity report when a mocked method or property name contains a `$` spockIssue:2364[]
+* Fix Mock does not intercept package-private methods in OSGi correctly spockIssue:2384[]
+** This only works for Java > 9, due to missing `MethodHandles.Lookup` API in Java 8
 
 === Breaking Changes
 

--- a/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
+++ b/spock-core/src/main/java/org/spockframework/mock/runtime/ByteBuddyMockFactory.java
@@ -29,7 +29,6 @@ import net.bytebuddy.description.modifier.Visibility;
 import net.bytebuddy.dynamic.Transformer;
 import net.bytebuddy.dynamic.loading.ClassInjector;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
-import net.bytebuddy.dynamic.loading.MultipleParentClassLoader;
 import net.bytebuddy.dynamic.scaffold.TypeValidation;
 import net.bytebuddy.implementation.FieldAccessor;
 import net.bytebuddy.implementation.FixedValue;
@@ -96,19 +95,36 @@ class ByteBuddyMockFactory {
    * A mock is considered local, if all additional interfaces of the mock (including {@link ISpockMockObject}) are
    * loadable by the target class' classloader.
    *
-   * @param targetClass The to-be-mocked class
+   * @param targetClass          The to-be-mocked class
    * @param additionalInterfaces Additional interfaces of the to-be-mocked type
    * @return true, if this is a local mock. Otherwise false
    */
   @VisibleForTesting
   static boolean isLocalMock(Class<?> targetClass, Collection<Class<?>> additionalInterfaces) {
-    // Inspired by https://github.com/mockito/mockito/blob/99426415c0ceb30e55216c3934854528c83f410e/mockito-core/src/main/java/org/mockito/internal/creation/bytebuddy/SubclassBytecodeGenerator.java#L165-L166
-    ClassLoader cl = new MultipleParentClassLoader.Builder()
-      .appendMostSpecific(targetClass)
-      .appendMostSpecific(additionalInterfaces)
-      .appendMostSpecific(ISpockMockObject.class)
-      .build();
-    return cl == targetClass.getClassLoader();
+    ClassLoader targetLoader = targetClass.getClassLoader();
+    if (targetLoader == null) {
+      targetLoader = ClassLoader.getSystemClassLoader();
+    }
+    Class<?> spockMockClass = loadClassIfAvailableInClassLoader(targetLoader, ISpockMockObject.class);
+    if (spockMockClass != ISpockMockObject.class) {
+      //The ISpockMockObject is not visible to the targetLoader, so we can't be local.
+      return false;
+    }
+    for (Class<?> ifClass : additionalInterfaces) {
+      Class<?> ifClassOfTarget = loadClassIfAvailableInClassLoader(targetLoader, ifClass);
+      if (ifClassOfTarget != ifClass) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Class<?> loadClassIfAvailableInClassLoader(ClassLoader loader, Class<?> clazz) {
+    try {
+      return loader.loadClass(clazz.getName());
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
   }
 
   Object createMock(IMockMaker.IMockCreationSettings settings) {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/osgi/OsgiPackagePrivateMemberMockSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/osgi/OsgiPackagePrivateMemberMockSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.spockframework.smoke.mock.osgi
+
+import spock.lang.IgnoreIf
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.util.EmbeddedSpecRunner
+
+@SuppressWarnings('UnnecessaryQualifiedReference')
+class OsgiPackagePrivateMemberMockSpec extends Specification {
+  def runner = new EmbeddedSpecRunner(new OsgiTestClassLoader(this.class.classLoader))
+
+  @Issue("https://github.com/spockframework/spock/issues/2384")
+  @IgnoreIf({ jvm.java8 })
+  def "OSGi package private mock shall be mockable with ByteBuddy"() {
+    when:
+    def res = runner.runSpecBody("""
+    def mock = Mock(org.spockframework.smoke.mock.osgi.testclasses.PkgPrivateMemberClass, mockMaker: spock.mock.MockMakers.byteBuddy) {
+        packagePrivate() >> "mocked"
+    }
+
+    def "mock is called when invoked from Java code"() {
+        when:
+        def result = new org.spockframework.smoke.mock.osgi.testclasses.InvocationFromJava(mock).invoke()
+
+        then:
+        result == "mocked"
+    }
+
+    def "mock is called when invoked directly from Groovy"() {
+        when:
+        def result = mock.packagePrivate()
+
+        then:
+        result == "mocked"
+    }
+""")
+
+    then:
+    res.testsSucceededCount == 2
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/2384")
+  @IgnoreIf({ !jvm.java8 })
+  def "OSGi package private mock is not mockable in Java 8 due to MethodHandles.Lookup API not available"() {
+    when:
+    def res = runner.runSpecBody("""
+    def mock = Mock(org.spockframework.smoke.mock.osgi.testclasses.PkgPrivateMemberClass, mockMaker: spock.mock.MockMakers.byteBuddy) {
+        packagePrivate() >> "mocked"
+    }
+
+    def "mock is not called when invoked from Java code, because Java 8 does not have Lookup API"() {
+        when:
+        def result = new org.spockframework.smoke.mock.osgi.testclasses.InvocationFromJava(mock).invoke()
+
+        then:
+        result == "original"
+    }
+""")
+
+    then:
+    res.testsSucceededCount == 1
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/osgi/OsgiTestClassLoader.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/osgi/OsgiTestClassLoader.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.spockframework.smoke.mock.osgi
+
+import groovy.transform.CompileStatic
+
+import static java.util.Objects.requireNonNull
+
+/**
+ * Fakes an OSGi like ClassLoader env, by not using the parent ClassLoader semantics.
+ */
+@CompileStatic
+class OsgiTestClassLoader extends ClassLoader {
+  private final ClassLoader hostCl
+
+  OsgiTestClassLoader(ClassLoader hostCl) {
+    super(null)
+    this.hostCl = requireNonNull(hostCl)
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    if (!name.startsWith("org.spockframework.smoke.mock.osgi.testclasses")) {
+      return hostCl.loadClass(name)
+    }
+    super.loadClass(name, resolve)
+  }
+
+  @Override
+  protected Class<?> findClass(String name) throws ClassNotFoundException {
+    def clsFilePath = name
+    clsFilePath = clsFilePath.replace(".", "/")
+    clsFilePath += ".class"
+    def is = hostCl.getResourceAsStream(clsFilePath)
+    if (is == null) {
+      throw new ClassNotFoundException(name)
+    }
+    def clsData = is.getBytes()
+    return defineClass(name, clsData, 0, clsData.length)
+  }
+
+  @Override
+  URL getResource(String name) {
+    return hostCl.getResource(name)
+  }
+
+  @Override
+  Enumeration<URL> getResources(String name) throws IOException {
+    return hostCl.getResources(name)
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/osgi/testclasses/InvocationFromJava.java
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/osgi/testclasses/InvocationFromJava.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.spockframework.smoke.mock.osgi.testclasses;
+
+public class InvocationFromJava {
+  PkgPrivateMemberClass obj;
+
+  public InvocationFromJava(PkgPrivateMemberClass obj) {
+    this.obj = obj;
+  }
+
+  public Object invoke() {
+    return obj.packagePrivate();
+  }
+}

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/osgi/testclasses/PkgPrivateMemberClass.java
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/osgi/testclasses/PkgPrivateMemberClass.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.spockframework.smoke.mock.osgi.testclasses;
+
+public class PkgPrivateMemberClass {
+
+  String packagePrivate() {
+    return "original";
+  }
+}


### PR DESCRIPTION
We now do a real search in the mock targets ClassLoader to check if the Spock classes and additional interfaces are visible instead of asking the Parent ClassLoader hierarchy, which does not work in an OSGi environment.

Fixes #2384