### PR TITLE
Improve rendering fidelity of the AST-to-source transpiler

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -17,6 +17,7 @@ include::include.adoc[]
 * Fix Pattern flags being dropped when `java.util.regex.Pattern` instances are used in Spock regex conditions spockIssue:2298[]
 * Fix `MockitoMockMaker` throws NPE on null object spockIssue:2337[]
 * Fix `SourceToAstNodeAndSourceTranspiler` dropping nested generic type arguments, so signatures like `Iterator<Tuple2<Integer, Integer>>` are now rendered faithfully instead of `Iterator<Tuple2>` spockPull:2393[]
+* Fix `SourceToAstNodeAndSourceTranspiler` rendering of several other constructs: the elvis operator, attribute access (`.@`), implicit-`it` closures, safe index access (`?[]`), numeric literal type suffixes (`L`, `F`, `D`, `G`), left-open ranges (`<..`), and explicit type arguments of method calls spockPull:2393[]
 
 === Breaking Changes
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -16,6 +16,7 @@ include::include.adoc[]
 * Fix argument mismatch descriptions for varargs methods by expanding varargs instead of reporting `<too few arguments>` spockPull:2315[]
 * Fix Pattern flags being dropped when `java.util.regex.Pattern` instances are used in Spock regex conditions spockIssue:2298[]
 * Fix `MockitoMockMaker` throws NPE on null object spockIssue:2337[]
+* Fix `SourceToAstNodeAndSourceTranspiler` dropping nested generic type arguments, so signatures like `Iterator<Tuple2<Integer, Integer>>` are now rendered faithfully instead of `Iterator<Tuple2>` spockPull:2393[]
 
 === Breaking Changes
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -17,7 +17,7 @@ include::include.adoc[]
 * Fix Pattern flags being dropped when `java.util.regex.Pattern` instances are used in Spock regex conditions spockIssue:2298[]
 * Fix `MockitoMockMaker` throws NPE on null object spockIssue:2337[]
 * Fix `SourceToAstNodeAndSourceTranspiler` dropping nested generic type arguments, so signatures like `Iterator<Tuple2<Integer, Integer>>` are now rendered faithfully instead of `Iterator<Tuple2>` spockPull:2393[]
-* Fix `SourceToAstNodeAndSourceTranspiler` rendering of several other constructs: the elvis operator, attribute access (`.@`), implicit-`it` closures, safe index access (`?[]`), numeric literal type suffixes (`L`, `F`, `D`, `G`), left-open ranges (`<..`), and explicit type arguments of method calls spockPull:2393[]
+* Fix `SourceToAstNodeAndSourceTranspiler` rendering of several other constructs: the elvis operator, attribute access (`.@`), implicit-`it` closures, safe index access (`?[]`), numeric literal type suffixes (`L`, `F`, `D`, `G`), left-open ranges (`<..`), explicit type arguments of method calls, `for (index, value in iterable)` loops, and spurious empty `finally` blocks and `default` labels spockPull:2393[]
 
 === Breaking Changes
 

--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -17,7 +17,7 @@ include::include.adoc[]
 * Fix Pattern flags being dropped when `java.util.regex.Pattern` instances are used in Spock regex conditions spockIssue:2298[]
 * Fix `MockitoMockMaker` throws NPE on null object spockIssue:2337[]
 * Fix `SourceToAstNodeAndSourceTranspiler` dropping nested generic type arguments, so signatures like `Iterator<Tuple2<Integer, Integer>>` are now rendered faithfully instead of `Iterator<Tuple2>` spockPull:2393[]
-* Fix `SourceToAstNodeAndSourceTranspiler` rendering of several other constructs: the elvis operator, attribute access (`.@`), implicit-`it` closures, safe index access (`?[]`), numeric literal type suffixes (`L`, `F`, `D`, `G`), left-open ranges (`<..`), explicit type arguments of method calls, `for (index, value in iterable)` loops, and spurious empty `finally` blocks and `default` labels spockPull:2393[]
+* Fix `SourceToAstNodeAndSourceTranspiler` rendering of several other constructs: the elvis operator, attribute access (`.@`), implicit-`it` closures, safe index access (`?[]`), numeric literal type suffixes (`L`, `F`, `D`, `G`), left-open ranges (`<..`), explicit type arguments of method calls, `for (index, value in iterable)` loops, multiple-assignment declarations on Groovy 5, and spurious empty `finally` blocks and `default` labels spockPull:2393[]
 
 === Breaking Changes
 

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -730,6 +730,11 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     printStatementLabels(statement)
     print 'for ('
     if (statement?.variable != ForStatement.FOR_LOOP_DUMMY) {
+      Parameter indexVariable = forLoopIndexVariable(statement)
+      if (indexVariable) {
+        visitParameters([indexVariable])
+        print ', '
+      }
       visitParameters([statement.variable])
       print ' : '
     }
@@ -742,6 +747,12 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     }
     print '}'
     printLineBreak()
+  }
+
+  // ForStatement.getIndexVariable() only exists in Groovy 5+, which introduced for (index, value in iterable) loops
+  @CompileDynamic
+  private static Parameter forLoopIndexVariable(ForStatement statement) {
+    statement.respondsTo('getIndexVariable') ? statement.indexVariable : null
   }
 
   @Override

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -1230,13 +1230,16 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     statement?.catchStatements?.each { CatchStatement catchStatement ->
       visitCatchStatement(catchStatement)
     }
-    print 'finally {'
-    printLineBreak()
-    indented {
-      statement?.finallyStatement?.visit this
+    // a try without a finally block carries an EmptyStatement
+    if (statement?.finallyStatement && !(statement.finallyStatement instanceof EmptyStatement)) {
+      print 'finally {'
+      printLineBreak()
+      indented {
+        statement.finallyStatement.visit this
+      }
+      print '}'
+      printLineBreak()
     }
-    print '}'
-    printLineBreak()
   }
 
   @Override

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -756,9 +756,8 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   }
 
   // ForStatement.getIndexVariable() only exists in Groovy 5+, which introduced for (index, value in iterable) loops
-  @CompileDynamic
   private static Parameter forLoopIndexVariable(ForStatement statement) {
-    statement.respondsTo('getIndexVariable') ? statement.indexVariable : null
+    (Parameter) invokeIfSupported(statement, 'getIndexVariable', null)
   }
 
   @Override
@@ -772,7 +771,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
       ifElse?.ifBlock?.visit this
     }
     printLineBreak()
-    if (ifElse?.elseBlock && !(ifElse.elseBlock instanceof EmptyStatement)) {
+    if (isPresent(ifElse?.elseBlock)) {
       print '} else {'
       printLineBreak()
       indented {
@@ -809,7 +808,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
         visitCaseStatement it
       }
       // a switch without a default case carries an EmptyStatement
-      if (statement?.defaultStatement && !(statement.defaultStatement instanceof EmptyStatement)) {
+      if (isPresent(statement?.defaultStatement)) {
         print 'default: '
         printLineBreak()
         statement?.defaultStatement?.visit this
@@ -915,9 +914,8 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   }
 
   // BinaryExpression.isSafe() only exists in Groovy 3+, which introduced safe index access
-  @CompileDynamic
   private static boolean isSafeIndexAccess(BinaryExpression expression) {
-    expression.respondsTo('isSafe') ? expression.isSafe() : false
+    invokeIfSupported(expression, 'isSafe', false)
   }
 
   @Override
@@ -1000,9 +998,8 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   }
 
   // RangeExpression.isExclusiveLeft() only exists in Groovy 4+, which introduced left-open ranges
-  @CompileDynamic
   private static boolean isExclusiveLeft(RangeExpression expression) {
-    expression.respondsTo('isExclusiveLeft') ? expression.isExclusiveLeft() : false
+    invokeIfSupported(expression, 'isExclusiveLeft', false)
   }
 
   @Override
@@ -1263,7 +1260,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
       visitCatchStatement(catchStatement)
     }
     // a try without a finally block carries an EmptyStatement
-    if (statement?.finallyStatement && !(statement.finallyStatement instanceof EmptyStatement)) {
+    if (isPresent(statement?.finallyStatement)) {
       print 'finally {'
       printLineBreak()
       indented {
@@ -1442,6 +1439,17 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
       first = false
       printExpression it
     }
+  }
+
+  // an absent optional statement (e.g. a finally block) is represented by an EmptyStatement
+  private static boolean isPresent(Statement statement) {
+    statement != null && !(statement instanceof EmptyStatement)
+  }
+
+  // probes AST APIs that only exist in Groovy versions newer than the 2.5 baseline this class compiles against
+  @CompileDynamic
+  private static Object invokeIfSupported(Object receiver, String methodName, Object fallbackValue) {
+    receiver.respondsTo(methodName) ? receiver."$methodName"() : fallbackValue
   }
 
   @Override

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -878,13 +878,25 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   void visitBinaryExpression(BinaryExpression expression) {
     expression?.leftExpression?.visit this
     if (!(expression.rightExpression instanceof EmptyExpression) || expression.operation.type != Types.ASSIGN) {
-      print " $expression.operation.text "
+      String operation = expression.operation.text
+      // Groovy 3 represents a safe index access as a plain '[' token with the safe flag set,
+      // while Groovy 4+ uses a dedicated '?[' token
+      if (operation == '[' && isSafeIndexAccess(expression)) {
+        operation = '?['
+      }
+      print " $operation "
       expression.rightExpression.visit this
 
-      if (expression?.operation?.text == '[') {
+      if (operation in ['[', '?[']) {
         print ']'
       }
     }
+  }
+
+  // BinaryExpression.isSafe() only exists in Groovy 3+, which introduced safe index access
+  @CompileDynamic
+  private static boolean isSafeIndexAccess(BinaryExpression expression) {
+    expression.respondsTo('isSafe') ? expression.isSafe() : false
   }
 
   @Override

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -959,12 +959,21 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   void visitRangeExpression(RangeExpression expression) {
     print '('
     expression?.from?.visit this
+    if (isExclusiveLeft(expression)) {
+      print '<'
+    }
     print '..'
     if (!expression?.inclusive) {
       print '<'
     }
     expression?.to?.visit this
     print ')'
+  }
+
+  // RangeExpression.isExclusiveLeft() only exists in Groovy 4+, which introduced left-open ranges
+  @CompileDynamic
+  private static boolean isExclusiveLeft(RangeExpression expression) {
+    expression.respondsTo('isExclusiveLeft') ? expression.isExclusiveLeft() : false
   }
 
   @Override

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -66,7 +66,8 @@ class SourceToAstNodeAndSourceTranspiler {
 
     def writer = new StringBuilderWriter()
 
-    classLoader = classLoader ?: new GroovyClassLoader(getClass().classLoader)
+    GroovyClassLoader ownClassLoader = classLoader == null ? new GroovyClassLoader(getClass().classLoader) : null
+    classLoader = classLoader ?: ownClassLoader
 
     def scriptName = 'script.groovy'
     GroovyCodeSource codeSource = new GroovyCodeSource(script, scriptName, '/groovy/script')
@@ -94,6 +95,9 @@ class SourceToAstNodeAndSourceTranspiler {
       cfe.message.eachLine {
         writer.println it
       }
+    } finally {
+      // only close the classloader we created ourselves; a passed-in one may still be used by the caller
+      ownClassLoader?.close()
     }
 
     return new TranspileResult(writer.toString(), captureVisitor.nodeCaptures)

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -908,9 +908,13 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   void visitClosureExpression(ClosureExpression expression) {
     print '{ '
     if (expression?.parameters) {
-      visitParameters(expression?.parameters)
+      visitParameters(expression.parameters)
+      print ' ->'
+    } else if (expression?.parameters == null) {
+      // null parameters denote an explicit zero-arg closure { -> }, while an empty array denotes the
+      // implicit `it` (see ClosureWriter); rendering an arrow for the latter would drop `it`
+      print ' ->'
     }
-    print ' ->'
     printLineBreak()
     indented {
       expression?.code?.visit this

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -1020,6 +1020,16 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     } else {
       //noinspection GroovyPointlessBoolean
       print escapeChars == true ? escapeCharacters(expression.value as String) : expression.value
+      // without the type suffix, re-parsing the rendered value would produce an Integer or BigDecimal
+      if (expression.value instanceof Long) {
+        print 'L'
+      } else if (expression.value instanceof Float) {
+        print 'F'
+      } else if (expression.value instanceof Double) {
+        print 'D'
+      } else if (expression.value instanceof BigInteger) {
+        print 'G'
+      }
     }
   }
 

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -791,7 +791,8 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
       statement?.caseStatements?.each {
         visitCaseStatement it
       }
-      if (statement?.defaultStatement) {
+      // a switch without a default case carries an EmptyStatement
+      if (statement?.defaultStatement && !(statement.defaultStatement instanceof EmptyStatement)) {
         print 'default: '
         printLineBreak()
         statement?.defaultStatement?.visit this

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -1231,7 +1231,10 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
 
   @Override
   void visitShortTernaryExpression(ElvisOperatorExpression expression) {
-    visitTernaryExpression(expression)
+    // render the elvis form instead of the equivalent ternary, which would duplicate the condition expression
+    expression?.booleanExpression?.visit this
+    print ' ?: '
+    expression?.falseExpression?.visit this
   }
 
   @Override

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -846,6 +846,8 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
       print '?'
     }
     print '.'
+    // explicit type arguments, e.g. Collections.<String>emptyList()
+    visitGenerics expression.genericsTypes
     Expression method = expression.method
     if (method instanceof ConstantExpression) {
       visitConstantExpression(method, true)

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -542,6 +542,11 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
         }
         first = false
         print it.name
+        // a concrete type argument may carry its own nested type arguments (e.g. Tuple2<Integer, Integer>);
+        // recurse so they are not dropped. Placeholders (T) and wildcards (?) never carry them.
+        if (!it.placeholder && !it.wildcard) {
+          visitGenerics it.type?.genericsTypes
+        }
         if (it.upperBounds) {
           print ' extends '
           boolean innerFirst = true

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -960,7 +960,8 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     } else if (expression?.safe) {
       print '?'
     }
-    print '.'
+    // an AttributeExpression accesses the field directly, bypassing the property accessor
+    print expression instanceof AttributeExpression ? '.@' : '.'
     if (expression?.property instanceof ConstantExpression) {
       visitConstantExpression((ConstantExpression)expression?.property, true)
     } else {

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -66,12 +66,14 @@ class SourceToAstNodeAndSourceTranspiler {
 
     def writer = new StringBuilderWriter()
 
-    GroovyClassLoader ownClassLoader = classLoader == null ? new GroovyClassLoader(getClass().classLoader) : null
-    classLoader = classLoader ?: ownClassLoader
+    // wrap any non-Groovy classloader (or the default) instead of blindly casting it below
+    GroovyClassLoader ownClassLoader = classLoader instanceof GroovyClassLoader ? null
+      : new GroovyClassLoader(classLoader ?: getClass().classLoader)
+    GroovyClassLoader groovyClassLoader = ownClassLoader ?: (GroovyClassLoader) classLoader
 
     def scriptName = 'script.groovy'
     GroovyCodeSource codeSource = new GroovyCodeSource(script, scriptName, '/groovy/script')
-    CompilationUnit cu = new CompilationUnit((CompilerConfiguration)(config ?: CompilerConfiguration.DEFAULT), (CodeSource)codeSource.codeSource, (GroovyClassLoader)classLoader)
+    CompilationUnit cu = new CompilationUnit((CompilerConfiguration)(config ?: CompilerConfiguration.DEFAULT), (CodeSource)codeSource.codeSource, groovyClassLoader)
     def captureVisitor = new AstNodeCaptureVisitor()
     cu.addPhaseOperation(captureVisitor, compilePhase)
     cu.addSource(codeSource.name, script)

--- a/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
+++ b/spock-core/src/main/groovy/spock/util/SourceToAstNodeAndSourceTranspiler.groovy
@@ -849,12 +849,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   @Override
   void visitMethodCallExpression(MethodCallExpression expression) {
 
-    Expression objectExp = expression.objectExpression
-    if (objectExp instanceof VariableExpression) {
-      visitVariableExpression(objectExp, false)
-    } else {
-      objectExp.visit(this)
-    }
+    printExpression expression.objectExpression
     if (expression.spreadSafe) {
       print '*'
     }
@@ -894,18 +889,24 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
 
   @Override
   void visitBinaryExpression(BinaryExpression expression) {
-    expression?.leftExpression?.visit this
+    // a declaration needs the padding after the already printed type; see visitDeclarationExpression
+    if (!(expression instanceof DeclarationExpression) && expression.leftExpression instanceof VariableExpression) {
+      visitVariableExpression((VariableExpression) expression.leftExpression, false)
+    } else {
+      expression?.leftExpression?.visit this
+    }
     if (!(expression.rightExpression instanceof EmptyExpression) || expression.operation.type != Types.ASSIGN) {
-      String operation = expression.operation.text
-      // Groovy 3 represents a safe index access as a plain '[' token with the safe flag set,
-      // while Groovy 4+ uses a dedicated '?[' token
-      if (operation == '[' && isSafeIndexAccess(expression)) {
-        operation = '?['
+      boolean isAccess = expression.operation.type == Types.LEFT_SQUARE_BRACKET
+      if (isAccess) {
+        // Groovy 3 represents a safe index access as a plain '[' token with the safe flag set,
+        // while Groovy 4+ uses a dedicated '?[' token
+        print isSafeIndexAccess(expression) ? '?[' : '['
+      } else {
+        print " $expression.operation.text "
       }
-      print " $operation "
       expression.rightExpression.visit this
 
-      if (operation in ['[', '?[']) {
+      if (isAccess) {
         print ']'
       }
     }
@@ -919,18 +920,26 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
 
   @Override
   void visitPostfixExpression(PostfixExpression expression) {
-    print '('
-    expression?.expression?.visit this
-    print ')'
+    if (expression?.expression instanceof VariableExpression) {
+      visitVariableExpression((VariableExpression) expression.expression, false)
+    } else {
+      print '('
+      expression?.expression?.visit this
+      print ')'
+    }
     print expression?.operation?.text
   }
 
   @Override
   void visitPrefixExpression(PrefixExpression expression) {
     print expression?.operation?.text
-    print '('
-    expression?.expression?.visit this
-    print ')'
+    if (expression?.expression instanceof VariableExpression) {
+      visitVariableExpression((VariableExpression) expression.expression, false)
+    } else {
+      print '('
+      expression?.expression?.visit this
+      print ')'
+    }
   }
 
 
@@ -954,7 +963,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
 
   @Override
   void visitLambdaExpression(LambdaExpression expression) {
-    print '( '
+    print '('
     if (expression?.parameters) {
       visitParameters(expression?.parameters)
     }
@@ -969,7 +978,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   @Override
   void visitTupleExpression(TupleExpression expression) {
     print '('
-    visitExpressionsAndCommaSeparate(expression?.expressions)
+    printExpressions(expression?.expressions)
     print ')'
   }
 
@@ -996,7 +1005,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
 
   @Override
   void visitPropertyExpression(PropertyExpression expression) {
-    expression?.objectExpression?.visit this
+    printExpression expression?.objectExpression
     trimSpaceRight() // remove space inserted by previous expression
     if (expression?.spreadSafe) {
       print '*'
@@ -1076,16 +1085,25 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
 
   @Override
   void visitDeclarationExpression(DeclarationExpression expression) {
-    // handle multiple assignment expressions
-    if (expression?.leftExpression instanceof ArgumentListExpression) {
-      print 'def '
-      visitArgumentlistExpression((ArgumentListExpression)expression?.leftExpression, true)
-      print " $expression.operation.text "
-      expression.rightExpression.visit this
-    } else {
+    if (!expression.isMultipleAssignmentDeclaration()) {
       visitType expression?.leftExpression?.type
       visitBinaryExpression expression // is a BinaryExpression
+      return
     }
+
+    print 'def ('
+    boolean first = true
+    expression.tupleExpression.expressions.each { Expression e ->
+      if (!first) {
+        print ', '
+      }
+      first = false
+      visitType e.type
+      print ' '
+      printExpression e
+    }
+    print ') = '
+    expression.rightExpression.visit this
   }
 
   @Override
@@ -1123,42 +1141,55 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     expression?.expression?.visit this
   }
 
+  private void printUnaryExpression(String opText, Expression inner) {
+    print opText
+    if (inner instanceof VariableExpression) {
+      visitVariableExpression(inner, false)
+    } else if (inner instanceof PropertyExpression) {
+      inner.visit this
+    } else {
+      print '('
+      inner?.visit this
+      print ')'
+    }
+  }
+
   @Override
   void visitNotExpression(NotExpression expression) {
-    print '!('
-    expression?.expression?.visit this
-    print ')'
+    printUnaryExpression('!', expression?.expression)
   }
 
   @Override
   void visitUnaryMinusExpression(UnaryMinusExpression expression) {
-    print '-('
-    expression?.expression?.visit this
-    print ')'
+    printUnaryExpression('-', expression?.expression)
   }
 
   @Override
   void visitUnaryPlusExpression(UnaryPlusExpression expression) {
-    print '+('
-    expression?.expression?.visit this
-    print ')'
+    printUnaryExpression('+', expression?.expression)
   }
 
   @Override
   void visitCastExpression(CastExpression expression) {
+    print '('
     if (expression.coerce) {
-      print '(('
-      expression?.expression?.visit this
-      print ') as '
+      boolean needsParens = !(expression.expression instanceof VariableExpression || expression.expression instanceof PropertyExpression)
+      if (needsParens) {
+        print '('
+      }
+      printExpression(expression.expression)
+      if (needsParens) {
+        print ')'
+      }
+      print ' as '
       visitType(expression?.type)
-      print ')'
     } else {
-      print '(('
+      print '('
       visitType(expression?.type)
       print ') '
-      expression?.expression?.visit this
-      print ')'
+      printExpression(expression?.expression)
     }
+    print ')'
   }
 
   /**
@@ -1174,25 +1205,9 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     }
   }
 
-  void visitArgumentlistExpression(ArgumentListExpression expression, boolean showTypes = false) {
-    print '('
-    int count = expression?.expressions?.size()
-    expression.expressions.each {
-      if (showTypes) {
-        visitType it.type
-        print ' '
-      }
-      if (it instanceof VariableExpression) {
-        visitVariableExpression it, false
-      } else if (it instanceof ConstantExpression) {
-        visitConstantExpression it, false
-      } else {
-        it.visit this
-      }
-      count--
-      if (count) print ', '
-    }
-    print ')'
+  @Override
+  void visitArgumentlistExpression(ArgumentListExpression expression) {
+    visitTupleExpression expression
   }
 
   @Override
@@ -1208,7 +1223,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     if (expression?.mapEntryExpressions?.size() == 0) {
       print ':'
     } else {
-      visitExpressionsAndCommaSeparate((List)expression?.mapEntryExpressions)
+      printExpressions(expression?.mapEntryExpressions)
     }
     print ']'
   }
@@ -1227,7 +1242,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
   @Override
   void visitListExpression(ListExpression expression) {
     print '['
-    visitExpressionsAndCommaSeparate(expression?.expressions)
+    printExpressions(expression?.expressions)
     print ']'
   }
 
@@ -1296,7 +1311,7 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
 
   @Override
   void visitBooleanExpression(BooleanExpression expression) {
-    expression?.expression?.visit this
+    printExpression expression?.expression
   }
 
   @Override
@@ -1362,6 +1377,9 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     expression?.expressions?.each {
       if (!first) {
         print ';'
+        if (!(it instanceof EmptyExpression)) {
+          print ' '
+        }
       }
       first = false
       it.visit this
@@ -1388,33 +1406,39 @@ class AstNodeToScriptVisitor extends CompilationUnit.PrimaryClassNodeOperation i
     print 'new '
     visitType expression?.elementType
     print '['
-    visitExpressionsAndCommaSeparate(expression?.sizeExpression)
+    printExpressions(expression?.sizeExpression)
     print ']'
     if (expression?.expressions != null) { // print array initializer
       print '{'
-      visitExpressionsAndCommaSeparate(expression?.expressions)
+      printExpressions(expression?.expressions)
       print '}'
     }
   }
 
-  private void visitExpressionsAndCommaSeparate(List<? super Expression> expressions) {
-    boolean first = true
-    expressions?.each {
-      if (!first) {
-        print ', '
-      }
-      first = false
+  private void printExpression(Expression expression) {
+    if (expression instanceof VariableExpression) {
+      visitVariableExpression(expression, false)
+    } else if (expression instanceof AnnotationConstantExpression) {
       /*
       I have no idea why the AnnotationConstantExpression does it,
       but it first visits the values of the members before it visits itself.
       That's why you got org.spockframework.runtime.model.BlockKind.SETUP followed by [] followed by the actual correct representation.
       https://issues.apache.org/jira/browse/GROOVY-9980
        */
-      if (it instanceof AnnotationConstantExpression) {
-        visitConstantExpression(it)
-      } else {
-        (it as ASTNode).visit this
+      visitConstantExpression(expression)
+    } else {
+      expression?.visit this
+    }
+  }
+
+  private void printExpressions(List<? extends Expression> expressions) {
+    boolean first = true
+    expressions?.each {
+      if (!first) {
+        print ', '
       }
+      first = false
+      printExpression it
     }
   }
 

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -294,6 +294,29 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  def "try without a finally block is rendered without an empty one"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m() {
+    try {
+      println 'x'
+    } catch (RuntimeException e) {
+      println e
+    }
+    try {
+      println 'y'
+    } finally {
+      println 'done'
+    }
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -271,6 +271,29 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  def "switch without a default case is rendered without a default label"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m(i) {
+    switch (i) {
+      case 1:
+        return 'one'
+    }
+    switch (i) {
+      case 2:
+        return 'two'
+      default:
+        return 'many'
+    }
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -236,6 +236,24 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  @Requires({ GroovyRuntimeUtil.MAJOR_VERSION >= 4 })
+  def "range boundary exclusions are rendered on both sides"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m() {
+    def a = 1..5
+    def b = 1..<5
+    def c = 1<..5
+    def d = 1<..<5
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -317,6 +317,26 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  @Requires({ GroovyRuntimeUtil.MAJOR_VERSION >= 5 })
+  def "for-in loops with an index variable render both variables"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m(List l) {
+    for (item in l) {
+      println item
+    }
+    for (i, item in l) {
+      println item
+    }
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -254,6 +254,23 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  def "explicit type arguments of method calls are rendered"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m() {
+    def a = Collections.<String>emptyList()
+    def b = this.<Integer>identity(1)
+  }
+
+  def <T> T identity(T t) { t }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -150,6 +150,21 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  def "elvis operator is rendered in short form"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m(c, d) {
+    def a = c ?: d
+    def b = c.count('x') ?: d
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -217,6 +217,25 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  def "numeric literals keep their type suffix"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m() {
+    def integer = 42
+    def longValue = 42L
+    def floatValue = 2.5f
+    def doubleValue = 3.5d
+    def bigInteger = 10G
+    def bigDecimal = 1.5
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -136,6 +136,20 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  def "nested generic type arguments are rendered faithfully"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  Map<String, List<Integer>> nested() { null }
+  List<? extends Number> upperBounded() { null }
+  def <T extends CharSequence> List<T> methodTypeParameter() { null }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -200,6 +200,23 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  @Requires({ GroovyRuntimeUtil.MAJOR_VERSION >= 3 })
+  def "safe index accesses are rendered with the closing bracket"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m(List l, Map mp) {
+    def a = l?[0]
+    def b = mp?['key']
+    l?[1] = 42
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -184,6 +184,22 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  def "closure parameter lists are rendered faithfully"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  def m() {
+    def implicitIt = { it * 2 }
+    def noArgs = { -> 'x' }
+    def oneArg = { int x -> x }
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/ast/AstSpec.groovy
@@ -165,6 +165,25 @@ class Foo {
     snapshotter.assertThat(result.source).matchesSnapshot()
   }
 
+  def "attribute access is rendered with the at sign"() {
+    when:
+    def result = compiler.transpile('''
+class Foo {
+  int order
+
+  def m(Foo other, List<Foo> foos) {
+    def a = other.@order
+    def b = other?.@order
+    def c = foos*.@order
+    this.@order = a
+  }
+}
+''', EnumSet.of(Show.METHODS))
+
+    then:
+    snapshotter.assertThat(result.source).matchesSnapshot()
+  }
+
   def "enums"() {
     given:
     // groovy 4 renders differently

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/attribute_access_is_rendered_with_the_at_sign.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/attribute_access_is_rendered_with_the_at_sign.groovy
@@ -1,0 +1,6 @@
+public java.lang.Object m(Foo other, java.util.List<Foo> foos) {
+    java.lang.Object a = other.@order
+    java.lang.Object b = other?.@order
+    java.lang.Object c = foos*.@order
+    this.@order = a
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/closure_parameter_lists_are_rendered_faithfully.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/closure_parameter_lists_are_rendered_faithfully.groovy
@@ -1,0 +1,11 @@
+public java.lang.Object m() {
+    java.lang.Object implicitIt = {
+        it * 2
+    }
+    java.lang.Object noArgs = { ->
+        'x'
+    }
+    java.lang.Object oneArg = { int x ->
+        x
+    }
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/elvis_operator_is_rendered_in_short_form.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/elvis_operator_is_rendered_in_short_form.groovy
@@ -1,0 +1,4 @@
+public java.lang.Object m(java.lang.Object c, java.lang.Object d) {
+    java.lang.Object a = c ?: d
+    java.lang.Object b = c.count('x') ?: d
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/enums-groovy4.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/enums-groovy4.groovy
@@ -13,18 +13,18 @@ public final class Alpha extends java.lang.Enum<Alpha> {
 
     public Alpha next() {
         java.lang.Integer ordinal = this.ordinal() + 1
-        if ( ordinal >= $VALUES.length) {
+        if (ordinal >= $VALUES.length) {
             return MIN_VALUE
         }
-        return $VALUES [ ordinal ]
+        return $VALUES[ ordinal ]
     }
 
     public Alpha previous() {
         java.lang.Integer ordinal = this.ordinal() - 1
-        if ( ordinal < 0) {
+        if (ordinal < 0) {
             return MAX_VALUE
         }
-        return $VALUES [ ordinal ]
+        return $VALUES[ ordinal ]
     }
 
     public static Alpha valueOf(java.lang.String name) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/enums.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/enums.groovy
@@ -13,18 +13,18 @@ public final class Alpha extends java.lang.Enum<Alpha> {
 
     public Alpha next() {
         java.lang.Object ordinal = this.ordinal().next()
-        if ( ordinal >= $VALUES.size()) {
+        if (ordinal >= $VALUES.size()) {
             ordinal = 0
         }
-        return $VALUES.getAt( ordinal )
+        return $VALUES.getAt(ordinal)
     }
 
     public Alpha previous() {
         java.lang.Object ordinal = this.ordinal().previous()
-        if ( ordinal < 0) {
+        if (ordinal < 0) {
             ordinal = $VALUES.size().minus(1)
         }
-        return $VALUES.getAt( ordinal )
+        return $VALUES.getAt(ordinal)
     }
 
     public static Alpha valueOf(java.lang.String name) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/explicit_type_arguments_of_method_calls_are_rendered.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/explicit_type_arguments_of_method_calls_are_rendered.groovy
@@ -1,0 +1,8 @@
+public java.lang.Object m() {
+    java.lang.Object a = java.util.Collections.<String>emptyList()
+    java.lang.Object b = this.<Integer>identity(1)
+}
+
+public <T> T identity(T t) {
+    t
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/for_in_loops_with_an_index_variable_render_both_variables.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/for_in_loops_with_an_index_variable_render_both_variables.groovy
@@ -1,0 +1,8 @@
+public java.lang.Object m(java.util.List l) {
+    for (java.lang.Object item : l ) {
+        this.println(item)
+    }
+    for (final int i, java.lang.Object item : l ) {
+        this.println(item)
+    }
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise-groovy5.groovy
@@ -140,7 +140,7 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
         java.lang.Integer i = 2
         java.lang.Object( j , k ) = x
         java.lang.Object l = b ? c : d
-        java.lang.Object m = c ? c : d
+        java.lang.Object m = c ?: d
         java.lang.Object n = this.&'convert'
         java.lang.Object o = this.order
         java.lang.Object p = (1..5)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise-groovy5.groovy
@@ -82,8 +82,8 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
 
     public void loops() {
         outer:
-        for (java.lang.Integer i = 0; i < INT ;( i )++) {
-            if ( i % 2 == 0) {
+        for (java.lang.Integer i = 0; i < INT ; i++) {
+            if (i % 2 == 0) {
                 this.print('even')
                 continue outer
             } else {
@@ -130,15 +130,15 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
 
     public void operators() {
         java.lang.Integer a = ~( INT )
-        java.lang.Boolean b = !( a )
-        java.lang.Integer c = -( a )
-        java.lang.Integer d = +( c )
+        java.lang.Boolean b = !a
+        java.lang.Integer c = -a
+        java.lang.Integer d = +c
         java.lang.Object e = ['a': b , STR : c ]
         java.lang.Object f = [*: e , 'foo': 'bar']
-        java.lang.Object g = "a: ${a} and b: ${ e.a.compareTo(c)}"
+        java.lang.Object g = "a: ${a} and b: ${e.a.compareTo(c)}"
         java.lang.Integer h = 1
         java.lang.Integer i = 2
-        java.lang.Object( j , k ) = x
+        def (java.lang.Object j, java.lang.Object k) = x
         java.lang.Object l = b ? c : d
         java.lang.Object m = c ?: d
         java.lang.Object n = this.&'convert'
@@ -150,14 +150,14 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
             x * x
         }
         java.lang.Object t = [:]
-        java.lang.Object u = ++( c )
+        java.lang.Object u = ++c
         java.lang.Object v = this."${STR}"(a)
         java.lang.Object w = {
             this.println(g)
         }
-        java.lang.Object x = (( c ) as long)
-        java.lang.Object y = ((long) c )
-        java.lang.Object z = [1, 2, 3] [ 0]
+        java.lang.Object x = (c as long)
+        java.lang.Object y = ((long) c)
+        java.lang.Object z = [1, 2, 3][0]
         assert c == d : null
     }
 
@@ -188,7 +188,7 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
     @java.lang.Override
     public int compareTo(java.lang.Object o) {
         synchronized ( o ) {
-            return order <=> (( o ) as apackage.another.Bar).order
+            return order <=> (o as apackage.another.Bar).order
         }
     }
 

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise-groovy5.groovy
@@ -142,7 +142,7 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
         java.lang.Object l = b ? c : d
         java.lang.Object m = c ?: d
         java.lang.Object n = this.&'convert'
-        java.lang.Object o = this.order
+        java.lang.Object o = this.@order
         java.lang.Object p = (1..5)
         java.lang.Object q = (1..<5)
         java.lang.Object r = x*.size()?.intersect([1])

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise-groovy5.groovy
@@ -152,7 +152,7 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
         java.lang.Object t = [:]
         java.lang.Object u = ++( c )
         java.lang.Object v = this."${STR}"(a)
-        java.lang.Object w = { ->
+        java.lang.Object w = {
             this.println(g)
         }
         java.lang.Object x = (( c ) as long)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise.groovy
@@ -82,8 +82,8 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
 
     public void loops() {
         outer:
-        for (java.lang.Integer i = 0; i < INT ;( i )++) {
-            if ( i % 2 == 0) {
+        for (java.lang.Integer i = 0; i < INT ; i++) {
+            if (i % 2 == 0) {
                 this.print('even')
                 continue outer
             } else {
@@ -130,12 +130,12 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
 
     public void operators() {
         java.lang.Integer a = ~( INT )
-        java.lang.Boolean b = !( a )
-        java.lang.Integer c = -( a )
-        java.lang.Integer d = +( c )
+        java.lang.Boolean b = !a
+        java.lang.Integer c = -a
+        java.lang.Integer d = +c
         java.lang.Object e = ['a': b , STR : c ]
         java.lang.Object f = [*: e , 'foo': 'bar']
-        java.lang.Object g = "a: ${a} and b: ${ e.a.compareTo(c)}"
+        java.lang.Object g = "a: ${a} and b: ${e.a.compareTo(c)}"
         java.lang.Integer h = 1
         java.lang.Integer i = 2
         def (java.lang.Object j, java.lang.Object k) = x
@@ -150,14 +150,14 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
             x * x
         }
         java.lang.Object t = [:]
-        java.lang.Object u = ++( c )
+        java.lang.Object u = ++c
         java.lang.Object v = this."${STR}"(a)
         java.lang.Object w = {
             this.println(g)
         }
-        java.lang.Object x = (( c ) as long)
-        java.lang.Object y = ((long) c )
-        java.lang.Object z = [1, 2, 3] [ 0]
+        java.lang.Object x = (c as long)
+        java.lang.Object y = ((long) c)
+        java.lang.Object z = [1, 2, 3][0]
         assert c == d : null
     }
 
@@ -188,7 +188,7 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
     @java.lang.Override
     public int compareTo(java.lang.Object o) {
         synchronized ( o ) {
-            return order <=> (( o ) as apackage.another.Bar).order
+            return order <=> (o as apackage.another.Bar).order
         }
     }
 

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise.groovy
@@ -142,7 +142,7 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
         java.lang.Object l = b ? c : d
         java.lang.Object m = c ?: d
         java.lang.Object n = this.&'convert'
-        java.lang.Object o = this.order
+        java.lang.Object o = this.@order
         java.lang.Object p = (1..5)
         java.lang.Object q = (1..<5)
         java.lang.Object r = x*.size()?.intersect([1])

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise.groovy
@@ -140,7 +140,7 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
         java.lang.Integer i = 2
         def (java.lang.Object j, java.lang.Object k) = x
         java.lang.Object l = b ? c : d
-        java.lang.Object m = c ? c : d
+        java.lang.Object m = c ?: d
         java.lang.Object n = this.&'convert'
         java.lang.Object o = this.order
         java.lang.Object p = (1..5)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/full_feature_exercise.groovy
@@ -152,7 +152,7 @@ public class apackage.another.Bar extends apackage.another.Foo implements apacka
         java.lang.Object t = [:]
         java.lang.Object u = ++( c )
         java.lang.Object v = this."${STR}"(a)
-        java.lang.Object w = { ->
+        java.lang.Object w = {
             this.println(g)
         }
         java.lang.Object x = (( c ) as long)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/groovy_3_language_features.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/groovy_3_language_features.groovy
@@ -9,11 +9,11 @@ public void methodRef() {
 }
 
 public void lambdas() {
-    java.lang.Object lambda = ( java.lang.Object x) -> {
+    java.lang.Object lambda = (java.lang.Object x) -> {
         x * x }
-    java.lang.Object lambdaMultiArg = ( int a, int b) -> {
+    java.lang.Object lambdaMultiArg = (int a, int b) -> {
         a <=> b }
-    java.lang.Object lambdaNoArg = ( ) -> {
+    java.lang.Object lambdaNoArg = () -> {
         throw new java.lang.RuntimeException('bam')
     }
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/nested_generic_type_arguments_are_rendered_faithfully.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/nested_generic_type_arguments_are_rendered_faithfully.groovy
@@ -1,0 +1,11 @@
+public java.util.Map<String, List<Integer>> nested() {
+    null
+}
+
+public java.util.List<? extends java.lang.Number> upperBounded() {
+    null
+}
+
+public <T extends java.lang.CharSequence> java.util.List<T> methodTypeParameter() {
+    null
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/numeric_literals_keep_their_type_suffix.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/numeric_literals_keep_their_type_suffix.groovy
@@ -1,0 +1,8 @@
+public java.lang.Object m() {
+    java.lang.Object integer = 42
+    java.lang.Object longValue = 42L
+    java.lang.Object floatValue = 2.5F
+    java.lang.Object doubleValue = 3.5D
+    java.lang.Object bigInteger = 10G
+    java.lang.Object bigDecimal = 1.5
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/range_boundary_exclusions_are_rendered_on_both_sides.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/range_boundary_exclusions_are_rendered_on_both_sides.groovy
@@ -1,0 +1,6 @@
+public java.lang.Object m() {
+    java.lang.Object a = (1..5)
+    java.lang.Object b = (1..<5)
+    java.lang.Object c = (1<..5)
+    java.lang.Object d = (1<..<5)
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/safe_index_accesses_are_rendered_with_the_closing_bracket.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/safe_index_accesses_are_rendered_with_the_closing_bracket.groovy
@@ -1,0 +1,5 @@
+public java.lang.Object m(java.util.List l, java.util.Map mp) {
+    java.lang.Object a = l ?[ 0]
+    java.lang.Object b = mp ?[ 'key']
+    l ?[ 1] = 42
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/safe_index_accesses_are_rendered_with_the_closing_bracket.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/safe_index_accesses_are_rendered_with_the_closing_bracket.groovy
@@ -1,5 +1,5 @@
 public java.lang.Object m(java.util.List l, java.util.Map mp) {
-    java.lang.Object a = l ?[ 0]
-    java.lang.Object b = mp ?[ 'key']
-    l ?[ 1] = 42
+    java.lang.Object a = l?[0]
+    java.lang.Object b = mp?['key']
+    l?[1] = 42
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/switch_without_a_default_case_is_rendered_without_a_default_label.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/switch_without_a_default_case_is_rendered_without_a_default_label.groovy
@@ -1,0 +1,12 @@
+public java.lang.Object m(java.lang.Object i) {
+    switch ( i ) {
+        case 1:
+            return 'one'
+    }
+    switch ( i ) {
+        case 2:
+            return 'two'
+        default:
+        return 'many'
+    }
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/try_without_a_finally_block_is_rendered_without_an_empty_one.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/AstSpec/try_without_a_finally_block_is_rendered_without_an_empty_one.groovy
@@ -1,0 +1,14 @@
+public java.lang.Object m() {
+    try {
+        this.println('x')
+    }
+    catch (java.lang.RuntimeException e) {
+        this.println(e)
+    }
+    try {
+        this.println('y')
+    }
+    finally {
+        this.println('done')
+    }
+}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_GString_labels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_GString_labels.groovy
@@ -10,21 +10,21 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     java.lang.Integer idx = 0
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    "given ${( idx )++}"
+    "given ${idx++}"
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 1)
     try {
-        org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), '\"expect \${idx++}\"', 3, 13, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), "${$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), ( idx )++)}expect "))
+        org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), '\"expect \${idx++}\"', 3, 13, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), "${$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), idx++)}expect "))
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '\"expect \${idx++}\"', 3, 13, null, $spock_condition_throwable)}
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
-    "when ${( idx )++}"
+    "when ${idx++}"
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 3)
     try {
-        org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), '\"then \${idx++}\"', 5, 11, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), "${$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), ( idx )++)}then "))
+        org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), '\"then \${idx++}\"', 5, 11, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), "${$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), idx++)}then "))
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '\"then \${idx++}\"', 5, 11, null, $spock_condition_throwable)}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_GString_labels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_GString_labels.groovy
@@ -18,8 +18,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '\"expect \${idx++}\"', 3, 13, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
     "when ${( idx )++}"
@@ -30,8 +28,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '\"then \${idx++}\"', 5, 11, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 3)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_empty_labels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_empty_labels.groovy
@@ -24,21 +24,21 @@ public void $spock_feature_0_0() {
     finally {
         org.spockframework.runtime.model.BlockInfo $spock_failedBlock = null
         try {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_failedBlock = this.getSpecificationContext().getCurrentBlock()
             }
             org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 4)
             org.spockframework.runtime.SpockRuntime.callBlockExited(this, 4)
         }
         catch (java.lang.Throwable $spock_tmp_throwable) {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_feature_throwable.addSuppressed($spock_tmp_throwable)
             } else {
                 throw $spock_tmp_throwable
             }
         }
         finally {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 ((org.spockframework.runtime.SpecificationContext) this.getSpecificationContext()).setCurrentBlock($spock_failedBlock)
             }
         }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_labels_and_blocks.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/BlocksAst/all_observable_blocks_with_labels_and_blocks.groovy
@@ -26,21 +26,21 @@ public void $spock_feature_0_0() {
     finally {
         org.spockframework.runtime.model.BlockInfo $spock_failedBlock = null
         try {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_failedBlock = this.getSpecificationContext().getCurrentBlock()
             }
             org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 5)
             org.spockframework.runtime.SpockRuntime.callBlockExited(this, 5)
         }
         catch (java.lang.Throwable $spock_tmp_throwable) {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_feature_throwable.addSuppressed($spock_tmp_throwable)
             } else {
                 throw $spock_tmp_throwable
             }
         }
         finally {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 ((org.spockframework.runtime.SpecificationContext) this.getSpecificationContext()).setCurrentBlock($spock_failedBlock)
             }
         }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference.groovy
@@ -31,7 +31,7 @@ public void $spock_feature_0_0() {
     finally {
         org.spockframework.runtime.model.BlockInfo $spock_failedBlock = null
         try {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_failedBlock = this.getSpecificationContext().getCurrentBlock()
             }
             org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
@@ -39,14 +39,14 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
         }
         catch (java.lang.Throwable $spock_tmp_throwable) {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_feature_throwable.addSuppressed($spock_tmp_throwable)
             } else {
                 throw $spock_tmp_throwable
             }
         }
         finally {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 ((org.spockframework.runtime.SpecificationContext) this.getSpecificationContext()).setCurrentBlock($spock_failedBlock)
             }
         }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference.groovy
@@ -22,8 +22,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'println(foobar)', 6, 3, null, $spock_condition_throwable)}
-        finally {
-        }
         org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     }
     catch (java.lang.Throwable $spock_tmp_throwable) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
@@ -22,8 +22,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'println(foobar)', 6, 3, null, $spock_condition_throwable)}
-        finally {
-        }
         org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     }
     catch (java.lang.Throwable $spock_tmp_throwable) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
@@ -10,7 +10,7 @@ public java.lang.Object foobar() {
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ValueRecorder $spock_valueRecorder = new org.spockframework.runtime.ValueRecorder()
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
-    java.lang.Object( foobar , b ) = [null, null]
+    def (java.lang.Object foobar, java.lang.Object b) = [null, null]
     java.lang.Throwable $spock_feature_throwable
     try {
         org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
@@ -31,7 +31,7 @@ public void $spock_feature_0_0() {
     finally {
         org.spockframework.runtime.model.BlockInfo $spock_failedBlock = null
         try {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_failedBlock = this.getSpecificationContext().getCurrentBlock()
             }
             org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
@@ -39,14 +39,14 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
         }
         catch (java.lang.Throwable $spock_tmp_throwable) {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_feature_throwable.addSuppressed($spock_tmp_throwable)
             } else {
                 throw $spock_tmp_throwable
             }
         }
         finally {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 ((org.spockframework.runtime.SpecificationContext) this.getSpecificationContext()).setCurrentBlock($spock_failedBlock)
             }
         }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments.groovy
@@ -31,7 +31,7 @@ public void $spock_feature_0_0() {
     finally {
         org.spockframework.runtime.model.BlockInfo $spock_failedBlock = null
         try {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_failedBlock = this.getSpecificationContext().getCurrentBlock()
             }
             org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 2)
@@ -39,14 +39,14 @@ public void $spock_feature_0_0() {
             org.spockframework.runtime.SpockRuntime.callBlockExited(this, 2)
         }
         catch (java.lang.Throwable $spock_tmp_throwable) {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 $spock_feature_throwable.addSuppressed($spock_tmp_throwable)
             } else {
                 throw $spock_tmp_throwable
             }
         }
         finally {
-            if ( $spock_feature_throwable != null) {
+            if ($spock_feature_throwable != null) {
                 ((org.spockframework.runtime.SpecificationContext) this.getSpecificationContext()).setCurrentBlock($spock_failedBlock)
             }
         }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/CleanupBlocksAstSpec/cleanup_rewrite_keeps_correct_method_reference_for_multi_assignments.groovy
@@ -22,8 +22,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'println(foobar)', 6, 3, null, $spock_condition_throwable)}
-        finally {
-        }
         org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     }
     catch (java.lang.Throwable $spock_tmp_throwable) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/multi_parameterization.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/multi_parameterization.groovy
@@ -14,8 +14,6 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b) {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a == b', 1, 83, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/multi_parameterization.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/multi_parameterization.groovy
@@ -25,9 +25,9 @@ public java.lang.Object $spock_feature_0_0prov0() {
 
 @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ['a', 'b'])
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0) {
-    java.lang.Object a = (( $spock_p0 instanceof java.util.Map ? $spock_p0.getAt('a') : $spock_p0.getAt(0)) as java.lang.Object)
-    java.lang.Object b = (( $spock_p0 instanceof java.util.Map ? $spock_p0.getAt('b') : $spock_p0.getAt(1)) as java.lang.Object)
-    return new java.lang.Object[]{ a , b }
+    java.lang.Object a = (($spock_p0 instanceof java.util.Map ? $spock_p0.getAt('a') : $spock_p0.getAt(0)) as java.lang.Object)
+    java.lang.Object b = (($spock_p0 instanceof java.util.Map ? $spock_p0.getAt('b') : $spock_p0.getAt(1)) as java.lang.Object)
+    return new java.lang.Object[]{a, b}
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/nested_multi_parameterization.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/nested_multi_parameterization.groovy
@@ -14,8 +14,6 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b) {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a == b', 1, 83, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/nested_multi_parameterization.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/nested_multi_parameterization.groovy
@@ -25,10 +25,10 @@ public java.lang.Object $spock_feature_0_0prov0() {
 
 @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ['a', 'b'])
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0) {
-    java.lang.Object a = (( $spock_p0 instanceof java.util.Map ? $spock_p0.getAt('a') : $spock_p0.getAt(0)) as java.lang.Object)
+    java.lang.Object a = (($spock_p0 instanceof java.util.Map ? $spock_p0.getAt('a') : $spock_p0.getAt(0)) as java.lang.Object)
     java.lang.Object $spock_l0 = (($spock_p0.getAt(1)) as java.lang.Object)
-    java.lang.Object b = (( $spock_l0 instanceof java.util.Map ? $spock_l0.getAt('b') : $spock_l0.getAt(1)) as java.lang.Object)
-    return new java.lang.Object[]{ a , b }
+    java.lang.Object b = (($spock_l0 instanceof java.util.Map ? $spock_l0.getAt('b') : $spock_l0.getAt(1)) as java.lang.Object)
+    return new java.lang.Object[]{a, b}
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables.groovy
@@ -14,8 +14,6 @@ public void $spock_feature_0_0(java.lang.Object name, java.lang.Object greeting)
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'greeting == \"Hello, world\"', 1, 83, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }
@@ -42,8 +40,6 @@ public java.lang.Object[] $spock_feature_0_0wherevars() {
     catch (java.lang.Throwable $spock_tmp_throwable) {
         org.spockframework.runtime.SpockRuntime.closeWhereBlockVariablesAfterFailure($spock_whereVariableValues, $spock_tmp_throwable)
         throw $spock_tmp_throwable
-    }
-    finally {
     }
 }
 /*--------- end::snapshot[] ---------*/

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables.groovy
@@ -25,16 +25,16 @@ public java.lang.Object $spock_feature_0_0prov0(java.lang.Object prefix) {
 
 @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ['name', 'greeting'])
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object prefix) {
-    java.lang.Object name = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object greeting = (( prefix + name ) as java.lang.Object)
-    return new java.lang.Object[]{ name , greeting }
+    java.lang.Object name = ($spock_p0 as java.lang.Object)
+    java.lang.Object greeting = ((prefix + name ) as java.lang.Object)
+    return new java.lang.Object[]{name, greeting}
 }
 
 public java.lang.Object[] $spock_feature_0_0wherevars() {
     java.lang.Object[] $spock_whereVariableValues = new java.lang.Object[1]{}
     try {
         java.lang.Object prefix = 'Hello, '
-        $spock_whereVariableValues [ 0] = prefix
+        $spock_whereVariableValues[0] = prefix
         return $spock_whereVariableValues
     }
     catch (java.lang.Throwable $spock_tmp_throwable) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_combined_with_data_table__data_pipe__derived_variables__cross_multiplication_and_filter.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_combined_with_data_table__data_pipe__derived_variables__cross_multiplication_and_filter.groovy
@@ -30,21 +30,21 @@ public java.lang.Object $spock_feature_0_0prov2(java.lang.Object base, java.lang
 }
 
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object $spock_p1, java.lang.Object $spock_p2, java.lang.Object base, java.lang.Object sep) {
-    java.lang.Object x = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object y = (( $spock_p1 ) as java.lang.Object)
-    java.lang.Object z = (( $spock_p2 ) as java.lang.Object)
+    java.lang.Object x = ($spock_p0 as java.lang.Object)
+    java.lang.Object y = ($spock_p1 as java.lang.Object)
+    java.lang.Object z = ($spock_p2 as java.lang.Object)
     java.lang.Object label = (("${x}${sep}${y}") as java.lang.Object)
-    java.lang.Object total = (( x + y + base ) as java.lang.Object)
-    return new java.lang.Object[]{ x , y , z , label , total }
+    java.lang.Object total = ((x + y + base ) as java.lang.Object)
+    return new java.lang.Object[]{x, y, z, label, total}
 }
 
 public java.lang.Object[] $spock_feature_0_0wherevars() {
     java.lang.Object[] $spock_whereVariableValues = new java.lang.Object[2]{}
     try {
         java.lang.Object base = 10
-        $spock_whereVariableValues [ 0] = base
+        $spock_whereVariableValues[0] = base
         java.lang.Object sep = '-'
-        $spock_whereVariableValues [ 1] = sep
+        $spock_whereVariableValues[1] = sep
         return $spock_whereVariableValues
     }
     catch (java.lang.Throwable $spock_tmp_throwable) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_combined_with_data_table__data_pipe__derived_variables__cross_multiplication_and_filter.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_combined_with_data_table__data_pipe__derived_variables__cross_multiplication_and_filter.groovy
@@ -13,8 +13,6 @@ public void $spock_feature_0_0(java.lang.Object x, java.lang.Object y, java.lang
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 5, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }
@@ -53,8 +51,6 @@ public java.lang.Object[] $spock_feature_0_0wherevars() {
         org.spockframework.runtime.SpockRuntime.closeWhereBlockVariablesAfterFailure($spock_whereVariableValues, $spock_tmp_throwable)
         throw $spock_tmp_throwable
     }
-    finally {
-    }
 }
 
 public static org.spockframework.runtime.model.DataVariableMultiplication[] $spock_feature_0_0prods() {
@@ -69,8 +65,6 @@ public void $spock_feature_0_0filter(java.lang.Object x, java.lang.Object y, jav
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'total > 0', 20, 5, null, $spock_condition_throwable)}
-    finally {
-    }
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy3_4.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy3_4.groovy
@@ -25,17 +25,17 @@ public java.lang.Object $spock_feature_0_0prov0(java.lang.Object prefix, java.la
 
 @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ['name', 'greeting'])
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object prefix, java.lang.Object suffix) {
-    java.lang.Object name = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object greeting = (( prefix + name + suffix ) as java.lang.Object)
-    return new java.lang.Object[]{ name , greeting }
+    java.lang.Object name = ($spock_p0 as java.lang.Object)
+    java.lang.Object greeting = ((prefix + name + suffix ) as java.lang.Object)
+    return new java.lang.Object[]{name, greeting}
 }
 
 public java.lang.Object[] $spock_feature_0_0wherevars() {
     java.lang.Object[] $spock_whereVariableValues = new java.lang.Object[2]{}
     try {
         def (java.lang.Object prefix, java.lang.Object suffix) = ['Hello, ', '!']
-        $spock_whereVariableValues [ 0] = prefix
-        $spock_whereVariableValues [ 1] = suffix
+        $spock_whereVariableValues[0] = prefix
+        $spock_whereVariableValues[1] = suffix
         return $spock_whereVariableValues
     }
     catch (java.lang.Throwable $spock_tmp_throwable) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy3_4.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy3_4.groovy
@@ -14,8 +14,6 @@ public void $spock_feature_0_0(java.lang.Object name, java.lang.Object greeting)
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'greeting == \"Hello, world!\"', 1, 83, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }
@@ -43,8 +41,6 @@ public java.lang.Object[] $spock_feature_0_0wherevars() {
     catch (java.lang.Throwable $spock_tmp_throwable) {
         org.spockframework.runtime.SpockRuntime.closeWhereBlockVariablesAfterFailure($spock_whereVariableValues, $spock_tmp_throwable)
         throw $spock_tmp_throwable
-    }
-    finally {
     }
 }
 /*--------- end::snapshot[] ---------*/

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy5.groovy
@@ -25,17 +25,17 @@ public java.lang.Object $spock_feature_0_0prov0(java.lang.Object prefix, java.la
 
 @org.spockframework.runtime.model.DataProcessorMetadata(dataVariables = ['name', 'greeting'])
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object prefix, java.lang.Object suffix) {
-    java.lang.Object name = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object greeting = (( prefix + name + suffix ) as java.lang.Object)
-    return new java.lang.Object[]{ name , greeting }
+    java.lang.Object name = ($spock_p0 as java.lang.Object)
+    java.lang.Object greeting = ((prefix + name + suffix ) as java.lang.Object)
+    return new java.lang.Object[]{name, greeting}
 }
 
 public java.lang.Object[] $spock_feature_0_0wherevars() {
     java.lang.Object[] $spock_whereVariableValues = new java.lang.Object[2]{}
     try {
-        java.lang.Object( prefix , suffix ) = ['Hello, ', '!']
-        $spock_whereVariableValues [ 0] = prefix
-        $spock_whereVariableValues [ 1] = suffix
+        def (java.lang.Object prefix, java.lang.Object suffix) = ['Hello, ', '!']
+        $spock_whereVariableValues[0] = prefix
+        $spock_whereVariableValues[1] = suffix
         return $spock_whereVariableValues
     }
     catch (java.lang.Throwable $spock_tmp_throwable) {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataAstSpec/where_block_variables_with_multiple_assignment-groovy5.groovy
@@ -14,8 +14,6 @@ public void $spock_feature_0_0(java.lang.Object name, java.lang.Object greeting)
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'greeting == \"Hello, world!\"', 1, 83, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }
@@ -43,8 +41,6 @@ public java.lang.Object[] $spock_feature_0_0wherevars() {
     catch (java.lang.Throwable $spock_tmp_throwable) {
         org.spockframework.runtime.SpockRuntime.closeWhereBlockVariablesAfterFailure($spock_whereVariableValues, $spock_tmp_throwable)
         throw $spock_tmp_throwable
-    }
-    finally {
     }
 }
 /*--------- end::snapshot[] ---------*/

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[0].groovy
@@ -30,10 +30,10 @@ public java.lang.Object $spock_feature_0_0prov2(java.util.List $spock_p_a, java.
 }
 
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object $spock_p1, java.lang.Object $spock_p2) {
-    java.lang.Object a = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object b = (( $spock_p1 ) as java.lang.Object)
-    java.lang.Object c = (( $spock_p2 ) as java.lang.Object)
-    return new java.lang.Object[]{ a , b , c }
+    java.lang.Object a = ($spock_p0 as java.lang.Object)
+    java.lang.Object b = ($spock_p1 as java.lang.Object)
+    java.lang.Object c = ($spock_p2 as java.lang.Object)
+    return new java.lang.Object[]{a, b, c}
 }
 
 public static org.spockframework.runtime.model.DataVariableMultiplication[] $spock_feature_0_0prods() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[0].groovy
@@ -13,8 +13,6 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b, java.lang
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 7, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[1].groovy
@@ -30,10 +30,10 @@ public java.lang.Object $spock_feature_0_0prov2(java.util.List $spock_p_a, java.
 }
 
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object $spock_p1, java.lang.Object $spock_p2) {
-    java.lang.Object a = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object b = (( $spock_p1 ) as java.lang.Object)
-    java.lang.Object c = (( $spock_p2 ) as java.lang.Object)
-    return new java.lang.Object[]{ a , b , c }
+    java.lang.Object a = ($spock_p0 as java.lang.Object)
+    java.lang.Object b = ($spock_p1 as java.lang.Object)
+    java.lang.Object c = ($spock_p2 as java.lang.Object)
+    return new java.lang.Object[]{a, b, c}
 }
 
 public static org.spockframework.runtime.model.DataVariableMultiplication[] $spock_feature_0_0prods() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[1].groovy
@@ -13,8 +13,6 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b, java.lang
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 7, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[2].groovy
@@ -30,10 +30,10 @@ public java.lang.Object $spock_feature_0_0prov2(java.util.List $spock_p_a, java.
 }
 
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object $spock_p1, java.lang.Object $spock_p2) {
-    java.lang.Object a = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object b = (( $spock_p1 ) as java.lang.Object)
-    java.lang.Object c = (( $spock_p2 ) as java.lang.Object)
-    return new java.lang.Object[]{ a , b , c }
+    java.lang.Object a = ($spock_p0 as java.lang.Object)
+    java.lang.Object b = ($spock_p1 as java.lang.Object)
+    java.lang.Object c = ($spock_p2 as java.lang.Object)
+    return new java.lang.Object[]{a, b, c}
 }
 
 public static org.spockframework.runtime.model.DataVariableMultiplication[] $spock_feature_0_0prods() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/data_tables_with__separators_can_be_combined-[2].groovy
@@ -13,8 +13,6 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b, java.lang
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 7, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/filter_block_becomes_its_own_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/filter_block_becomes_its_own_method.groovy
@@ -13,8 +13,6 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b) {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 2, 7, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }
@@ -45,15 +43,11 @@ public void $spock_feature_0_0filter(java.lang.Object a, java.lang.Object b) {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a == 1', 15, 7, null, $spock_condition_throwable)}
-    finally {
-    }
     try {
         org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'b == 2', 16, 7, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), b) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)))
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'b == 2', 16, 7, null, $spock_condition_throwable)}
-    finally {
-    }
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/filter_block_becomes_its_own_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/filter_block_becomes_its_own_method.groovy
@@ -26,9 +26,9 @@ public java.lang.Object $spock_feature_0_0prov1(java.util.List $spock_p_a) {
 }
 
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object $spock_p1) {
-    java.lang.Object a = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object b = (( $spock_p1 ) as java.lang.Object)
-    return new java.lang.Object[]{ a , b }
+    java.lang.Object a = ($spock_p0 as java.lang.Object)
+    java.lang.Object b = ($spock_p1 as java.lang.Object)
+    return new java.lang.Object[]{a, b}
 }
 
 public static org.spockframework.runtime.model.DataVariableMultiplication[] $spock_feature_0_0prods() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/using_a_variable_in_a_cell_multiple_times_compiles.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/using_a_variable_in_a_cell_multiple_times_compiles.groovy
@@ -13,8 +13,6 @@ public void $spock_feature_0_0(java.lang.Object a, java.lang.Object b, java.lang
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a + b == result', 2, 9, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/using_a_variable_in_a_cell_multiple_times_compiles.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/using_a_variable_in_a_cell_multiple_times_compiles.groovy
@@ -37,10 +37,10 @@ public java.lang.Object $spock_feature_0_0prov2(java.util.List $spock_p_a, java.
 }
 
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0, java.lang.Object $spock_p1, java.lang.Object $spock_p2) {
-    java.lang.Object a = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object b = (( $spock_p1 ) as java.lang.Object)
-    java.lang.Object result = (( $spock_p2 ) as java.lang.Object)
-    return new java.lang.Object[]{ a , b , result }
+    java.lang.Object a = ($spock_p0 as java.lang.Object)
+    java.lang.Object b = ($spock_p1 as java.lang.Object)
+    java.lang.Object result = ($spock_p2 as java.lang.Object)
+    return new java.lang.Object[]{a, b, result}
 }
 /*--------- end::snapshot[] ---------*/
   }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/using_a_variable_in_a_cell_multiple_times_compiles.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/DataTablesAstSpec/using_a_variable_in_a_cell_multiple_times_compiles.groovy
@@ -28,11 +28,11 @@ public java.lang.Object $spock_feature_0_0prov1(java.util.List $spock_p_a) {
 }
 
 public java.lang.Object $spock_feature_0_0prov2(java.util.List $spock_p_a, java.util.List $spock_p_b) {
-    return [{ ->
+    return [{
         java.lang.Object a = $spock_p_a.get(0)
         java.lang.Object b = $spock_p_b.get(0)
         return a + b
-    }.call(), { ->
+    }.call(), {
         java.lang.Object a = $spock_p_a.get(1)
         return a + a
     }.call()]

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/collection_condition_matchCollectionsAsSet_is_transformed_correctly.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/collection_condition_matchCollectionsAsSet_is_transformed_correctly.groovy
@@ -17,8 +17,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'x =~ [1]', 4, 9, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/collection_condition_matchCollectionsInAnyOrder_is_transformed_correctly.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/collection_condition_matchCollectionsInAnyOrder_is_transformed_correctly.groovy
@@ -17,8 +17,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'x ==~ [1]', 4, 9, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/regex_find_conditions_are_transformed_correctly.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/regex_find_conditions_are_transformed_correctly.groovy
@@ -17,8 +17,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'x =~ /\\d/', 4, 9, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/regex_match_conditions_are_transformed_correctly.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/CollectionConditionAstSpec/regex_match_conditions_are_transformed_correctly.groovy
@@ -17,8 +17,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'x ==~ /a\\db/', 4, 9, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 1)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_explicit_condition.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_explicit_condition.groovy
@@ -10,8 +10,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'null.with {\n  false\n}', 2, 8, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_explicit_condition.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_explicit_condition.groovy
@@ -4,7 +4,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
     try {
-        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'null.with {\n  false\n}', 2, 8, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), null), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 'with'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), { ->
+        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'null.with {\n  false\n}', 2, 8, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), null), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 'with'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), {
             false
         })}, $spock_valueRecorder.realizeNas(5, false), true, 4)
     }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_implicit_condition.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_implicit_condition.groovy
@@ -4,7 +4,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
     try {
-        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'null.with {\n  false\n}', 2, 1, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), null), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 'with'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), { ->
+        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'null.with {\n  false\n}', 2, 1, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), null), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 'with'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), {
             false
         })}, $spock_valueRecorder.realizeNas(5, false), false, 4)
     }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_implicit_condition.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/GDK_method_that_looks_like_built_in_method_as_implicit_condition.groovy
@@ -10,8 +10,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'null.with {\n  false\n}', 2, 1, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[0].groovy
@@ -9,8 +9,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'false', 3, 3, null, $spock_condition_throwable)}
-        finally {
-        }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[0].groovy
@@ -2,7 +2,7 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.with([''], { ->
+    this.with([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder1.reset(), 'false', 3, 3, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), false))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[1].groovy
@@ -1,7 +1,7 @@
 @org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
 public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyAll([''], { ->
+    this.verifyAll([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         org.spockframework.runtime.ErrorCollector $spock_errorCollector1 = new org.spockframework.runtime.ErrorCollector()
         try {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[1].groovy
@@ -10,8 +10,6 @@ public void $spock_feature_0_0() {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector1, $spock_valueRecorder1, 'false', 3, 3, null, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector1.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[2].groovy
@@ -9,8 +9,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'false', 3, 3, null, $spock_condition_throwable)}
-        finally {
-        }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod-[2].groovy
@@ -2,7 +2,7 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyEach([''], { ->
+    this.verifyEach([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder1.reset(), 'false', 3, 3, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), false))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[0].groovy
@@ -2,7 +2,7 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.with([''], { ->
+    this.with([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder1.reset(), 'true', 3, 3, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[0].groovy
@@ -9,8 +9,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 3, 3, null, $spock_condition_throwable)}
-        finally {
-        }
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[1].groovy
@@ -10,8 +10,6 @@ public void $spock_feature_0_0() {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector1, $spock_valueRecorder1, 'true', 3, 3, null, $spock_condition_throwable)}
-            finally {
-            }
             throw new java.lang.Exception('foo')
         }
         finally {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[1].groovy
@@ -1,7 +1,7 @@
 @org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
 public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyAll([''], { ->
+    this.verifyAll([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         org.spockframework.runtime.ErrorCollector $spock_errorCollector1 = new org.spockframework.runtime.ErrorCollector()
         try {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[2].groovy
@@ -2,7 +2,7 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyEach([''], { ->
+    this.verifyEach([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder1.reset(), 'true', 3, 3, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_exception-[2].groovy
@@ -9,8 +9,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 3, 3, null, $spock_condition_throwable)}
-        finally {
-        }
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[0].groovy
@@ -1,7 +1,7 @@
 @org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
 public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.with([''], { ->
+    this.with([''], {
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[1].groovy
@@ -1,7 +1,7 @@
 @org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
 public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyAll([''], { ->
+    this.verifyAll([''], {
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_with_only_exception-[2].groovy
@@ -1,7 +1,7 @@
 @org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
 public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyEach([''], { ->
+    this.verifyEach([''], {
         throw new java.lang.Exception('foo')
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[0].groovy
@@ -2,10 +2,10 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.with([''], { ->
+    this.with([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
-            this.with([''], { ->
+            this.with([''], {
                 org.spockframework.runtime.ValueRecorder $spock_valueRecorder2 = new org.spockframework.runtime.ValueRecorder()
                 try {
                     org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder2.reset(), 'false', 4, 5, null, $spock_valueRecorder2.record($spock_valueRecorder2.startRecordingValue(0), false))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[0].groovy
@@ -12,14 +12,10 @@ public void $spock_feature_0_0() {
                 }
                 catch (java.lang.Throwable $spock_condition_throwable) {
                     org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder2, 'false', 4, 5, null, $spock_condition_throwable)}
-                finally {
-                }
             })
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
-        finally {
-        }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[1].groovy
@@ -1,12 +1,12 @@
 @org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
 public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyAll([''], { ->
+    this.verifyAll([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         org.spockframework.runtime.ErrorCollector $spock_errorCollector1 = new org.spockframework.runtime.ErrorCollector()
         try {
             try {
-                this.verifyAll([''], { ->
+                this.verifyAll([''], {
                     org.spockframework.runtime.ValueRecorder $spock_valueRecorder2 = new org.spockframework.runtime.ValueRecorder()
                     org.spockframework.runtime.ErrorCollector $spock_errorCollector2 = new org.spockframework.runtime.ErrorCollector()
                     try {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[1].groovy
@@ -15,8 +15,6 @@ public void $spock_feature_0_0() {
                         }
                         catch (java.lang.Throwable $spock_condition_throwable) {
                             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector2, $spock_valueRecorder2, 'false', 4, 5, null, $spock_condition_throwable)}
-                        finally {
-                        }
                     }
                     finally {
                         $spock_errorCollector2.validateCollectedErrors()}
@@ -24,8 +22,6 @@ public void $spock_feature_0_0() {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector1, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector1.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[2].groovy
@@ -12,14 +12,10 @@ public void $spock_feature_0_0() {
                 }
                 catch (java.lang.Throwable $spock_condition_throwable) {
                     org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder2, 'false', 4, 5, null, $spock_condition_throwable)}
-                finally {
-                }
             })
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
-        finally {
-        }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod-[2].groovy
@@ -2,10 +2,10 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyEach([''], { ->
+    this.verifyEach([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
-            this.verifyEach([''], { ->
+            this.verifyEach([''], {
                 org.spockframework.runtime.ValueRecorder $spock_valueRecorder2 = new org.spockframework.runtime.ValueRecorder()
                 try {
                     org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder2.reset(), 'false', 4, 5, null, $spock_valueRecorder2.record($spock_valueRecorder2.startRecordingValue(0), false))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[0].groovy
@@ -12,15 +12,11 @@ public void $spock_feature_0_0() {
                 }
                 catch (java.lang.Throwable $spock_condition_throwable) {
                     org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder2, 'true', 4, 5, null, $spock_condition_throwable)}
-                finally {
-                }
                 throw new java.lang.Exception('foo')
             })
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
-        finally {
-        }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[0].groovy
@@ -2,10 +2,10 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.with([''], { ->
+    this.with([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
-            this.with([''], { ->
+            this.with([''], {
                 org.spockframework.runtime.ValueRecorder $spock_valueRecorder2 = new org.spockframework.runtime.ValueRecorder()
                 try {
                     org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder2.reset(), 'true', 4, 5, null, $spock_valueRecorder2.record($spock_valueRecorder2.startRecordingValue(0), true))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[1].groovy
@@ -1,12 +1,12 @@
 @org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
 public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyAll([''], { ->
+    this.verifyAll([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         org.spockframework.runtime.ErrorCollector $spock_errorCollector1 = new org.spockframework.runtime.ErrorCollector()
         try {
             try {
-                this.verifyAll([''], { ->
+                this.verifyAll([''], {
                     org.spockframework.runtime.ValueRecorder $spock_valueRecorder2 = new org.spockframework.runtime.ValueRecorder()
                     org.spockframework.runtime.ErrorCollector $spock_errorCollector2 = new org.spockframework.runtime.ErrorCollector()
                     try {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[1].groovy
@@ -15,8 +15,6 @@ public void $spock_feature_0_0() {
                         }
                         catch (java.lang.Throwable $spock_condition_throwable) {
                             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector2, $spock_valueRecorder2, 'true', 4, 5, null, $spock_condition_throwable)}
-                        finally {
-                        }
                         throw new java.lang.Exception('foo')
                     }
                     finally {
@@ -25,8 +23,6 @@ public void $spock_feature_0_0() {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector1, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector1.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[2].groovy
@@ -2,10 +2,10 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyEach([''], { ->
+    this.verifyEach([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
-            this.verifyEach([''], { ->
+            this.verifyEach([''], {
                 org.spockframework.runtime.ValueRecorder $spock_valueRecorder2 = new org.spockframework.runtime.ValueRecorder()
                 try {
                     org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder2.reset(), 'true', 4, 5, null, $spock_valueRecorder2.record($spock_valueRecorder2.startRecordingValue(0), true))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_exception-[2].groovy
@@ -12,15 +12,11 @@ public void $spock_feature_0_0() {
                 }
                 catch (java.lang.Throwable $spock_condition_throwable) {
                     org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder2, 'true', 4, 5, null, $spock_condition_throwable)}
-                finally {
-                }
                 throw new java.lang.Exception('foo')
             })
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
-        finally {
-        }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[0].groovy
@@ -2,10 +2,10 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.with([''], { ->
+    this.with([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
-            this.with([''], { ->
+            this.with([''], {
                 throw new java.lang.Exception('foo')
             })
         }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[0].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[0].groovy
@@ -11,8 +11,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
-        finally {
-        }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[1].groovy
@@ -12,8 +12,6 @@ public void $spock_feature_0_0() {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector1, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector1.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[1].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[1].groovy
@@ -1,12 +1,12 @@
 @org.spockframework.runtime.model.FeatureMetadata(name = 'a feature', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
 public void $spock_feature_0_0() {
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyAll([''], { ->
+    this.verifyAll([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         org.spockframework.runtime.ErrorCollector $spock_errorCollector1 = new org.spockframework.runtime.ErrorCollector()
         try {
             try {
-                this.verifyAll([''], { ->
+                this.verifyAll([''], {
                     throw new java.lang.Exception('foo')
                 })
             }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[2].groovy
@@ -2,10 +2,10 @@
 public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
-    this.verifyEach([''], { ->
+    this.verifyEach([''], {
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
-            this.verifyEach([''], { ->
+            this.verifyEach([''], {
                 throw new java.lang.Exception('foo')
             })
         }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[2].groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ConditionMethodsAstSpec/condition_method__conditionMethod_within_condition_method__conditionMethod_with_only_exception-[2].groovy
@@ -11,8 +11,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
-        finally {
-        }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec/thrown_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/ExceptionConditionsAstSpec/thrown_rewrite_keeps_correct_method_reference_for_multi_assignments-groovy5.groovy
@@ -8,7 +8,7 @@ public java.lang.Object foobar() {
 }
 
 public void $spock_feature_0_0() {
-    java.lang.Object( foobar , b ) = [null, null]
+    def (java.lang.Object foobar, java.lang.Object b) = [null, null]
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
     this.getSpecificationContext().setThrownException(null)
     try {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/ignores_conditions_in_overwritten_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/ignores_conditions_in_overwritten_methods.groovy
@@ -10,8 +10,6 @@ public class BaseAssertions extends java.lang.Object {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a >= 0', 5, 9, null, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/ignores_methods_without_annotation.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/ignores_methods_without_annotation.groovy
@@ -10,8 +10,6 @@ public class Assertions extends java.lang.Object {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 5, 9, null, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/methods_without_condition_declarations_stay_unchanged_in_specs.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/methods_without_condition_declarations_stay_unchanged_in_specs.groovy
@@ -18,8 +18,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 3, 5, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_at_all_nesting_levels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_at_all_nesting_levels.groovy
@@ -10,7 +10,7 @@ public class Assertions extends java.lang.Object {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a != 0', 5, 9, null, $spock_condition_throwable)}
-            if ( a > 0) {
+            if (a > 0) {
                 try {
                     org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 7, 13, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
                 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_at_all_nesting_levels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_at_all_nesting_levels.groovy
@@ -10,16 +10,12 @@ public class Assertions extends java.lang.Object {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a != 0', 5, 9, null, $spock_condition_throwable)}
-            finally {
-            }
             if ( a > 0) {
                 try {
                     org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 7, 13, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
                 }
                 catch (java.lang.Throwable $spock_condition_throwable) {
                     org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a % 2 == 0', 7, 13, null, $spock_condition_throwable)}
-                finally {
-                }
             }
         }
         finally {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_methods_inside_spec_classes.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_methods_inside_spec_classes.groovy
@@ -13,15 +13,11 @@ public void isPositiveAndEven(int a) {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 3, 5, null, $spock_condition_throwable)}
-        finally {
-        }
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 4, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a % 2 == 0', 4, 5, null, $spock_condition_throwable)}
-        finally {
-        }
     }
     finally {
         $spock_errorCollector.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_methods_outside_of_spec_classes.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_methods_outside_of_spec_classes.groovy
@@ -10,15 +10,11 @@ public class Assertions extends java.lang.Object {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 5, 9, null, $spock_condition_throwable)}
-            finally {
-            }
             try {
                 org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 6, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a % 2 == 0', 6, 9, null, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_private_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_private_methods.groovy
@@ -13,8 +13,6 @@ private void isPositive(int a) {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 17, 5, null, $spock_condition_throwable)}
-        finally {
-        }
         try {
             org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 18, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
                 it
@@ -22,8 +20,6 @@ private void isPositive(int a) {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 18, 5, null, $spock_condition_throwable)}
-        finally {
-        }
         if (true) {
             try {
                 org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 20, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
@@ -32,8 +28,6 @@ private void isPositive(int a) {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 20, 9, null, $spock_condition_throwable)}
-            finally {
-            }
         }
         try {
             this.with({
@@ -45,8 +39,6 @@ private void isPositive(int a) {
                 }
                 catch (java.lang.Throwable $spock_condition_throwable) {
                     org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, '[true, false].any { it }', 23, 9, null, $spock_condition_throwable)}
-                finally {
-                }
                 if (true) {
                     try {
                         org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 25, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
@@ -55,15 +47,11 @@ private void isPositive(int a) {
                     }
                     catch (java.lang.Throwable $spock_condition_throwable) {
                         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, '[true, false].any { it }', 25, 13, null, $spock_condition_throwable)}
-                    finally {
-                    }
                 }
             })
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
-        finally {
-        }
     }
     finally {
         $spock_errorCollector.validateCollectedErrors()}
@@ -81,8 +69,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 3, 5, null, $spock_condition_throwable)}
-    finally {
-    }
     if (true) {
         [true, false].any({
             it
@@ -97,8 +83,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, '[true, false].any { it }', 8, 9, null, $spock_condition_throwable)}
-        finally {
-        }
         if (true) {
             try {
                 org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 10, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
@@ -107,8 +91,6 @@ public void $spock_feature_0_0() {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, '[true, false].any { it }', 10, 13, null, $spock_condition_throwable)}
-            finally {
-            }
         }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_private_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_private_methods.groovy
@@ -16,7 +16,7 @@ private void isPositive(int a) {
         finally {
         }
         try {
-            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 18, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), { ->
+            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 18, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
                 it
             })}, $spock_valueRecorder.realizeNas(7, false), false, 6)
         }
@@ -26,7 +26,7 @@ private void isPositive(int a) {
         }
         if (true) {
             try {
-                org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 20, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), { ->
+                org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 20, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
                     it
                 })}, $spock_valueRecorder.realizeNas(7, false), false, 6)
             }
@@ -36,10 +36,10 @@ private void isPositive(int a) {
             }
         }
         try {
-            this.with({ ->
+            this.with({
                 org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
                 try {
-                    org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 23, 9, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), { ->
+                    org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 23, 9, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
                         it
                     })}, $spock_valueRecorder1.realizeNas(7, false), false, 6)
                 }
@@ -49,7 +49,7 @@ private void isPositive(int a) {
                 }
                 if (true) {
                     try {
-                        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 25, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), { ->
+                        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 25, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
                             it
                         })}, $spock_valueRecorder1.realizeNas(7, false), false, 6)
                     }
@@ -75,7 +75,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
     try {
-        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 3, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), { ->
+        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 3, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
             it
         })}, $spock_valueRecorder.realizeNas(7, false), false, 6)
     }
@@ -84,14 +84,14 @@ public void $spock_feature_0_0() {
     finally {
     }
     if (true) {
-        [true, false].any({ ->
+        [true, false].any({
             it
         })
     }
-    this.with({ ->
+    this.with({
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
-            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 8, 9, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), { ->
+            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 8, 9, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
                 it
             })}, $spock_valueRecorder1.realizeNas(7, false), false, 6)
         }
@@ -101,7 +101,7 @@ public void $spock_feature_0_0() {
         }
         if (true) {
             try {
-                org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 10, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), { ->
+                org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 10, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
                     it
                 })}, $spock_valueRecorder1.realizeNas(7, false), false, 6)
             }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_static_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_conditions_in_static_methods.groovy
@@ -10,8 +10,6 @@ public class Assertions extends java.lang.Object {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 5, 9, null, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_explicit_conditions.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyAllMethodsAstSpec/transforms_explicit_conditions.groovy
@@ -10,15 +10,11 @@ public class Assertions extends java.lang.Object {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 5, 16, null, $spock_condition_throwable)}
-            finally {
-            }
             try {
                 org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 6, 16, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a % 2 == 0', 6, 16, null, $spock_condition_throwable)}
-            finally {
-            }
         }
         finally {
             $spock_errorCollector.validateCollectedErrors()}

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/ignores_conditions_in_overwritten_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/ignores_conditions_in_overwritten_methods.groovy
@@ -9,8 +9,6 @@ public class BaseAssertions extends java.lang.Object {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a >= 0', 5, 9, null, $spock_condition_throwable)}
-        finally {
-        }
     }
 
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/ignores_methods_without_annotation.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/ignores_methods_without_annotation.groovy
@@ -9,8 +9,6 @@ public class Assertions extends java.lang.Object {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 5, 9, null, $spock_condition_throwable)}
-        finally {
-        }
     }
 
     public static void nonAssertion() {

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/methods_without_condition_declarations_stay_unchanged_in_specs.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/methods_without_condition_declarations_stay_unchanged_in_specs.groovy
@@ -18,8 +18,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'true', 3, 5, null, $spock_condition_throwable)}
-    finally {
-    }
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)
     this.getSpecificationContext().getMockController().leaveScope()
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_at_all_nesting_levels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_at_all_nesting_levels.groovy
@@ -9,16 +9,12 @@ public class Assertions extends java.lang.Object {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a != 0', 5, 9, null, $spock_condition_throwable)}
-        finally {
-        }
         if ( a > 0) {
             try {
                 org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 7, 13, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a % 2 == 0', 7, 13, null, $spock_condition_throwable)}
-            finally {
-            }
         }
     }
 

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_at_all_nesting_levels.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_at_all_nesting_levels.groovy
@@ -9,7 +9,7 @@ public class Assertions extends java.lang.Object {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a != 0', 5, 9, null, $spock_condition_throwable)}
-        if ( a > 0) {
+        if (a > 0) {
             try {
                 org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 7, 13, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
             }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_methods_inside_spec_classes.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_methods_inside_spec_classes.groovy
@@ -12,15 +12,11 @@ public void isPositiveAndEven(int a) {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 3, 5, null, $spock_condition_throwable)}
-    finally {
-    }
     try {
         org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 4, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a % 2 == 0', 4, 5, null, $spock_condition_throwable)}
-    finally {
-    }
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_methods_outside_of_spec_classes.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_methods_outside_of_spec_classes.groovy
@@ -9,15 +9,11 @@ public class Assertions extends java.lang.Object {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 5, 9, null, $spock_condition_throwable)}
-        finally {
-        }
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 6, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a % 2 == 0', 6, 9, null, $spock_condition_throwable)}
-        finally {
-        }
     }
 
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_private_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_private_methods.groovy
@@ -12,8 +12,6 @@ private void isPositive(int a) {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 17, 5, null, $spock_condition_throwable)}
-    finally {
-    }
     try {
         org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 18, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
             it
@@ -21,8 +19,6 @@ private void isPositive(int a) {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 18, 5, null, $spock_condition_throwable)}
-    finally {
-    }
     if (true) {
         try {
             org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 20, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
@@ -31,8 +27,6 @@ private void isPositive(int a) {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 20, 9, null, $spock_condition_throwable)}
-        finally {
-        }
     }
     try {
         this.with({
@@ -44,8 +38,6 @@ private void isPositive(int a) {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, '[true, false].any { it }', 23, 9, null, $spock_condition_throwable)}
-            finally {
-            }
             if (true) {
                 try {
                     org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 25, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
@@ -54,15 +46,11 @@ private void isPositive(int a) {
                 }
                 catch (java.lang.Throwable $spock_condition_throwable) {
                     org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, '[true, false].any { it }', 25, 13, null, $spock_condition_throwable)}
-                finally {
-                }
             }
         })
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.groupConditionFailedWithException($spock_errorCollector, $spock_condition_throwable)}
-    finally {
-    }
 }
 
 @org.spockframework.runtime.model.FeatureMetadata(name = 'foo', ordinal = 0, line = 1, blocks = [@org.spockframework.runtime.model.BlockMetadata(kind = org.spockframework.runtime.model.BlockKind.EXPECT, texts = [])], parameterNames = [])
@@ -77,8 +65,6 @@ public void $spock_feature_0_0() {
     }
     catch (java.lang.Throwable $spock_condition_throwable) {
         org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, '[true, false].any { it }', 3, 5, null, $spock_condition_throwable)}
-    finally {
-    }
     if (true) {
         [true, false].any({
             it
@@ -93,8 +79,6 @@ public void $spock_feature_0_0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, '[true, false].any { it }', 8, 9, null, $spock_condition_throwable)}
-        finally {
-        }
         if (true) {
             try {
                 org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 10, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
@@ -103,8 +87,6 @@ public void $spock_feature_0_0() {
             }
             catch (java.lang.Throwable $spock_condition_throwable) {
                 org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, '[true, false].any { it }', 10, 13, null, $spock_condition_throwable)}
-            finally {
-            }
         }
     })
     org.spockframework.runtime.SpockRuntime.callBlockExited(this, 0)

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_private_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_private_methods.groovy
@@ -15,7 +15,7 @@ private void isPositive(int a) {
     finally {
     }
     try {
-        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 18, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), { ->
+        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 18, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
             it
         })}, $spock_valueRecorder.realizeNas(7, false), false, 6)
     }
@@ -25,7 +25,7 @@ private void isPositive(int a) {
     }
     if (true) {
         try {
-            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 20, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), { ->
+            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 20, 9, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
                 it
             })}, $spock_valueRecorder.realizeNas(7, false), false, 6)
         }
@@ -35,10 +35,10 @@ private void isPositive(int a) {
         }
     }
     try {
-        this.with({ ->
+        this.with({
             org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
             try {
-                org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 23, 9, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), { ->
+                org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 23, 9, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
                     it
                 })}, $spock_valueRecorder1.realizeNas(7, false), false, 6)
             }
@@ -48,7 +48,7 @@ private void isPositive(int a) {
             }
             if (true) {
                 try {
-                    org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 25, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), { ->
+                    org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 25, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
                         it
                     })}, $spock_valueRecorder1.realizeNas(7, false), false, 6)
                 }
@@ -71,7 +71,7 @@ public void $spock_feature_0_0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     org.spockframework.runtime.SpockRuntime.callBlockEntered(this, 0)
     try {
-        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 3, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), { ->
+        org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder.reset(), '[true, false].any { it }', 3, 5, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), [$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), true), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), false)]), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), {
             it
         })}, $spock_valueRecorder.realizeNas(7, false), false, 6)
     }
@@ -80,14 +80,14 @@ public void $spock_feature_0_0() {
     finally {
     }
     if (true) {
-        [true, false].any({ ->
+        [true, false].any({
             it
         })
     }
-    this.with({ ->
+    this.with({
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
-            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 8, 9, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), { ->
+            org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 8, 9, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
                 it
             })}, $spock_valueRecorder1.realizeNas(7, false), false, 6)
         }
@@ -97,7 +97,7 @@ public void $spock_feature_0_0() {
         }
         if (true) {
             try {
-                org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 10, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), { ->
+                org.spockframework.runtime.SpockRuntime.verifyMethodCondition($spock_errorCollector, $spock_valueRecorder1.reset(), '[true, false].any { it }', 10, 13, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(2), [$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(1), false)]), $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(3), 'any'), new java.lang.Object[]{$spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(4), {
                     it
                 })}, $spock_valueRecorder1.realizeNas(7, false), false, 6)
             }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_static_methods.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_conditions_in_static_methods.groovy
@@ -9,8 +9,6 @@ public class Assertions extends java.lang.Object {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 5, 9, null, $spock_condition_throwable)}
-        finally {
-        }
     }
 
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_explicit_conditions.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/ast/condition/VerifyMethodsAstSpec/transforms_explicit_conditions.groovy
@@ -9,15 +9,11 @@ public class Assertions extends java.lang.Object {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a > 0', 5, 16, null, $spock_condition_throwable)}
-        finally {
-        }
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder.reset(), 'a % 2 == 0', 6, 16, null, $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(4), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(2), $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(0), a) % $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(1), 2)) == $spock_valueRecorder.record($spock_valueRecorder.startRecordingValue(3), 0)))
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder, 'a % 2 == 0', 6, 16, null, $spock_condition_throwable)}
-        finally {
-        }
     }
 
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_provider_with_asserting_closure_produces_error_rethrower_variable_in_data_provider_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_provider_with_asserting_closure_produces_error_rethrower_variable_in_data_provider_method.groovy
@@ -20,9 +20,9 @@ public java.lang.Object $spock_feature_0_0prov0() {
 }
 
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0) {
-    java.lang.Object dataPipe = (( $spock_p0 ) as java.lang.Object)
+    java.lang.Object dataPipe = ($spock_p0 as java.lang.Object)
     java.lang.Object dataVariable = ((null) as java.lang.Object)
-    return new java.lang.Object[]{ dataPipe , dataVariable }
+    return new java.lang.Object[]{dataPipe, dataVariable}
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_provider_with_asserting_closure_produces_error_rethrower_variable_in_data_provider_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_provider_with_asserting_closure_produces_error_rethrower_variable_in_data_provider_method.groovy
@@ -9,7 +9,7 @@ public void $spock_feature_0_0(java.lang.Object dataPipe, java.lang.Object dataV
 
 public java.lang.Object $spock_feature_0_0prov0() {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
-    return [{ ->
+    return [{
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder1.reset(), 'true', 2, 29, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true))

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_provider_with_asserting_closure_produces_error_rethrower_variable_in_data_provider_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_provider_with_asserting_closure_produces_error_rethrower_variable_in_data_provider_method.groovy
@@ -16,8 +16,6 @@ public java.lang.Object $spock_feature_0_0prov0() {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 2, 29, null, $spock_condition_throwable)}
-        finally {
-        }
     }]
 }
 

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_variable_with_asserting_closure_produces_error_rethrower_variable_in_data_processor_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_variable_with_asserting_closure_produces_error_rethrower_variable_in_data_processor_method.groovy
@@ -21,8 +21,6 @@ public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0) {
         }
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 3, 31, null, $spock_condition_throwable)}
-        finally {
-        }
     }) as java.lang.Object)
     return new java.lang.Object[]{ dataPipe , dataVariable }
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_variable_with_asserting_closure_produces_error_rethrower_variable_in_data_processor_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_variable_with_asserting_closure_produces_error_rethrower_variable_in_data_processor_method.groovy
@@ -13,7 +13,7 @@ public java.lang.Object $spock_feature_0_0prov0() {
 
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0) {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
-    java.lang.Object dataPipe = (( $spock_p0 ) as java.lang.Object)
+    java.lang.Object dataPipe = ($spock_p0 as java.lang.Object)
     java.lang.Object dataVariable = (({
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
@@ -22,7 +22,7 @@ public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0) {
         catch (java.lang.Throwable $spock_condition_throwable) {
             org.spockframework.runtime.SpockRuntime.conditionFailedWithException($spock_errorCollector, $spock_valueRecorder1, 'true', 3, 31, null, $spock_condition_throwable)}
     }) as java.lang.Object)
-    return new java.lang.Object[]{ dataPipe , dataVariable }
+    return new java.lang.Object[]{dataPipe, dataVariable}
 }
 /*--------- end::snapshot[] ---------*/
 }

--- a/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_variable_with_asserting_closure_produces_error_rethrower_variable_in_data_processor_method.groovy
+++ b/spock-specs/src/test/resources/snapshots/org/spockframework/smoke/parameterization/DataProviders/data_variable_with_asserting_closure_produces_error_rethrower_variable_in_data_processor_method.groovy
@@ -14,7 +14,7 @@ public java.lang.Object $spock_feature_0_0prov0() {
 public java.lang.Object $spock_feature_0_0proc(java.lang.Object $spock_p0) {
     org.spockframework.runtime.ErrorCollector $spock_errorCollector = org.spockframework.runtime.ErrorRethrower.INSTANCE
     java.lang.Object dataPipe = (( $spock_p0 ) as java.lang.Object)
-    java.lang.Object dataVariable = (({ ->
+    java.lang.Object dataVariable = (({
         org.spockframework.runtime.ValueRecorder $spock_valueRecorder1 = new org.spockframework.runtime.ValueRecorder()
         try {
             org.spockframework.runtime.SpockRuntime.verifyCondition($spock_errorCollector, $spock_valueRecorder1.reset(), 'true', 3, 31, null, $spock_valueRecorder1.record($spock_valueRecorder1.startRecordingValue(0), true))


### PR DESCRIPTION
This PR started as a fix for nested generic type arguments and grew into a general fidelity pass over `SourceToAstNodeAndSourceTranspiler`, after exercising it with constructs the test suite never covered. Each fix is a separate commit with an `AstSpec` snapshot test.

### Fidelity fixes

* Nested generic type arguments: `Map<String, List<Integer>>` was rendered as `Map<String, List>`
* Elvis operator: `c ?: d` was rendered as `c ? c : d`, duplicating the condition expression
* Attribute access: `this.@order` was rendered as `this.order`, silently turning direct field access into property access (also `?.@` and `*.@`)
* Implicit-`it` closures: `{ it * 2 }` was rendered as `{ -> it * 2 }`, which declares a zero-arg closure without `it`. Note the AST convention: null parameters mean `{ -> }`, an empty array means implicit `it` (see `ClosureWriter`)
* Safe index access: `l?[0]` was rendered unbalanced as `l ?[ 0` under Groovy 4+, and as a plain (non-safe) `l [ 0]` under Groovy 3, where the parser keeps the `[` token and sets the safe flag instead
* Numeric literal type suffixes: `42L`, `2.5f`, `3.5d`, `10G` were rendered without suffix, so re-parsing would change their types
* Left-open ranges (Groovy 4+): `1<..5` was rendered as `(1..5)`
* Explicit type arguments of method calls: `Collections.<String>emptyList()` was rendered as `Collections.emptyList()`
* Multiple-assignment declarations (Groovy 5): the parser uses a plain `TupleExpression` as the left side, which the previous `ArgumentListExpression` check missed, rendering the broken `java.lang.Object( foobar , b ) = [null, null]` instead of `def (java.lang.Object foobar, java.lang.Object b) = [null, null]`

### Adopted from upstream `AstNodeToScriptAdapter`

* No spurious empty `default:` label for switches without one (groovy@dc020e06c8)
* No spurious empty `finally {}` for try statements without one (groovy@db888a0537); this alone cleaned 56 snapshots of noise from Spock's condition rewriting
* Groovy 5 `for (index, value in iterable)` loops render the index variable (groovy@876fbed302)
* The internally created `GroovyClassLoader` is closed after compilation (groovy@49fb716307)
* The cosmetic rendering overhaul (groovy@4988329696 and its predecessors): variables are no longer space-padded when used as assignment targets, unary/postfix/prefix operands, cast subjects, call receivers, or list and argument elements, so output reads like real Groovy: `!a`, `i++`, `[1, 2, 3][0]`, `(c as long)`, `((long) c)` instead of `!( a )`, `( i )++`, `[1, 2, 3] [ 0]`, `(( c ) as long)`, `((long) c )`. Since the fidelity fixes above already touched most snapshots, folding this in only added 6 more changed snapshot files (72 to 78 of 133)

APIs that do not exist in Groovy 2.5 (`BinaryExpression.isSafe()`, `RangeExpression.isExclusiveLeft()`, `ForStatement.getIndexVariable()`) are probed dynamically.

### Verification

The full snapshot suite (19 spec classes) passes under all variants (2.5, 3.0, 4.0, 5.0); shared snapshots are byte-identical across them. Version-specific constructs are guarded with `@Requires` on the Groovy major version.

Upstream still has all the fidelity bugs listed above (verified against groovy master aa30a69065); contributing them back is prepared separately.
