### PR TITLE
Escape method and property names when rendering interaction mismatches

### DIFF
--- a/docs/release_notes.adoc
+++ b/docs/release_notes.adoc
@@ -18,6 +18,7 @@ include::include.adoc[]
 * Fix `MockitoMockMaker` throws NPE on null object spockIssue:2337[]
 * Fix `SourceToAstNodeAndSourceTranspiler` dropping nested generic type arguments, so signatures like `Iterator<Tuple2<Integer, Integer>>` are now rendered faithfully instead of `Iterator<Tuple2>` spockPull:2393[]
 * Fix `SourceToAstNodeAndSourceTranspiler` rendering of several other constructs: the elvis operator, attribute access (`.@`), implicit-`it` closures, safe index access (`?[]`), numeric literal type suffixes (`L`, `F`, `D`, `G`), left-open ranges (`<..`), explicit type arguments of method calls, `for (index, value in iterable)` loops, multiple-assignment declarations on Groovy 5, and spurious empty `finally` blocks and `default` labels spockPull:2393[]
+* Fix interaction mismatch rendering failing with a lexer error and dropping the similarity report when a mocked method or property name contains a `$` spockIssue:2364[]
 
 === Breaking Changes
 

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/EqualMethodNameConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/EqualMethodNameConstraint.java
@@ -19,6 +19,7 @@ package org.spockframework.mock.constraint;
 import org.spockframework.mock.*;
 import org.spockframework.runtime.Condition;
 import org.spockframework.util.CollectionUtil;
+import org.spockframework.util.TextUtil;
 
 /**
  *
@@ -43,7 +44,7 @@ public class EqualMethodNameConstraint implements IInvocationConstraint {
   @Override
   public String describeMismatch(IMockInvocation invocation) {
     Condition condition = new Condition(CollectionUtil.listOf(invocation.getMethod().getName(), methodName, false),
-      String.format("methodName == \"%s\"", methodName), null, null,
+      String.format("methodName == \"%s\"", TextUtil.escapeGroovyDoubleQuotedString(methodName)), null, null,
       null, null);
     return condition.getRendering();
   }

--- a/spock-core/src/main/java/org/spockframework/mock/constraint/EqualPropertyNameConstraint.java
+++ b/spock-core/src/main/java/org/spockframework/mock/constraint/EqualPropertyNameConstraint.java
@@ -17,6 +17,7 @@ package org.spockframework.mock.constraint;
 import org.spockframework.mock.IMockInvocation;
 import org.spockframework.runtime.Condition;
 import org.spockframework.util.CollectionUtil;
+import org.spockframework.util.TextUtil;
 
 /**
  *
@@ -41,7 +42,7 @@ public class EqualPropertyNameConstraint extends PropertyNameConstraint {
   @Override
   public String describeMismatch(IMockInvocation invocation) {
     Condition condition = new Condition(CollectionUtil.listOf(getPropertyName(invocation), propertyName, false),
-      String.format("propertyName == \"%s\"", propertyName), null, null,
+      String.format("propertyName == \"%s\"", TextUtil.escapeGroovyDoubleQuotedString(propertyName)), null, null,
       null, null);
     return condition.getRendering();
   }

--- a/spock-core/src/main/java/org/spockframework/util/TextUtil.java
+++ b/spock-core/src/main/java/org/spockframework/util/TextUtil.java
@@ -128,6 +128,24 @@ public abstract class TextUtil {
     return builder.toString();
   }
 
+  /**
+   * Escapes {@code seq} for embedding in a Groovy double-quoted (GString) literal.
+   * On top of {@link #escape(char)}, this also escapes {@code "} and {@code $}, which
+   * would otherwise close the string or start an interpolation.
+   */
+  public static String escapeGroovyDoubleQuotedString(CharSequence seq) {
+    StringBuilder builder = new StringBuilder(seq.length() * 3 / 2);
+    for (int i = 0; i < seq.length(); i++) {
+      char ch = seq.charAt(i);
+      if (ch == '"' || ch == '$') {
+        builder.append('\\').append(ch);
+      } else {
+        builder.append(escape(ch));
+      }
+    }
+    return builder.toString();
+  }
+
   public static String printStackTrace(Throwable throwable) {
     StringWriter writer = new StringWriter();
     throwable.printStackTrace(new PrintWriter(writer));

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/TooFewInvocations.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/TooFewInvocations.groovy
@@ -19,6 +19,7 @@ package org.spockframework.smoke.mock
 import org.hamcrest.CoreMatchers
 import org.spockframework.EmbeddedSpecification
 import org.spockframework.mock.TooFewInvocationsError
+import spock.lang.Issue
 
 import java.util.regex.Pattern
 
@@ -744,6 +745,76 @@ Unmatched invocations (ordered by similarity):
     exceptionMessage == expected
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/2364")
+  def "can describe method name mismatch when the method name contains a dollar sign"() {
+    when:
+    runner.addClassImport(WithDollar)
+    runner.runFeatureBody("""
+def mock = Mock(WithDollar)
+
+when:
+mock.compareTo('a')
+
+then:
+1 * mock.compareTo\$(_)
+    """)
+
+    then:
+    TooFewInvocationsError e = thrown()
+    def exceptionMessage = normalize(e.message)
+    def expected = normalize('''
+Too few invocations for:
+
+1 * mock.compareTo$(_)   (0 invocations)
+
+Unmatched invocations (ordered by similarity):
+
+1 * mock.compareTo('a')
+methodName == "compareTo\\$"
+|          |
+compareTo  false
+           1 difference (90% similarity)
+           compareTo(-)
+           compareTo($)
+    ''')
+    exceptionMessage == expected
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/2364")
+  def "can describe property name mismatch when the property name contains a dollar sign"() {
+    when:
+    runner.addClassImport(WithDollar)
+    runner.runFeatureBody("""
+def mock = Mock(WithDollar)
+
+when:
+mock.foo
+
+then:
+1 * mock.bar\$
+    """)
+
+    then:
+    TooFewInvocationsError e = thrown()
+    def exceptionMessage = normalize(e.message)
+    def expected = normalize('''
+Too few invocations for:
+
+1 * mock.bar$   (0 invocations)
+
+Unmatched invocations (ordered by similarity):
+
+1 * mock.getFoo()
+propertyName == "bar\\$"
+|            |
+foo          false
+             4 differences (0% similarity)
+             (foo-)
+             (bar$)
+    ''')
+    exceptionMessage == expected
+  }
+
   def "can describe regex method name mismatch"() {
     when:
     runner.addClassImport(Person)
@@ -1194,6 +1265,13 @@ One or more arguments(s) didn't match:
 
   String normalize(String str) {
     EMPTY_LINE.matcher(str.normalize().trim()).replaceAll('')
+  }
+
+  interface WithDollar {
+    int compareTo(Object o)
+    int compareTo$(Object o)
+    String getFoo()
+    String getBar$()
   }
 
   static class Person {

--- a/spock-specs/src/test/groovy/org/spockframework/util/TextUtilSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/util/TextUtilSpec.groovy
@@ -34,4 +34,18 @@ class TextUtilSpec extends Specification {
     "useTCPStacK"  | "USE_TCP_STAC_K"
     "fred123Usage" | "FRED123_USAGE"
   }
+
+  def "escapeGroovyDoubleQuotedString"() {
+    expect:
+    TextUtil.escapeGroovyDoubleQuotedString(input) == escaped
+
+    where:
+    input        | escaped
+    ""           | ""
+    "foo"        | "foo"
+    'compareTo$' | 'compareTo\\$'
+    'a"b'        | 'a\\"b'
+    'a\\b'       | 'a\\\\b'
+    'a\nb'       | 'a\\nb'
+  }
 }


### PR DESCRIPTION
Fixes #2364

### Problem

When a mock interaction is unsatisfied, Spock lists the unmatched invocations
"ordered by similarity". For a name mismatch it builds a synthetic condition
(`methodName == "<name>"` or `propertyName == "<name>"`) and re-parses it as
Groovy to produce the aligned similarity report.

If the name contains a `$`, that `$` inside the double-quoted literal starts a
GString interpolation, so the Groovy lexer fails with
`unknown recognition error type: ...LexerNoViableAltException` on stderr and the
similarity report is dropped:

    1 * mock.compareTo('a')
    methodName == "compareTo$"
    |
    false

### Fix

Escape the name for a double-quoted Groovy literal (`"`, `$`, `\`, and control
characters) before formatting the condition, in both `EqualMethodNameConstraint`
and `EqualPropertyNameConstraint`. The condition parses again and the report
renders:

    1 * mock.compareTo('a')
    methodName == "compareTo\$"
    |          |
    compareTo  false
               1 difference (90% similarity)
               compareTo(-)
               compareTo($)

Names without special characters format exactly as before, so existing output
is unchanged.

### Tests

* `TooFewInvocations`: two functional specs for a method name and a property
  name containing `$`, red before the fix and green after.
* `TextUtilSpec`: unit coverage for the new
  `TextUtil.escapeGroovyDoubleQuotedString` helper.

Verified on Groovy variants 4.0 and 5.0; the mock, condition, and util specs
pass.

AI assistance: developed with help from Claude. I have reviewed the change and
understand and stand behind every line.
