### PR TITLE
Fix 'as boolean' coercion in assertion blocks

### DIFF
--- a/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
+++ b/spock-core/src/main/java/org/spockframework/compiler/ConditionRewriter.java
@@ -554,7 +554,9 @@ public class ConditionRewriter extends AbstractExpressionConverter<Expression> i
     // maintain type casts to preserve method disambiguation
     // for example when giving a casted null as argument
     if (expr instanceof CastExpression) {
-      return new CastExpression(expr.getType(), result);
+      CastExpression cast = new CastExpression(expr.getType(), result);
+      cast.setCoerce(((CastExpression) expr).isCoerce());
+      return cast;
     } else {
       return result;
     }

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionEvaluation.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionEvaluation.groovy
@@ -323,13 +323,12 @@ class ConditionEvaluation extends EmbeddedSpecification {
   }
 
   @Issue("https://github.com/spockframework/spock/issues/2410")
-  def "as boolean coercion on null is preserved in assertion block"() {
-    given:
-    def result = [error: true]
-
+  def "as boolean coercion is preserved in assertion block"() {
     expect:
-    (result.success as boolean) == false
     (null as boolean) == false
+    ("text" as boolean) == true
+    ([] as boolean) == false
+    ([1] as boolean) == true
   }
 
   def "ArgumentListExpression"() {

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionEvaluation.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionEvaluation.groovy
@@ -322,6 +322,16 @@ class ConditionEvaluation extends EmbeddedSpecification {
     ([1, 2, 3] as int[]).getClass().isArray()
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/2410")
+  def "as boolean coercion on null is preserved in assertion block"() {
+    given:
+    def result = [error: true]
+
+    expect:
+    (result.success as boolean) == false
+    (null as boolean) == false
+  }
+
   def "ArgumentListExpression"() {
     expect:
     3.toString() == "3"

--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionEvaluation.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/ConditionEvaluation.groovy
@@ -324,11 +324,23 @@ class ConditionEvaluation extends EmbeddedSpecification {
 
   @Issue("https://github.com/spockframework/spock/issues/2410")
   def "as boolean coercion is preserved in assertion block"() {
+    def result = [error: true]
     expect:
+    (result.success as boolean) == false
     (null as boolean) == false
     ("text" as boolean) == true
     ([] as boolean) == false
     ([1] as boolean) == true
+  }
+
+  @Issue("https://github.com/spockframework/spock/issues/2410")
+  def "as boolean coercion is preserved in then block"() {
+    when:
+    def result = [error: true]
+
+    then:
+    (result.success as boolean) == false
+    (null as boolean) == false
   }
 
   def "ArgumentListExpression"() {


### PR DESCRIPTION
Fixes #2410

The condition rewriter was dropping the coerce flag when creating new CastExpressions, which broke 'as boolean' coercions in assertions. Simple fix to preserve the flag when rewriting the cast. Added a test to verify it works.