### PR TITLE
Add test demonstrating StackOverflowError in SpockComparisonFailure.toString()

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/smoke/condition/CircularToStringFailureSpec.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/condition/CircularToStringFailureSpec.groovy
@@ -1,0 +1,41 @@
+package org.spockframework.smoke.condition
+
+import org.spockframework.EmbeddedSpecification
+import org.spockframework.runtime.SpockComparisonFailure
+import spock.lang.Issue
+import spock.lang.PendingFeature
+
+class CircularToStringFailureSpec extends EmbeddedSpecification {
+
+  @Issue("https://github.com/spockframework/spock/issues/2413")
+  @PendingFeature
+  def "SpockComparisonFailure.toString() does not throw StackOverflowError for circular toString()"() {
+    when:
+    runner.runFeatureBody '''
+        given:
+        def ref = new org.spockframework.smoke.condition.CircularToStringFailureSpec.CircularRef()
+        ref.self = ref
+
+        expect:
+        ref == "not equal"
+    '''
+
+    then:
+    SpockComparisonFailure failure = thrown()
+
+    when:
+    failure.toString()
+
+    then:
+    notThrown(StackOverflowError)
+  }
+
+  static class CircularRef {
+    CircularRef self
+
+    @Override
+    String toString() {
+      "CircularRef(self=" + String.valueOf(self) + ")"
+    }
+  }
+}


### PR DESCRIPTION
When a failing assertion involves an object with a circular toString(), SpockComparisonFailure.toString() triggers a StackOverflowError while rendering the condition. This causes test runners like Surefire to silently drop the test result, making failures invisible.

## Root cause

1. Spock test fails, SpockComparisonFailure embeds actual/expected values
2. SpockComparisonFailure.toString() calls getMessage() calls condition.getRendering()
3. Condition rendering calls toString() on the assertion values
4. ExpressionInfoValueRenderer.renderValue() catches Exception but not Error
5. StackOverflowError propagates, crashing the test runner's reporting

JUnit 5 does not have this issue - AssertionFailedError stores values without triggering recursive toString() during reporting.

## Test

The added test in CircularToStringFailureSpec creates an object with a circular toString(), triggers a SpockComparisonFailure, and asserts that toString() does not throw StackOverflowError. The test currently fails, demonstrating the bug.

## AI disclosure

The test and analysis of the root cause were developed with significant assistance from an AI coding assistant. The bug was first identified in a separate MRE project using Surefire, then traced through the Spock source code with the AI's help. The test itself was AI-generated but reviewed, compiled, and verified locally. I can explain the bug and the test.